### PR TITLE
bases: introduce persistent in-instance datastore InstanceConfig

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=pydantic
 
 # Specify a score threshold to be exceeded before program exits with error.
 fail-under=10.0

--- a/.pylintrc
+++ b/.pylintrc
@@ -31,7 +31,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_fixme_info
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -143,6 +143,8 @@ disable=print-statement,
 # Manually added:
 #  line-too-long: do not enforce hard-string requirement.
         line-too-long,
+#  fixme: do not error on FIXMEs, we'll use pylint-fixme-info plugin.
+        fixme,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Base implementations."""
+
+from .errors import BaseConfigurationError  # noqa: F401

--- a/craft_providers/bases/errors.py
+++ b/craft_providers/bases/errors.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Image errors."""
+
+from craft_providers.errors import ProviderError
+
+
+class BaseConfigurationError(ProviderError):
+    """Error configuring the base."""

--- a/craft_providers/bases/instance_config.py
+++ b/craft_providers/bases/instance_config.py
@@ -1,0 +1,118 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Persistent instance config / datastore resident in provided environment."""
+
+import dataclasses
+import io
+import logging
+import pathlib
+import subprocess
+from typing import TYPE_CHECKING, Dict, Optional
+
+import pydantic
+import yaml
+
+from craft_providers import Executor, errors
+
+from .errors import BaseConfigurationError
+
+# Avoid pyright errors by using dataclasses.dataclass during type checking by
+# importing the standard library version.
+# https://github.com/microsoft/pyright/issues/637
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    from pydantic.dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass  # pylint: disable=used-before-assignment
+class InstanceConfiguration:
+    """Instance configuration datastore.
+
+    :param compatibility_tag: Compatibility tag for instance.
+    """
+
+    compatibility_tag: str
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, str]) -> "InstanceConfiguration":
+        """Unmarshal data dictionary.
+
+        :param data: Dictionary to unmarshal.
+
+        :returns: InstanceConfiguration.
+        """
+        return cls(compatibility_tag=data["compatibility_tag"])  # type: ignore
+
+    @classmethod
+    def load(
+        cls, *, executor: Executor, config_path: pathlib.Path
+    ) -> Optional["InstanceConfiguration"]:
+        """Load instance configuration from executed environment.
+
+        :param executor: Executor for instance.
+        :param config_path: Path to configuration file.
+
+        :returns: InstanceConfiguration object.
+        """
+        # Ideally we replace test / cat with an improved
+        # Executor.pull_file_io() once Multipass bug is fixed.
+        try:
+            proc = executor.execute_run(
+                command=["test", "-f", config_path.as_posix()],
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            return None
+
+        try:
+            proc = executor.execute_run(
+                command=["cat", config_path.as_posix()],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as error:
+            raise BaseConfigurationError(
+                brief=f"Failed to read instance config in environment at {config_path.as_posix()}",
+                details=errors.details_from_called_process_error(error),
+            ) from error
+
+        data = yaml.safe_load(proc.stdout)
+
+        try:
+            return cls.unmarshal(data)
+        except (pydantic.ValidationError, KeyError) as error:
+            raise BaseConfigurationError(
+                brief="Invalid instance config data.",
+                details=f"Instance configuration data: {data!r}",
+            ) from error
+
+    def save(self, *, executor: Executor, config_path: pathlib.Path) -> None:
+        """Save instance configuration in executed environment.
+
+        :param executor: Executor for instance.
+        :param config_path: Path to configuration file.
+        """
+        data = dataclasses.asdict(self)
+
+        executor.create_file(
+            destination=config_path,
+            content=io.BytesIO(yaml.dump(data).encode()),
+            file_mode="0644",
+        )

--- a/craft_providers/bases/instance_config.py
+++ b/craft_providers/bases/instance_config.py
@@ -14,12 +14,11 @@
 
 """Persistent instance config / datastore resident in provided environment."""
 
-import dataclasses
 import io
 import logging
 import pathlib
 import subprocess
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import Dict, Optional
 
 import pydantic
 import yaml
@@ -28,19 +27,10 @@ from craft_providers import Executor, errors
 
 from .errors import BaseConfigurationError
 
-# Avoid pyright errors by using dataclasses.dataclass during type checking by
-# importing the standard library version.
-# https://github.com/microsoft/pyright/issues/637
-if TYPE_CHECKING:
-    from dataclasses import dataclass
-else:
-    from pydantic.dataclasses import dataclass
-
 logger = logging.getLogger(__name__)
 
 
-@dataclass  # pylint: disable=used-before-assignment
-class InstanceConfiguration:
+class InstanceConfiguration(pydantic.BaseModel):
     """Instance configuration datastore.
 
     :param compatibility_tag: Compatibility tag for instance.
@@ -109,7 +99,7 @@ class InstanceConfiguration:
         :param executor: Executor for instance.
         :param config_path: Path to configuration file.
         """
-        data = dataclasses.asdict(self)
+        data = self.dict()
 
         executor.create_file(
             destination=config_path,

--- a/craft_providers/bases/instance_config.py
+++ b/craft_providers/bases/instance_config.py
@@ -59,8 +59,8 @@ class InstanceConfiguration(pydantic.BaseModel):
 
         :returns: InstanceConfiguration object.
         """
-        # Ideally we replace test / cat with an improved
-        # Executor.pull_file_io() once Multipass bug is fixed.
+        # TODO: Replace test / cat usage with an improved
+        # Executor.pull_file_io() once available.
         try:
             proc = executor.execute_run(
                 command=["test", "-f", config_path.as_posix()],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.12
 appdirs==1.4.4
-astroid==2.5.1
+astroid==2.5.2
 attrs==20.3.0
 autoflake==1.4
 Babel==2.9.0
@@ -20,7 +20,7 @@ filelock==3.0.12
 flake8==3.9.0
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.7.3
+importlib-metadata==3.10.0
 iniconfig==1.1.1
 isort==5.8.0
 jeepney==0.6.0
@@ -38,17 +38,18 @@ pluggy==0.13.1
 py==1.10.0
 pycodestyle==2.7.0
 pycparser==2.20
+pydantic==1.8.1
 pydocstyle==6.0.0
 pyflakes==2.3.1
 Pygments==2.8.1
-pylint==2.7.2
+pylint==2.7.4
 pyparsing==2.4.7
-pytest==6.2.2
+pytest==6.2.3
 pytest-subprocess==1.0.1
 pytz==2021.1
 PyYAML==5.4.1
 readme-renderer==29.0
-regex==2021.3.17
+regex==2021.4.4
 requests==2.25.1
 requests-toolbelt==0.9.1
 rfc3986==1.4.0
@@ -57,7 +58,7 @@ six==1.15.0
 snowballstemmer==2.1.0
 Sphinx==3.5.3
 sphinx-autodoc-typehints==1.11.1
-sphinx-rtd-theme==0.5.1
+sphinx-rtd-theme==0.5.2
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -43,6 +43,7 @@ pydocstyle==6.0.0
 pyflakes==2.3.1
 Pygments==2.8.1
 pylint==2.7.4
+pylint-fixme-info==1.0.1
 pyparsing==2.4.7
 pytest==6.2.3
 pytest-subprocess==1.0.1
@@ -67,7 +68,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 toml==0.10.2
 tox==3.23.0
-tqdm==4.59.0
+tqdm==4.60.0
 twine==3.4.1
 typed-ast==1.4.2
 typing-extensions==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+pydantic==1.8.1
 PyYAML==5.4.1
+typing-extensions==3.7.4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,13 @@ extend-ignore = E501
 
 [mypy]
 python_version = 3.8
+plugins = pydantic.mypy
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
+warn_untyped_fields = True
 
 [pydocstyle]
 # D105 Missing docstring in magic method (reason: magic methods already have definitions)

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ test_requires = [
     "mypy",
     "pydocstyle",
     "pylint",
+    "pylint-fixme-info",
     "pytest",
     "pytest-subprocess",
     "tox",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 install_requires = [
+    "pydantic",
     "pyyaml",
 ]
 

--- a/tests/unit/bases/test_instance_config.py
+++ b/tests/unit/bases/test_instance_config.py
@@ -1,0 +1,116 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import pathlib
+import subprocess
+from unittest import mock
+
+import pytest
+
+from craft_providers import Executor, errors
+from craft_providers.bases.errors import BaseConfigurationError
+from craft_providers.bases.instance_config import InstanceConfiguration
+
+
+@pytest.fixture
+def mock_executor():
+    executor_mock = mock.Mock(spec=Executor)
+    yield executor_mock
+
+
+def test_save(mock_executor):
+    config = InstanceConfiguration(compatibility_tag="tag-foo-v1")
+    config_path = pathlib.Path("/etc/crafty-crafty.conf")
+
+    config.save(executor=mock_executor, config_path=config_path)
+
+    assert mock_executor.mock_calls == [
+        mock.call.create_file(
+            destination=config_path, content=mock.ANY, file_mode="0644"
+        )
+    ]
+
+    assert (
+        mock_executor.mock_calls[0].kwargs["content"].read()
+        == b"compatibility_tag: tag-foo-v1\n"
+    )
+
+
+def test_load(mock_executor):
+    mock_executor.execute_run.side_effect = [
+        None,
+        mock.Mock(stdout=b"compatibility_tag: tag-foo-v1\n"),
+    ]
+    config_path = pathlib.Path("/etc/crafty-crafty.conf")
+
+    config = InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
+
+    assert mock_executor.mock_calls == [
+        mock.call.execute_run(
+            command=["test", "-f", "/etc/crafty-crafty.conf"],
+            capture_output=True,
+            check=True,
+        ),
+        mock.call.execute_run(
+            command=["cat", "/etc/crafty-crafty.conf"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ),
+    ]
+
+    assert config == InstanceConfiguration(compatibility_tag="tag-foo-v1")
+
+
+def test_load_no_file(mock_executor):
+    error = subprocess.CalledProcessError(
+        -1, ["test", "-f", "/etc/craft-crafty.conf"], "", ""
+    )
+    mock_executor.execute_run.side_effect = [error]
+
+    config_path = pathlib.Path("/etc/crafty-crafty.conf")
+
+    config = InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
+
+    assert config is None
+
+
+def test_load_invalid_data(mock_executor):
+    mock_executor.execute_run.side_effect = [
+        None,
+        mock.Mock(stdout=b"invalid: data"),
+    ]
+    config_path = pathlib.Path("/etc/crafty-crafty.conf")
+
+    with pytest.raises(BaseConfigurationError) as exc_info:
+        InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
+
+    assert exc_info.value == BaseConfigurationError(
+        brief="Invalid instance config data.",
+        details="Instance configuration data: {'invalid': 'data'}",
+    )
+
+
+def test_load_error(mock_executor):
+    error = subprocess.CalledProcessError(-1, ["cat", "/etc/craft-crafty.conf"], "", "")
+    mock_executor.execute_run.side_effect = [None, error]
+
+    config_path = pathlib.Path("/etc/crafty-crafty.conf")
+
+    with pytest.raises(BaseConfigurationError) as exc_info:
+        InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
+
+    assert exc_info.value == BaseConfigurationError(
+        brief="Failed to read instance config in environment at /etc/crafty-crafty.conf",
+        details=errors.details_from_called_process_error(error),
+    )


### PR DESCRIPTION
    bases: introduce persistent in-instance datastore InstanceConfig
    
    Enable Bases to persist a datastore that they can load on future use.
    Initially, the only usage of this datastore is to track a "compatibility
    tag", a simple mechanism in which a Base can ensure the instance to be
    re-used is compatibile with the current Base.
    
    - Add generic BaseConfigurationError() which will be used for base
    configuration errors.
    
    - Update requirements to add pydantic.
    
    Signed-off-by: Chris Patterson <chris.patterson@canonical.com>