### PR TITLE
buildd: introduce os compatibility checks

### DIFF
--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -16,4 +16,5 @@
 
 from .buildd import BuilddBase  # noqa: F401
 from .buildd import BuilddBaseAlias  # noqa: F401
+from .errors import BaseCompatibilityError  # noqa: F401
 from .errors import BaseConfigurationError  # noqa: F401

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -128,10 +128,10 @@ class BuilddBase(Base):
 
         os_release = parse_os_release(proc.stdout)
 
-        os_id = os_release.get("NAME")
-        if os_id != "Ubuntu":
+        os_name = os_release.get("NAME")
+        if os_name != "Ubuntu":
             raise BaseCompatibilityError(
-                reason=f"Exepcted OS 'Ubuntu', found {os_id!r}"
+                reason=f"Exepcted OS 'Ubuntu', found {os_name!r}"
             )
 
         compat_version_id = self.alias.value

--- a/craft_providers/bases/errors.py
+++ b/craft_providers/bases/errors.py
@@ -12,10 +12,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Image errors."""
+"""Base errors."""
+
+from typing import Optional
 
 from craft_providers.errors import ProviderError
 
 
 class BaseConfigurationError(ProviderError):
     """Error configuring the base."""
+
+
+class BaseCompatibilityError(ProviderError):
+    """Base configuration compatibility error.
+
+    :param reason: Reason for incompatibility.
+    """
+
+    def __init__(self, reason: str, *, details: Optional[str] = None) -> None:
+        self.reason = reason
+
+        brief = f"Incompatible base detected: {reason}."
+        resolution = "Clean incompatible instance and retry the requested operation."
+
+        super().__init__(brief=brief, details=details, resolution=resolution)

--- a/tests/unit/bases/test_errors.py
+++ b/tests/unit/bases/test_errors.py
@@ -1,0 +1,57 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from craft_providers.bases import errors
+
+
+def test_base_configuration_error():
+    error = errors.BaseConfigurationError(brief="foo")
+
+    assert str(error) == "foo"
+
+
+def test_base_configuration_error_with_details():
+    error = errors.BaseConfigurationError(brief="foo", details="bar")
+
+    assert str(error) == "foo\nbar"
+
+
+def test_base_configuration_error_with_details_resolution():
+    error = errors.BaseConfigurationError(
+        brief="foo", details="bar", resolution="do this"
+    )
+
+    assert str(error) == "foo\nbar\ndo this"
+
+
+def test_base_compatibility_error():
+    error = errors.BaseCompatibilityError(reason="error during foo")
+
+    assert str(error) == (
+        "Incompatible base detected: error during foo.\n"
+        "Clean incompatible instance and retry the requested operation."
+    )
+
+
+def test_base_compatibility_error_with_details():
+    error = errors.BaseCompatibilityError(
+        reason="error during foo", details="Some details..."
+    )
+
+    assert str(error) == (
+        "Incompatible base detected: error during foo.\n"
+        "Some details...\n"
+        "Clean incompatible instance and retry the requested operation."
+    )


### PR DESCRIPTION
    - Introduce BaseCompatibilityError.
    - Add tests for base errors.
