### PR TITLE
pylint, flake: ignore line-too-long

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -138,7 +138,11 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+
+# Manually added:
+#  line-too-long: do not enforce hard-string requirement.
+        line-too-long,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ skip = .direnv,.git,.mypy_cache,.pytest_cache,.venv,__pycache__,venv
 [flake8]
 exclude = .direnv .git .mypy_cache .pytest_cache .venv __pycache__ venv
 max-line-length = 88
+# E501 line too long
+extend-ignore = E501
 
 [mypy]
 python_version = 3.8


### PR DESCRIPTION
Do not set a hard line limit.  Black will help autoformat,
but leave it to the author to determine if/when strings should
be broken up.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
