### PR TITLE
multipass: doc fix and require check for Multipass._run()

### DIFF
--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -50,10 +50,10 @@ class Multipass:
         self,
         command: List[str],
         *,
-        check=True,
+        check: bool,
         **kwargs,
     ) -> subprocess.CompletedProcess:
-        """Execute command in instance_name, allowing output to console."""
+        """Execute multipass command."""
         command = [str(self.multipass_path), *command]
 
         logger.debug("Executing on host: %s", shlex.join(command))


### PR DESCRIPTION
All callers specify check=, but better to require it than
    to change the default.