### PR TITLE
multipass: is_supported_version() interface and require >=1.7

### DIFF
--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -44,7 +44,10 @@ class Multipass:
     """Wrapper for multipass command.
 
     :param multipass_path: Path to multipass command to use.
+    :cvar minimum_required_version: Minimum required version for compatibility.
     """
+
+    minimum_required_version = "1.7"
 
     def __init__(
         self, *, multipass_path: pathlib.Path = pathlib.Path("multipass")
@@ -141,7 +144,7 @@ class Multipass:
         version, _ = self.version()
 
         return pkg_resources.parse_version(version) >= pkg_resources.parse_version(
-            "1.7"
+            self.minimum_required_version
         )
 
     def launch(

--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -31,6 +31,8 @@ import subprocess
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
+import pkg_resources
+
 from craft_providers import errors
 
 from .errors import MultipassError
@@ -127,6 +129,20 @@ class Multipass:
             ) from error
 
         return json.loads(proc.stdout)
+
+    def is_supported_version(self) -> bool:
+        """Check if Multipass version is supported.
+
+        A helper to check if Multipass meets minimum supported version for
+        craft-providers.
+
+        :returns: True if installed version is supported.
+        """
+        version, _ = self.version()
+
+        return pkg_resources.parse_version(version) >= pkg_resources.parse_version(
+            "1.7"
+        )
 
     def launch(
         self,

--- a/tests/integration/multipass/test_multipass.py
+++ b/tests/integration/multipass/test_multipass.py
@@ -64,6 +64,10 @@ def test_exec(instance, multipass):
     assert proc.stdout == b"this is a test\n"
 
 
+def test_is_supported_version(multipass):
+    assert multipass.is_supported_version() is True
+
+
 def test_list(instance, multipass):
     instances = multipass.list()
 
@@ -178,13 +182,14 @@ def test_transfer_destination_io(instance, multipass, home_tmp_path):
     assert out_path.read_text() == "this is a test"
 
 
-@pytest.mark.xfail(run=False, reason="Multipass bug issue #2005")
 def test_transfer_destination_io_large(instance, multipass, home_tmp_path):
     test_file = home_tmp_path / "test.txt"
 
     with test_file.open("wb") as stream:
         stream.seek(1024 * 1024 * 1024 * 4)
         stream.write(b"test")
+
+    assert test_file.stat().st_size == 4294967300
 
     multipass.transfer(
         source=str(test_file),

--- a/tests/unit/multipass/test_multipass.py
+++ b/tests/unit/multipass/test_multipass.py
@@ -196,6 +196,38 @@ def test_info_error(fake_process, mock_details_from_process_error):
     )
 
 
+def test_is_supported_version(fake_process):
+    fake_process.register_subprocess(
+        ["multipass", "version"], stdout=b"multipass  1.7.0\nmultipassd 1.7.0\n"
+    )
+
+    assert Multipass().is_supported_version() is True
+
+    assert len(fake_process.calls) == 1
+
+
+def test_is_supported_version_false(fake_process):
+    fake_process.register_subprocess(
+        ["multipass", "version"], stdout=b"multipass  1.4.0\nmultipassd 1.4.0\n"
+    )
+
+    assert Multipass().is_supported_version() is False
+
+    assert len(fake_process.calls) == 1
+
+
+def test_is_supported_version_error(fake_process, mock_details_from_process_error):
+    fake_process.register_subprocess(["multipass", "version"], stdout="invalid output")
+
+    with pytest.raises(MultipassError) as exc_info:
+        Multipass().is_supported_version()
+
+    assert len(fake_process.calls) == 1
+    assert exc_info.value == MultipassError(
+        brief="Unable to parse version output: b'invalid output'"
+    )
+
+
 def test_launch(fake_process):
     fake_process.register_subprocess(
         ["multipass", "launch", "test-image", "--name", "test-instance"]


### PR DESCRIPTION
In preparation for multipass release, add interface for supported version and remove skipped test for multipass issue in now-unsupported versions.
