### PR TITLE
buildd: install udev dependency for snapd (CRAFT-288)

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -467,6 +467,7 @@ class BuilddBase(Base):
                     "install",
                     "-y",
                     "fuse",
+                    "udev",
                 ],
                 check=True,
                 capture_output=True,

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -115,7 +115,7 @@ def test_setup(  # pylint: disable=too-many-arguments
         [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "apt-utils"]
     )
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "fuse"]
+        [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "fuse", "udev"]
     )
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "systemctl", "enable", "systemd-udevd"]
@@ -446,7 +446,7 @@ def test_setup_snapd_failures(
     return_codes[fail_index] = 1
 
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "fuse"],
+        [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "fuse", "udev"],
         returncode=return_codes[0],
     )
     fake_process.register_subprocess(


### PR DESCRIPTION
sudo and udev packages are required for LXD buildd images.
Subsequent PRs will include integration test coverage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
