### PR TITLE
lxd: introduce LXD for interacting with `lxd` command-line

### DIFF
--- a/craft_providers/lxd/lxd.py
+++ b/craft_providers/lxd/lxd.py
@@ -73,8 +73,8 @@ class LXD:
         version_components = version.split(".")
 
         try:
-            major_minor = ".".join([version_components[0], version_components[1]])
-            return float(major_minor) >= 4.0
+            major = int(version_components[0])
+            return major >= 4
         except (ValueError, IndexError) as error:
             raise LXDError(
                 "Failed to parse LXD version.",

--- a/craft_providers/lxd/lxd.py
+++ b/craft_providers/lxd/lxd.py
@@ -1,0 +1,138 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""LXD command-line interface helpers."""
+
+import logging
+import pathlib
+import subprocess
+from typing import Optional
+
+from craft_providers.errors import details_from_called_process_error
+
+from .errors import LXDError
+
+logger = logging.getLogger(__name__)
+
+
+class LXD:
+    """Interface to `lxd` command-line.
+
+    :param lxd_path: Path to lxd.
+    """
+
+    def __init__(self, *, lxd_path: pathlib.Path = pathlib.Path("lxd")) -> None:
+        self.lxd_path = lxd_path
+
+    def init(self, *, auto: bool = False, sudo: bool = False) -> None:
+        """Initialize LXD.
+
+        Sudo is required if user is not in lxd group.
+
+        :param auto: Use default settings.
+        :param sudo: Use sudo to invoke init.
+        """
+        if sudo:
+            cmd = ["sudo"]
+        else:
+            cmd = []
+
+        cmd += [str(self.lxd_path), "init"]
+
+        if auto:
+            cmd.append("--auto")
+
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as error:
+            raise LXDError(
+                "Failed to init LXD.",
+                details=details_from_called_process_error(error),
+            ) from error
+
+    def is_supported_version(self) -> bool:
+        """Check if LXD version is supported.
+
+        A helper to check if LXD meets minimum supported version for
+        craft-providers (currently >= 4.0).
+
+        :returns: True if installed version is supported.
+        """
+        version = self.version()
+        version_components = version.split(".")
+
+        try:
+            major_minor = ".".join([version_components[0], version_components[1]])
+            return float(major_minor) >= 4.0
+        except (ValueError, IndexError) as error:
+            raise LXDError(
+                "Failed to parse LXD version.",
+                details=f"Version data returned: {version!r}",
+            ) from error
+
+    def version(self) -> str:
+        """Query LXD version.
+
+        The version is of the format:
+        <major>.<minor>[.<micro>]
+
+        Version examples:
+        - 4.13
+        - 4.0.5
+        - 2.0.12
+
+        :returns: Version string.
+        """
+        cmd = [str(self.lxd_path), "version"]
+
+        try:
+            proc = subprocess.run(cmd, capture_output=True, check=True, text=True)
+        except subprocess.CalledProcessError as error:
+            raise LXDError(
+                "Failed to query LXD version.",
+                details=details_from_called_process_error(error),
+            ) from error
+
+        return proc.stdout.strip()
+
+    def wait_ready(
+        self,
+        *,
+        sudo: bool = False,
+        timeout: Optional[int] = None,
+    ) -> None:
+        """Wait until LXD is ready.
+
+        Sudo is required if user is not in lxd group.
+
+        :param sudo: Use sudo to invoke waitready.
+        :param timeout: Timeout in seconds.
+        """
+        if sudo:
+            cmd = ["sudo"]
+        else:
+            cmd = []
+
+        cmd += [str(self.lxd_path), "waitready"]
+
+        if timeout is not None:
+            cmd.append(f"--timeout={timeout}")
+
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as error:
+            raise LXDError(
+                "Failed to wait for LXD to get ready.",
+                details=details_from_called_process_error(error),
+            ) from error

--- a/craft_providers/lxd/lxd.py
+++ b/craft_providers/lxd/lxd.py
@@ -13,11 +13,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """LXD command-line interface helpers."""
-
 import logging
 import pathlib
 import subprocess
 from typing import Optional
+
+import pkg_resources
 
 from craft_providers.errors import details_from_called_process_error
 
@@ -70,16 +71,16 @@ class LXD:
         :returns: True if installed version is supported.
         """
         version = self.version()
-        version_components = version.split(".")
 
-        try:
-            major = int(version_components[0])
-            return major >= 4
-        except (ValueError, IndexError) as error:
+        if "." not in version:
             raise LXDError(
                 "Failed to parse LXD version.",
                 details=f"Version data returned: {version!r}",
-            ) from error
+            )
+
+        return pkg_resources.parse_version(version) >= pkg_resources.parse_version(
+            "4.0"
+        )
 
     def version(self) -> str:
         """Query LXD version.

--- a/tests/integration/lxd/test_lxd.py
+++ b/tests/integration/lxd/test_lxd.py
@@ -29,10 +29,14 @@ def test_init(lxd):
 
 
 def test_version(lxd):
-    components = lxd.version().split(".")
+    version = lxd.version()
+
+    assert isinstance(version, str) is True
+
+    components = version.split(".")
 
     assert len(components) in [2, 3]
-    assert all(int(c) for c in components)
+    assert all([int(c) for c in components])
 
 
 def test_wait_ready(lxd):

--- a/tests/integration/lxd/test_lxd.py
+++ b/tests/integration/lxd/test_lxd.py
@@ -36,7 +36,9 @@ def test_version(lxd):
     components = version.split(".")
 
     assert len(components) in [2, 3]
-    assert all([int(c) for c in components])
+
+    for component in components:
+        assert int(component) is True
 
 
 def test_wait_ready(lxd):

--- a/tests/integration/lxd/test_lxd.py
+++ b/tests/integration/lxd/test_lxd.py
@@ -37,9 +37,6 @@ def test_version(lxd):
 
     assert len(components) in [2, 3]
 
-    for component in components:
-        assert int(component) is True
-
 
 def test_wait_ready(lxd):
     lxd.wait_ready()

--- a/tests/integration/lxd/test_lxd.py
+++ b/tests/integration/lxd/test_lxd.py
@@ -12,9 +12,33 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""LXD environment provider."""
 
-from .errors import LXDError  # noqa: F401
-from .lxc import LXC  # noqa: F401
-from .lxd import LXD  # noqa: F401
-from .lxd_instance import LXDInstance  # noqa: F401
+import pytest
+
+from craft_providers.lxd import LXD
+
+
+@pytest.fixture()
+def lxd():
+    yield LXD()
+
+
+def test_init(lxd):
+    lxd.init(auto=True)
+    lxd.init(sudo=True, auto=True)
+
+
+def test_version(lxd):
+    components = lxd.version().split(".")
+
+    assert len(components) in [2, 3]
+    assert all(int(c) for c in components)
+
+
+def test_wait_ready(lxd):
+    lxd.wait_ready()
+    lxd.wait_ready(sudo=True)
+
+
+def test_is_supported_version(lxd):
+    assert lxd.is_supported_version() is True

--- a/tests/unit/lxd/test_lxd.py
+++ b/tests/unit/lxd/test_lxd.py
@@ -69,7 +69,14 @@ def test_init_error(fake_process):
 
 @pytest.mark.parametrize(
     "version,compatible",
-    [("3.0", False), ("3.1.4", False), ("4.0", True), ("4.1.4", True)],
+    [
+        ("3.0", False),
+        ("3.1.4", False),
+        ("3.10", False),
+        ("4.0", True),
+        ("4.1.4", True),
+        ("4.10", True),
+    ],
 )
 def test_is_supported_version(fake_process, version, compatible):
     fake_process.register_subprocess(

--- a/tests/unit/lxd/test_lxd.py
+++ b/tests/unit/lxd/test_lxd.py
@@ -91,7 +91,7 @@ def test_is_supported_version(fake_process, version, compatible):
     assert len(fake_process.calls) == 1
 
 
-@pytest.mark.parametrize("version_data", ["invalid", "invalid.version"])
+@pytest.mark.parametrize("version_data", ["", "invalid"])
 def test_is_supported_version_parse_error(fake_process, version_data):
     fake_process.register_subprocess(
         [

--- a/tests/unit/lxd/test_lxd.py
+++ b/tests/unit/lxd/test_lxd.py
@@ -1,0 +1,185 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_providers import errors
+from craft_providers.lxd import LXD, LXDError
+
+
+def test_init(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "init",
+        ]
+    )
+
+    LXD().init()
+
+    assert len(fake_process.calls) == 1
+
+
+def test_init_all_opts(fake_process):
+    fake_process.register_subprocess(
+        [
+            "sudo",
+            "lxd",
+            "init",
+            "--auto",
+        ]
+    )
+
+    LXD().init(
+        auto=True,
+        sudo=True,
+    )
+
+    assert len(fake_process.calls) == 1
+
+
+def test_init_error(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "init",
+        ],
+        returncode=1,
+    )
+
+    with pytest.raises(LXDError) as exc_info:
+        LXD().init()
+
+    assert exc_info.value == LXDError(
+        brief="Failed to init LXD.",
+        details=errors.details_from_called_process_error(exc_info.value.__cause__),  # type: ignore
+    )
+
+
+@pytest.mark.parametrize(
+    "version,compatible",
+    [("3.0", False), ("3.1.4", False), ("4.0", True), ("4.1.4", True)],
+)
+def test_is_supported_version(fake_process, version, compatible):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "version",
+        ],
+        stdout=version,
+    )
+
+    assert LXD().is_supported_version() == compatible
+    assert len(fake_process.calls) == 1
+
+
+@pytest.mark.parametrize("version_data", ["invalid", "invalid.version"])
+def test_is_supported_version_parse_error(fake_process, version_data):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "version",
+        ],
+        stdout=version_data,
+    )
+
+    with pytest.raises(LXDError) as exc_info:
+        LXD().is_supported_version()
+
+    assert exc_info.value == LXDError(
+        brief="Failed to parse LXD version.",
+        details=f"Version data returned: {version_data!r}",
+    )
+
+
+def test_version(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "version",
+        ],
+        stdout="test-version",
+    )
+
+    version = LXD().version()
+
+    assert len(fake_process.calls) == 1
+    assert version == "test-version"
+
+
+def test_version_error(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "version",
+        ],
+        returncode=1,
+    )
+
+    with pytest.raises(LXDError) as exc_info:
+        LXD().version()
+
+    assert exc_info.value == LXDError(
+        brief="Failed to query LXD version.",
+        details=errors.details_from_called_process_error(exc_info.value.__cause__),  # type: ignore
+    )
+
+
+def test_wait_ready(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "waitready",
+        ]
+    )
+
+    LXD().wait_ready()
+
+    assert len(fake_process.calls) == 1
+
+
+def test_wait_ready_all_opts(fake_process):
+    fake_process.register_subprocess(
+        [
+            "sudo",
+            "lxd",
+            "waitready",
+            "--timeout=5",
+        ]
+    )
+
+    LXD().wait_ready(
+        sudo=True,
+        timeout=5,
+    )
+
+    assert len(fake_process.calls) == 1
+
+
+def test_wait_ready_error(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxd",
+            "waitready",
+        ],
+        returncode=1,
+    )
+
+    with pytest.raises(LXDError) as exc_info:
+        LXD().wait_ready()
+
+    assert exc_info.value == LXDError(
+        brief="Failed to wait for LXD to get ready.",
+        details=errors.details_from_called_process_error(exc_info.value.__cause__),  # type: ignore
+    )


### PR DESCRIPTION
Includes a `is_supported_version()` helper to ensure LXD version
meets minimum required version by craft-providers.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
