### PR TITLE
docs: update and fix doc generation

### DIFF
--- a/docs/bases.rst
+++ b/docs/bases.rst
@@ -1,0 +1,17 @@
+***************************
+Bases
+***************************
+
+Abstract Base
+======================
+
+.. autoclass:: craft_providers.Base
+   :show-inheritance:
+   :members:
+
+Buildd Base
+========================
+
+.. autoclass:: craft_providers.bases.BuilddBase
+   :show-inheritance:
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",  # must be loaded after napoleon
+    "sphinx-pydantic",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/executors.rst
+++ b/docs/executors.rst
@@ -1,0 +1,24 @@
+***************************
+Executors
+***************************
+
+Abstract Executor
+======================
+
+.. autoclass:: craft_providers.Executor
+   :show-inheritance:
+   :members:
+
+LXD Executor
+========================
+
+.. autoclass:: craft_providers.lxd.LXDInstance
+   :show-inheritance:
+   :members:
+
+Multipass Executor
+========================
+
+.. autoclass:: craft_providers.multipass.MultipassInstance
+   :show-inheritance:
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,8 @@ Here you will find all of the provider documentation...
 
    executors
 
+   bases
+
 .. toctree::
    :caption: Internal APIs:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 alabaster==0.7.12
 appdirs==1.4.4
-astroid==2.5.3
+astroid==2.5.6
 attrs==20.3.0
 autoflake==1.4
-Babel==2.9.0
-black==20.8b1
+Babel==2.9.1
+black==21.4b2
 bleach==3.3.0
 certifi==2020.12.5
 cffi==1.14.5
@@ -20,11 +20,12 @@ filelock==3.0.12
 flake8==3.9.1
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==4.0.0
+importlib-metadata==4.0.1
 iniconfig==1.1.1
 isort==5.8.0
 jeepney==0.6.0
 Jinja2==2.11.3
+jsonpointer==2.1
 keyring==23.0.1
 lazy-object-proxy==1.6.0
 MarkupSafe==1.1.1
@@ -46,7 +47,7 @@ pylint==2.7.4
 pylint-fixme-info==1.0.2
 pyparsing==2.4.7
 pytest==6.2.3
-pytest-mock==3.5.1
+pytest-mock==3.6.0
 pytest-subprocess==1.1.0
 pytz==2021.1
 PyYAML==5.4.1
@@ -60,6 +61,8 @@ six==1.15.0
 snowballstemmer==2.1.0
 Sphinx==3.5.4
 sphinx-autodoc-typehints==1.12.0
+sphinx-jsonschema==1.16.8
+sphinx-pydantic==0.1.1
 sphinx-rtd-theme==0.5.2
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ dev_requires = [
 doc_requires = [
     "sphinx",
     "sphinx-autodoc-typehints",
+    "sphinx-pydantic",
     "sphinx-rtd-theme",
 ]
 


### PR DESCRIPTION
sphinx-pydantic is required because pydantic will break when
importing with TYPE_CHECKING.  The extension appears to work
around the issue, which would otherwise break most of the auto
generated documentation.

Add executors and bases documentation sections.

Re-freeze requirements.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
