### PR TITLE
lxd instance: drop sudo usage (CRAFT-289)

### DIFF
--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -55,12 +55,10 @@ def _rootify_lxc_command(
 
     :returns: List of command strings for multipass exec.
     """
-    sudo_cmd = ["sudo", "-H", "--"]
-
     if env is not None:
-        sudo_cmd += env_cmd.formulate_command(env)
+        return env_cmd.formulate_command(env) + command
 
-    return sudo_cmd + command
+    return command
 
 
 class LXDInstance(Executor):

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -117,9 +117,6 @@ def test_push_file_io(
         mock.call.exec(
             instance_name="test-instance",
             command=[
-                "sudo",
-                "-H",
-                "--",
                 "chown",
                 "root:root",
                 "/etc/test.conf",
@@ -181,7 +178,7 @@ def test_execute_popen(mock_lxc, instance):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name="test-instance",
-            command=["sudo", "-H", "--", "test-command", "flags"],
+            command=["test-command", "flags"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.Popen,
@@ -196,7 +193,7 @@ def test_execute_popen_with_env(mock_lxc, instance):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name="test-instance",
-            command=["sudo", "-H", "--", "env", "foo=bar", "test-command", "flags"],
+            command=["env", "foo=bar", "test-command", "flags"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.Popen,
@@ -210,7 +207,7 @@ def test_execute_run(mock_lxc, instance):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name="test-instance",
-            command=["sudo", "-H", "--", "test-command", "flags"],
+            command=["test-command", "flags"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -225,7 +222,7 @@ def test_execute_run_with_env(mock_lxc, instance):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name="test-instance",
-            command=["sudo", "-H", "--", "env", "foo=bar", "test-command", "flags"],
+            command=["env", "foo=bar", "test-command", "flags"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -242,9 +239,6 @@ def test_execute_run_with_env_unset(mock_lxc, instance):
         mock.call.exec(
             instance_name="test-instance",
             command=[
-                "sudo",
-                "-H",
-                "--",
                 "env",
                 "foo=bar",
                 "-u",
@@ -517,7 +511,7 @@ def test_pull_file(mock_lxc, instance, tmp_path):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name=instance.name,
-            command=["sudo", "-H", "--", "test", "-f", "/tmp/src.txt"],
+            command=["test", "-f", "/tmp/src.txt"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -548,7 +542,7 @@ def test_pull_file_no_source(mock_lxc, instance, tmp_path):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name=instance.name,
-            command=["sudo", "-H", "--", "test", "-f", "/tmp/src.txt"],
+            command=["test", "-f", "/tmp/src.txt"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -573,7 +567,7 @@ def test_pull_file_no_parent_directory(mock_lxc, instance, tmp_path):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name=instance.name,
-            command=["sudo", "-H", "--", "test", "-f", "/tmp/src.txt"],
+            command=["test", "-f", "/tmp/src.txt"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -598,7 +592,7 @@ def test_push_file(mock_lxc, instance, tmp_path):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name=instance.name,
-            command=["sudo", "-H", "--", "test", "-d", "/tmp"],
+            command=["test", "-d", "/tmp"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -646,7 +640,7 @@ def test_push_file_no_parent_directory(mock_lxc, instance, tmp_path):
     assert mock_lxc.mock_calls == [
         mock.call.exec(
             instance_name=instance.name,
-            command=["sudo", "-H", "--", "test", "-d", "/tmp"],
+            command=["test", "-d", "/tmp"],
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,


### PR DESCRIPTION
This will remove the sudo dependency for LXD, which is not in
the LXD buildd images.

As using sudo populates the processes with /etc/environment,
a subsequent PR will will improve environment handling to
ensure consistency across providers.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
