### PR TITLE
lxc: add project helpers and integration integration tests

### DIFF
--- a/craft_providers/lxd/project.py
+++ b/craft_providers/lxd/project.py
@@ -60,14 +60,22 @@ def purge(*, lxc: LXC, project: str, remote: str = "local") -> None:
 
     :raises LXDError: on unexpected error.
     """
+    logger.debug("Purging project %r on remote %r.", project, remote)
     projects = lxc.project_list(remote=remote)
     if project not in projects:
-        logger.debug("Attempted to purge non-existent project '%s'.", project)
+        logger.debug(
+            "Attempted to purge non-existent project %r on remote %r.", project, remote
+        )
         return
 
     # Cleanup any outstanding instance_names.
     for instance_name in lxc.list_names(project=project, remote=remote):
-        logger.debug("Deleting instance_name '%s'.", instance_name)
+        logger.debug(
+            "Deleting instance %r from project %r on remote %r.",
+            instance_name,
+            project,
+            remote,
+        )
         lxc.delete(
             instance_name=instance_name,
             project=project,
@@ -77,9 +85,13 @@ def purge(*, lxc: LXC, project: str, remote: str = "local") -> None:
 
     # Cleanup any outstanding images.
     for image in lxc.image_list(project=project):
-        logger.debug("Deleting image '%s'.", image)
+        logger.debug(
+            "Deleting image %r from project %r on remote %r.", image, project, remote
+        )
         lxc.image_delete(image=image["fingerprint"], project=project, remote=remote)
 
     # Cleanup project.
-    logger.debug("Deleting project '%s'.", project)
+    logger.debug("Deleting project %r on remote %r.", project, remote)
     lxc.project_delete(project=project, remote=remote)
+
+    logger.debug("Project %r on remote %r was purged successfully.", project, remote)

--- a/craft_providers/lxd/project.py
+++ b/craft_providers/lxd/project.py
@@ -1,0 +1,85 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Project helper utilities."""
+import logging
+
+from .lxc import LXC
+
+logger = logging.getLogger(__name__)
+
+
+def create_with_default_profile(
+    *,
+    lxc: LXC,
+    project: str,
+    profile: str = "default",
+    profile_project: str = "default",
+    remote: str = "local",
+) -> None:
+    """Create a project with a valid default profile.
+
+    LXD does not set a valid profile on newly created projects.  This will
+    create a project and set the profile to match the specified profile,
+    typically the default.
+
+    :param project: Name of project to create.
+    :param remote: Name of remote.
+    :param profile_name: Name of profile to copy.
+
+    :raises LXDError: on unexpected error.
+    """
+    lxc.project_create(project=project, remote=remote)
+
+    # Retrieve config from specified (default) project profile.
+    config = lxc.profile_show(profile=profile, project=profile_project, remote=remote)
+
+    # Set config.
+    lxc.profile_edit(profile="default", project=project, config=config, remote=remote)
+
+
+def purge(*, lxc: LXC, project: str, remote: str = "local") -> None:
+    """Purge a project including its instances and images.
+
+    The lxc command does not provide a straight-forward option to purge a
+    project.  This helper will purge anything related to a specified one.
+
+    :param project: Name of project to delete.
+    :param remote: Name of remote.
+
+    :raises LXDError: on unexpected error.
+    """
+    projects = lxc.project_list(remote=remote)
+    if project not in projects:
+        logger.debug("Attempted to purge non-existent project '%s'.", project)
+        return
+
+    # Cleanup any outstanding instance_names.
+    for instance_name in lxc.list_names(project=project, remote=remote):
+        logger.debug("Deleting instance_name '%s'.", instance_name)
+        lxc.delete(
+            instance_name=instance_name,
+            project=project,
+            remote=remote,
+            force=True,
+        )
+
+    # Cleanup any outstanding images.
+    for image in lxc.image_list(project=project):
+        logger.debug("Deleting image '%s'.", image)
+        lxc.image_delete(image=image["fingerprint"], project=project, remote=remote)
+
+    # Cleanup project.
+    logger.debug("Deleting project '%s'.", project)
+    lxc.project_delete(project=project, remote=remote)

--- a/tests/integration/lxd/__init__.py
+++ b/tests/integration/lxd/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -1,0 +1,119 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Fixtures for LXD integration tests."""
+import random
+import shutil
+import string
+import sys
+import time
+from contextlib import contextmanager
+from typing import Any, Dict, Optional
+
+import pytest
+
+from craft_providers.lxd import LXC
+from craft_providers.lxd import project as lxc_project
+
+
+def generate_instance_name():
+    return "itest-" + "".join(random.choices(string.ascii_uppercase, k=8))
+
+
+@pytest.fixture()
+def instance_name():
+    yield generate_instance_name()
+
+
+@contextmanager
+def tmp_instance(
+    *,
+    instance_name: str,
+    config_keys: Optional[Dict[str, Any]] = None,
+    ephemeral: bool = True,
+    image: str = "16.04",
+    image_remote: str = "ubuntu",
+    project: str,
+    remote: str = "local",
+    lxc: LXC = LXC(),
+):
+    if config_keys is None:
+        config_keys = dict()
+
+    lxc.launch(
+        instance_name=instance_name,
+        config_keys=config_keys,
+        ephemeral=ephemeral,
+        image=image,
+        image_remote=image_remote,
+        project=project,
+        remote=remote,
+    )
+
+    # Make sure container is ready
+    for _ in range(0, 60):
+        proc = lxc.exec(
+            command=["systemctl", "is-system-running"],
+            instance_name=instance_name,
+            project=project,
+            remote=remote,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        running_state = proc.stdout.strip()
+        if running_state in ["running", "degraded"]:
+            break
+
+        time.sleep(0.1)
+
+    yield instance_name
+
+    if instance_name in lxc.list(project=project, remote=remote):
+        lxc.delete(
+            instance_name=instance_name, project=project, remote=remote, force=True
+        )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def installed_lxd():
+    """Ensure lxd is installed, or skip the test if we cannot."""
+    if shutil.which("lxc") is None or shutil.which("lxd") is None:
+        pytest.skip("lxd not installed, skipped")
+
+    if sys.platform != "linux":
+        pytest.skip(f"lxd not supported on {sys.platform}")
+
+
+@pytest.fixture()
+def project(lxc):
+    """Create temporary LXD project and assert expected properties."""
+    project_name = "ptest-" + "".join(random.choices(string.ascii_uppercase, k=4))
+    lxc_project.create_with_default_profile(lxc=lxc, project=project_name)
+
+    projects = lxc.project_list()
+    assert project_name in projects
+
+    instances = lxc.list(project=project_name)
+    assert instances == []
+
+    expected_cfg = lxc.profile_show(profile="default", project="default")
+    expected_cfg["used_by"] = []
+
+    assert lxc.profile_show(profile="default", project=project_name) == expected_cfg
+
+    yield project_name
+
+    lxc_project.purge(lxc=lxc, project=project_name)

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -1,0 +1,175 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+import subprocess
+
+import pytest
+
+from craft_providers.lxd import LXC, LXDError
+
+from . import conftest
+
+
+@pytest.fixture()
+def instance(instance_name, project):
+    with conftest.tmp_instance(
+        instance_name=instance_name,
+        project=project,
+    ) as tmp_instance:
+        yield tmp_instance
+
+
+@pytest.fixture()
+def lxc():
+    yield LXC()
+
+
+def test_exec(instance, lxc, project):
+    proc = lxc.exec(
+        instance_name=instance,
+        command=["echo", "this is a test"],
+        project=project,
+        capture_output=True,
+    )
+
+    assert proc.stdout == b"this is a test\n"
+
+
+def test_delete(instance, lxc, project):
+    with pytest.raises(LXDError):
+        lxc.delete(instance_name=instance, force=False, project=project)
+
+    instances = lxc.list_names(project=project)
+    assert instances == [instance]
+
+
+def test_delete_force(instance, lxc, project):
+    lxc.delete(instance_name=instance, force=True, project=project)
+
+    instances = lxc.list_names(project=project)
+    assert instances == []
+
+
+def test_image_copy(lxc, project):
+    lxc.image_copy(
+        image="16.04",
+        image_remote="ubuntu",
+        alias="test-1604",
+        project=project,
+    )
+
+    images = lxc.image_list(project=project)
+    assert len(images) == 1
+
+
+def test_image_delete(lxc, project):
+    lxc.image_copy(
+        image="16.04",
+        image_remote="ubuntu",
+        alias="test-1604",
+        project=project,
+    )
+
+    lxc.image_delete(image="test-1604", project=project)
+
+    images = lxc.image_list(project=project)
+    assert images == []
+
+
+def test_file_push(instance, lxc, project, tmp_path):
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("this is a test")
+
+    lxc.file_push(
+        instance_name=instance,
+        project=project,
+        source=test_file,
+        destination=pathlib.Path("/tmp/foo"),
+    )
+
+    proc = lxc.exec(
+        command=["cat", "/tmp/foo"],
+        instance_name=instance,
+        project=project,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=True,
+    )
+
+    assert proc.stdout == b"this is a test"
+
+
+def test_file_pull(instance, lxc, project, tmp_path):
+    out_path = tmp_path / "out.txt"
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("this is a test")
+
+    lxc.file_push(
+        instance_name=instance,
+        project=project,
+        source=test_file,
+        destination=pathlib.Path("/tmp/foo"),
+    )
+
+    lxc.file_pull(
+        instance_name=instance,
+        project=project,
+        source=pathlib.Path("/tmp/foo"),
+        destination=out_path,
+    )
+
+    assert out_path.read_text() == "this is a test"
+
+
+def test_disk_add_remove(instance, lxc, tmp_path, project):
+    mount_target = pathlib.Path("/mnt")
+
+    # Make sure permissions allow read from inside guest without mappings.
+    tmp_path.chmod(0o755)
+
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("this is a test")
+
+    lxc.config_device_add_disk(
+        instance_name=instance,
+        source=tmp_path,
+        path=mount_target,
+        device="test_mount",
+        project=project,
+    )
+
+    proc = lxc.exec(
+        command=["cat", "/mnt/test.txt"],
+        instance_name=instance,
+        capture_output=True,
+        check=True,
+        project=project,
+    )
+
+    assert proc.stdout == b"this is a test"
+
+    lxc.config_device_remove(
+        instance_name=instance,
+        device="test_mount",
+        project=project,
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        lxc.exec(
+            command=["test", "-f", "/mnt/test.txt"],
+            project=project,
+            instance_name=instance,
+            check=True,
+        )

--- a/tests/unit/lxd/test_project.py
+++ b/tests/unit/lxd/test_project.py
@@ -1,0 +1,95 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+import pytest
+
+from craft_providers import lxd
+from craft_providers.lxd import project
+
+
+@pytest.fixture(autouse=True)
+def mock_lxc():
+    with mock.patch("craft_providers.lxd.LXC", spec=lxd.LXC) as lxc_mock:
+        lxc_mock.return_value.profile_show.return_value = {"test": "config"}
+        yield lxc_mock.return_value
+
+
+def test_create_with_default_profile(mock_lxc):
+    project.create_with_default_profile(
+        lxc=mock_lxc,
+        project="test-project",
+        profile="test-profile",
+        profile_project="test-profile-project",
+        remote="test-remote",
+    )
+
+    assert mock_lxc.mock_calls == [
+        mock.call.project_create(project="test-project", remote="test-remote"),
+        mock.call.profile_show(
+            profile="test-profile", project="test-profile-project", remote="test-remote"
+        ),
+        mock.call.profile_edit(
+            profile="default",
+            project="test-project",
+            config={"test": "config"},
+            remote="test-remote",
+        ),
+    ]
+
+
+def test_purge(mock_lxc):
+    mock_lxc.project_list.return_value = ["test-project", "default"]
+    mock_lxc.list_names.return_value = ["test-instance1", "test-instance2"]
+    mock_lxc.image_list.return_value = [{"fingerprint": "i1"}, {"fingerprint": "i2"}]
+
+    project.purge(lxc=mock_lxc, project="test-project", remote="test-remote")
+
+    assert mock_lxc.mock_calls == [
+        mock.call.project_list(remote="test-remote"),
+        mock.call.list_names(project="test-project", remote="test-remote"),
+        mock.call.delete(
+            instance_name="test-instance1",
+            project="test-project",
+            remote="test-remote",
+            force=True,
+        ),
+        mock.call.delete(
+            instance_name="test-instance2",
+            project="test-project",
+            remote="test-remote",
+            force=True,
+        ),
+        mock.call.image_list(project="test-project"),
+        mock.call.image_delete(
+            image="i1", project="test-project", remote="test-remote"
+        ),
+        mock.call.image_delete(
+            image="i2", project="test-project", remote="test-remote"
+        ),
+        mock.call.project_delete(project="test-project", remote="test-remote"),
+    ]
+
+
+def test_purge_no_project(mock_lxc):
+    mock_lxc.project_list.return_value = ["default"]
+    mock_lxc.list.return_value = ["test-instance1", "test-instance2"]
+    mock_lxc.image_list.return_value = [{"fingerprint": "i1"}, {"fingerprint": "i2"}]
+
+    project.purge(lxc=mock_lxc, project="test-project", remote="test-remote")
+
+    assert mock_lxc.mock_calls == [
+        mock.call.project_list(remote="test-remote"),
+    ]


### PR DESCRIPTION
Add project project helpers.  With these helpers we can now add the lxc integration tets.