### PR TITLE
multipass: introduce installation support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,7 @@ jobs:
       - name: Run integration tests on MacOS
         run: |
           source ${HOME}/.venv/bin/activate
+          export CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_UNINSTALL=1
           make test-integrations
 
   unit-tests:

--- a/craft_providers/multipass/errors.py
+++ b/craft_providers/multipass/errors.py
@@ -11,10 +11,32 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 """Multipass Errors."""
+
+from typing import Optional
 
 from craft_providers.errors import ProviderError
 
 
 class MultipassError(ProviderError):
     """Unexpected Multipass error."""
+
+
+class MultipassInstallationError(MultipassError):
+    """Multipass Installation Error.
+
+    :param reason: Reason for install failure.
+    :param details: Optional details to include.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        details: Optional[str] = None,
+    ) -> None:
+        brief = f"Failed to install Multipass: {reason}."
+        resolution = "Please visit https://multipass.run/ for instructions on installing Multipass for your operating system."
+
+        super().__init__(brief=brief, details=details, resolution=resolution)

--- a/craft_providers/multipass/installer.py
+++ b/craft_providers/multipass/installer.py
@@ -18,6 +18,7 @@ import logging
 import shutil
 import subprocess
 import sys
+import time
 
 from craft_providers.errors import details_from_called_process_error
 
@@ -46,6 +47,12 @@ def install() -> str:
         raise errors.MultipassInstallationError(
             f"unsupported platform {sys.platform!r}"
         )
+
+    # TODO: Multipass needs time after being installed or errors could happen on
+    # launch, i.e.: "Remote "" is unknown or unreachable." Current guidance is
+    # to sleep 20 seconds after install, but we should have a more reliable and
+    # timely approach. See: https://github.com/canonical/multipass/issues/1995
+    time.sleep(20)
 
     multipass_version, _ = Multipass().wait_until_ready()
     return multipass_version

--- a/craft_providers/multipass/installer.py
+++ b/craft_providers/multipass/installer.py
@@ -80,4 +80,4 @@ def is_installed() -> bool:
 
     :returns: Bool if multipass is installed.
     """
-    return not shutil.which("multipass") is None
+    return shutil.which("multipass") is not None

--- a/craft_providers/multipass/installer.py
+++ b/craft_providers/multipass/installer.py
@@ -1,0 +1,83 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Multipass Provider."""
+
+import logging
+import shutil
+import subprocess
+import sys
+
+from craft_providers.errors import details_from_called_process_error
+
+from . import errors
+from .multipass import Multipass
+
+logger = logging.getLogger(__name__)
+
+
+def install() -> str:
+    """Install Multipass.
+
+    :returns: Multipass version.
+
+    :raises MultipassInstallationError: on error.
+    """
+    if sys.platform == "darwin":
+        _install_darwin()
+    elif sys.platform == "linux":
+        _install_linux()
+    elif sys.platform == "win32":
+        _install_windows()
+    else:
+        raise errors.MultipassInstallationError(
+            f"unsupported platform {sys.platform!r}"
+        )
+
+    multipass_version, _ = Multipass().wait_until_ready()
+    return multipass_version
+
+
+def _install_darwin() -> None:
+    try:
+        subprocess.run(["brew", "install", "multipass"], check=True)
+    except subprocess.CalledProcessError as error:
+        raise errors.MultipassInstallationError(
+            "error during brew installation",
+            details=details_from_called_process_error(error),
+        ) from error
+
+
+def _install_linux() -> None:
+    try:
+        subprocess.run(["sudo", "snap", "install", "multipass"], check=True)
+    except subprocess.CalledProcessError as error:
+        raise errors.MultipassInstallationError(
+            "error during snap installation",
+            details=details_from_called_process_error(error),
+        ) from error
+
+
+def _install_windows() -> None:
+    raise errors.MultipassInstallationError(
+        "automated installation not yet supported for Windows"
+    )
+
+
+def is_installed() -> bool:
+    """Check if Multipass is installed (and found on PATH).
+
+    :returns: Bool if multipass is installed.
+    """
+    return not shutil.which("multipass") is None

--- a/craft_providers/multipass/installer.py
+++ b/craft_providers/multipass/installer.py
@@ -74,6 +74,6 @@ def _install_linux() -> None:
 def is_installed() -> bool:
     """Check if Multipass is installed (and found on PATH).
 
-    :returns: Bool if multipass is installed.
+    :returns: True if multipass is installed.
     """
     return shutil.which("multipass") is not None

--- a/craft_providers/multipass/installer.py
+++ b/craft_providers/multipass/installer.py
@@ -39,7 +39,9 @@ def install() -> str:
     elif sys.platform == "linux":
         _install_linux()
     elif sys.platform == "win32":
-        _install_windows()
+        raise errors.MultipassInstallationError(
+            "automated installation not yet supported for Windows"
+        )
     else:
         raise errors.MultipassInstallationError(
             f"unsupported platform {sys.platform!r}"
@@ -67,12 +69,6 @@ def _install_linux() -> None:
             "error during snap installation",
             details=details_from_called_process_error(error),
         ) from error
-
-
-def _install_windows() -> None:
-    raise errors.MultipassInstallationError(
-        "automated installation not yet supported for Windows"
-    )
 
 
 def is_installed() -> bool:

--- a/tests/integration/multipass/test_installer.py
+++ b/tests/integration/multipass/test_installer.py
@@ -12,9 +12,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Multipass provider support package."""
+import shutil
 
-from .errors import MultipassError, MultipassInstallationError  # noqa: F401
-from .installer import install, is_installed  # noqa: F401
-from .multipass import Multipass  # noqa: F401
-from .multipass_instance import MultipassInstance  # noqa: F401
+from craft_providers import multipass
+
+
+def test_is_installed():
+    expected = shutil.which("multipass") is not None
+
+    assert multipass.is_installed() is expected
+
+
+def test_install(uninstalled_multipass):  # pylint: disable=unused-argument
+    assert multipass.is_installed() is False
+
+    multipass_version = multipass.install()
+
+    assert multipass.is_installed() is True
+    assert multipass_version is not None

--- a/tests/integration/multipass/test_multipass.py
+++ b/tests/integration/multipass/test_multipass.py
@@ -13,7 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-import shutil
 import subprocess
 
 import pytest
@@ -21,10 +20,6 @@ import pytest
 from craft_providers.multipass import Multipass
 
 from . import conftest
-
-pytestmark = pytest.mark.skipif(
-    shutil.which("multipass") is None, reason="multipass not installed"
-)
 
 
 @pytest.fixture()

--- a/tests/integration/multipass/test_multipass_instance.py
+++ b/tests/integration/multipass/test_multipass_instance.py
@@ -14,17 +14,12 @@
 
 import io
 import pathlib
-import shutil
 
 import pytest
 
 from craft_providers.multipass import MultipassInstance
 
 from . import conftest
-
-pytestmark = pytest.mark.skipif(
-    shutil.which("multipass") is None, reason="multipass not installed"
-)
 
 
 @pytest.fixture()

--- a/tests/unit/multipass/test_errors.py
+++ b/tests/unit/multipass/test_errors.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from craft_providers.multipass import errors
+
+
+def test_multipass_error():
+    error = errors.MultipassError(brief="foo")
+
+    assert str(error) == "foo"
+
+
+def test_multipass_error_with_details():
+    error = errors.MultipassError(brief="foo", details="bar")
+
+    assert str(error) == "foo\nbar"
+
+
+def test_multipass_error_with_details_resolution():
+    error = errors.MultipassError(brief="foo", details="bar", resolution="do this")
+
+    assert str(error) == "foo\nbar\ndo this"
+
+
+def test_multipass_installation_error():
+    error = errors.MultipassInstallationError(reason="error during foo")
+
+    assert str(error) == (
+        "Failed to install Multipass: error during foo.\n"
+        "Please visit https://multipass.run/ for instructions on installing Multipass for your operating system."
+    )
+
+
+def test_multipass_installation_error_with_details():
+    error = errors.MultipassInstallationError(
+        reason="error during foo", details="Some details..."
+    )
+
+    assert str(error) == (
+        "Failed to install Multipass: error during foo.\n"
+        "Some details...\n"
+        "Please visit https://multipass.run/ for instructions on installing Multipass for your operating system."
+    )

--- a/tests/unit/multipass/test_installer.py
+++ b/tests/unit/multipass/test_installer.py
@@ -1,0 +1,119 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import shutil
+import sys
+from unittest import mock
+
+import pytest
+
+from craft_providers import multipass
+
+
+@pytest.fixture
+def mock_details_from_process_error():
+    details = "<details>"
+    with mock.patch(
+        "craft_providers.multipass.installer.details_from_called_process_error",
+        return_value=details,
+    ) as mock_details:
+        yield mock_details
+
+
+def test_install_darwin(fake_process, monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    fake_process.register_subprocess(["brew", "install", "multipass"])
+    fake_process.register_subprocess(
+        ["multipass", "version"], stdout="multipass 1.4.2\nmultipassd 1.4.2\n"
+    )
+
+    multipass.install()
+
+    assert list(fake_process.calls) == [
+        ["brew", "install", "multipass"],
+        ["multipass", "version"],
+    ]
+
+
+def test_install_darwin_error(
+    fake_process, mock_details_from_process_error, monkeypatch
+):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    fake_process.register_subprocess(
+        ["brew", "install", "multipass"],
+        returncode=1,
+    )
+
+    with pytest.raises(multipass.MultipassInstallationError) as exc_info:
+        multipass.install()
+
+    assert exc_info.value == multipass.MultipassInstallationError(
+        reason="error during brew installation",
+        details=mock_details_from_process_error.return_value,
+    )
+
+
+def test_install_linux(fake_process, monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    fake_process.register_subprocess(["sudo", "snap", "install", "multipass"])
+    fake_process.register_subprocess(
+        ["multipass", "version"], stdout="multipass 1.4.2\nmultipassd 1.4.2\n"
+    )
+
+    multipass.install()
+
+    assert list(fake_process.calls) == [
+        ["sudo", "snap", "install", "multipass"],
+        ["multipass", "version"],
+    ]
+
+
+def test_install_linux_error(
+    fake_process, mock_details_from_process_error, monkeypatch
+):
+    monkeypatch.setattr(sys, "platform", "linux")
+    fake_process.register_subprocess(
+        ["sudo", "snap", "install", "multipass"],
+        returncode=1,
+    )
+
+    with pytest.raises(multipass.MultipassInstallationError) as exc_info:
+        multipass.install()
+
+    assert exc_info.value == multipass.MultipassInstallationError(
+        reason="error during snap installation",
+        details=mock_details_from_process_error.return_value,
+    )
+
+
+def test_install_windows_error(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    with pytest.raises(multipass.MultipassInstallationError) as exc_info:
+        multipass.install()
+
+    assert exc_info.value == multipass.MultipassInstallationError(
+        reason="automated installation not yet supported for Windows",
+    )
+
+
+@pytest.mark.parametrize(
+    "which,is_installed", [("/path/to/multipass", True), (None, False)]
+)
+def test_is_installed(which, is_installed, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda x: which)
+
+    assert multipass.is_installed() == is_installed


### PR DESCRIPTION
- Add MultipassInstallationError.

- Add unit tests for Multipass errors (formatting).

- Add unit & integration tests for installer bits.

- Update CI to allow MacOS integration tests to uninstall multipass.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
