### PR TITLE
buildd: add instance configuration & perform compatibility check

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -91,7 +91,7 @@ class BuilddBase(Base):
         used for compatibility checks (or other data).  Set to
         /etc/craft-instance.conf, but may be overridden for application-specific
         reasons.
-    :cvar instance_config_type: Class defining instance configuration.  May be
+    :cvar instance_config_class: Class defining instance configuration.  May be
         overridden with an application-specific subclass of InstanceConfiguration
         to enable application-specific extensions.
 
@@ -102,7 +102,7 @@ class BuilddBase(Base):
 
     compatibility_tag: str = "buildd-base-v0"
     instance_config_path: pathlib.Path = pathlib.Path("/etc/craft-instance.conf")
-    instance_config_type: Type[
+    instance_config_class: Type[
         instance_config.InstanceConfiguration
     ] = instance_config.InstanceConfiguration
 
@@ -131,7 +131,7 @@ class BuilddBase(Base):
         :raises BaseConfigurationError: on other unexpected error.
         """
         _check_deadline(deadline)
-        config = self.instance_config_type.load(
+        config = self.instance_config_class.load(
             executor=executor,
             config_path=self.instance_config_path,
         )


### PR DESCRIPTION
buildd: add instance configuration & perform compatibility check

A compatibility tag will allow buildd to evolve in the future, providing
an interface to declare a subsequent update as incompatible with the old
one, forcing the user (or application) to clean the instance before
use.  It is possible that this may never increment if compatibility
is forever maintained, but since it cannot be guaranteed, we define this up
front with an extendable InstanceConfiguration for application-specific
customization.

Using class variables to allow application-specific extensions, read the                                           
instance configuration (if available) from /etc/craft-instance.conf using                       
InstanceConfiguration.

Set the compatibility tag to "buildd-base-v0" and provide guidance on how                                     
the applications should extend this tag.

Depends on #25 #24 