### PR TITLE
util: add temp path helpers for creating temp paths in home directory

### DIFF
--- a/craft_providers/util/temp_paths.py
+++ b/craft_providers/util/temp_paths.py
@@ -28,13 +28,3 @@ def home_temporary_directory() -> Iterator[pathlib.Path]:
         dir=pathlib.Path.home(),
     ) as tmp_dir:
         yield pathlib.Path(tmp_dir)
-
-
-@contextlib.contextmanager
-def home_temporary_file(name: str) -> Iterator[pathlib.Path]:
-    """Create temporary directory in home directory where Multipass has access.
-
-    :param name: Name of file to use (in temporary directory).
-    """
-    with home_temporary_directory() as tmp_dir:
-        yield tmp_dir / name

--- a/craft_providers/util/temp_paths.py
+++ b/craft_providers/util/temp_paths.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers for temporary files."""
+
+import contextlib
+import pathlib
+import tempfile
+from typing import Iterator
+
+
+@contextlib.contextmanager
+def home_temporary_directory() -> Iterator[pathlib.Path]:
+    """Create temporary directory in home directory where Multipass has access."""
+    with tempfile.TemporaryDirectory(
+        suffix=".tmp-craft",
+        dir=pathlib.Path.home(),
+    ) as tmp_dir:
+        yield pathlib.Path(tmp_dir)
+
+
+@contextlib.contextmanager
+def home_temporary_file(name: str) -> Iterator[pathlib.Path]:
+    """Create temporary directory in home directory where Multipass has access.
+
+    :param name: Name of file to use (in temporary directory).
+    """
+    with home_temporary_directory() as tmp_dir:
+        yield tmp_dir / name

--- a/tests/unit/util/test_temp_paths.py
+++ b/tests/unit/util/test_temp_paths.py
@@ -23,15 +23,3 @@ def test_home_temporary_directory():
         assert tmp_path.is_dir() is True
 
     assert tmp_path.exists() is False
-
-
-def test_home_temporary_file():
-    with temp_paths.home_temporary_file(name="foo") as tmp_path:
-        assert tmp_path.relative_to(pathlib.Path.home())
-        assert tmp_path.exists() is False
-        assert tmp_path.parent.is_dir() is True
-        assert tmp_path.name == "foo"
-
-        tmp_path.write_text("foo")
-
-    assert tmp_path.exists() is False

--- a/tests/unit/util/test_temp_paths.py
+++ b/tests/unit/util/test_temp_paths.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+
+from craft_providers.util import temp_paths
+
+
+def test_home_temporary_directory():
+    with temp_paths.home_temporary_directory() as tmp_path:
+        assert tmp_path.relative_to(pathlib.Path.home())
+        assert tmp_path.is_dir() is True
+
+    assert tmp_path.exists() is False
+
+
+def test_home_temporary_file():
+    with temp_paths.home_temporary_file(name="foo") as tmp_path:
+        assert tmp_path.relative_to(pathlib.Path.home())
+        assert tmp_path.exists() is False
+        assert tmp_path.parent.is_dir() is True
+        assert tmp_path.name == "foo"
+
+        tmp_path.write_text("foo")
+
+    assert tmp_path.exists() is False


### PR DESCRIPTION
A few places need temp files/dirs and create them in the home directory
for Multipass to be able to access.

This adds two helpers to do this consistently:
- home_temporary_file()
- home_temporary_directory()

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
