### PR TITLE
lxd: add buildd remote support (CRAFT-260)

### DIFF
--- a/craft_providers/lxd/__init__.py
+++ b/craft_providers/lxd/__init__.py
@@ -20,3 +20,4 @@ from .launcher import launch  # noqa: F401
 from .lxc import LXC  # noqa: F401
 from .lxd import LXD  # noqa: F401
 from .lxd_instance import LXDInstance  # noqa: F401
+from .remotes import configure_buildd_image_remote  # noqa: F401

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Remote helper utilities."""
+import logging
+
+from .lxc import LXC
+
+logger = logging.getLogger(__name__)
+
+
+BUILDD_REMOTE_NAME = "com.cloud-images.buildd.releases"
+BUILDD_REMOTE_ADDR = "https://cloud-images.ubuntu.com/buildd/releases"
+
+
+def configure_buildd_image_remote(
+    lxc: LXC = LXC(),
+) -> str:
+    """Configure buildd remote, adding remote as required.
+
+    :param lxc: LXC client.
+
+    :returns: Name of remote to pass to launcher.
+    """
+    if BUILDD_REMOTE_NAME in lxc.remote_list():
+        logger.debug("Remote %r already exists.", BUILDD_REMOTE_NAME)
+    else:
+        lxc.remote_add(
+            remote=BUILDD_REMOTE_NAME,
+            addr=BUILDD_REMOTE_ADDR,
+            protocol="simplestreams",
+        )
+        logger.debug("Remote %r was successfully added.", BUILDD_REMOTE_NAME)
+
+    return BUILDD_REMOTE_NAME

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -20,7 +20,7 @@ from .lxc import LXC
 logger = logging.getLogger(__name__)
 
 
-BUILDD_REMOTE_NAME = "com.cloud-images.buildd.releases"
+BUILDD_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd"
 BUILDD_REMOTE_ADDR = "https://cloud-images.ubuntu.com/buildd/releases"
 
 

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -28,7 +28,7 @@ from craft_providers import bases, lxd
 )
 def test_configure_and_launch_buildd_remotes(instance_name, alias, image_name):
     image_remote = lxd.configure_buildd_image_remote()
-    assert image_remote == "com.cloud-images.buildd.releases"
+    assert image_remote == "craft-com.ubuntu.cloud-buildd"
 
     base_configuration = bases.BuilddBase(alias=alias)
     instance = lxd.launch(

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+
+import pytest
+
+from craft_providers import bases, lxd
+
+
+@pytest.mark.parametrize(
+    "alias,image_name",
+    [
+        (bases.BuilddBaseAlias.BIONIC, "18.04"),
+        (bases.BuilddBaseAlias.FOCAL, "20.04"),
+    ],
+)
+def test_configure_and_launch_buildd_remotes(instance_name, alias, image_name):
+    image_remote = lxd.configure_buildd_image_remote()
+    assert image_remote == "com.cloud-images.buildd.releases"
+
+    base_configuration = bases.BuilddBase(alias=alias)
+    instance = lxd.launch(
+        name=instance_name,
+        base_configuration=base_configuration,
+        image_name=image_name,
+        image_remote=image_remote,
+    )
+
+    try:
+        assert isinstance(instance, lxd.LXDInstance)
+        assert instance.exists() is True
+        assert instance.is_running() is True
+
+        proc = instance.execute_run(["echo", "hi"], check=True, stdout=subprocess.PIPE)
+
+        assert proc.stdout == b"hi\n"
+    finally:
+        instance.delete()

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -31,12 +31,12 @@ def mock_lxc():
 def test_configure_buildd_image_remote_fresh(mock_lxc):
     name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
 
-    assert name == "com.cloud-images.buildd.releases"
+    assert name == "craft-com.ubuntu.cloud-buildd"
     assert mock_lxc.mock_calls == [
         mock.call.remote_list(),
-        mock.call.remote_list().__contains__("com.cloud-images.buildd.releases"),
+        mock.call.remote_list().__contains__("craft-com.ubuntu.cloud-buildd"),
         mock.call.remote_add(
-            remote="com.cloud-images.buildd.releases",
+            remote="craft-com.ubuntu.cloud-buildd",
             addr="https://cloud-images.ubuntu.com/buildd/releases",
             protocol="simplestreams",
         ),
@@ -44,11 +44,11 @@ def test_configure_buildd_image_remote_fresh(mock_lxc):
 
 
 def test_configure_buildd_image_remote_already_exists(mock_lxc):
-    mock_lxc.remote_list.return_value = {"com.cloud-images.buildd.releases": {}}
+    mock_lxc.remote_list.return_value = {"craft-com.ubuntu.cloud-buildd": {}}
 
     name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
 
-    assert name == "com.cloud-images.buildd.releases"
+    assert name == "craft-com.ubuntu.cloud-buildd"
     assert mock_lxc.mock_calls == [
         mock.call.remote_list(),
     ]

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+import pytest
+
+from craft_providers import lxd
+
+
+@pytest.fixture
+def mock_lxc():
+    with mock.patch(
+        "craft_providers.lxd.launcher.LXC",
+        spec=lxd.LXC,
+    ) as mock_lxc:
+        yield mock_lxc.return_value
+
+
+def test_configure_buildd_image_remote_fresh(mock_lxc):
+    name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
+
+    assert name == "com.cloud-images.buildd.releases"
+    assert mock_lxc.mock_calls == [
+        mock.call.remote_list(),
+        mock.call.remote_list().__contains__("com.cloud-images.buildd.releases"),
+        mock.call.remote_add(
+            remote="com.cloud-images.buildd.releases",
+            addr="https://cloud-images.ubuntu.com/buildd/releases",
+            protocol="simplestreams",
+        ),
+    ]
+
+
+def test_configure_buildd_image_remote_already_exists(mock_lxc):
+    mock_lxc.remote_list.return_value = {"com.cloud-images.buildd.releases": {}}
+
+    name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
+
+    assert name == "com.cloud-images.buildd.releases"
+    assert mock_lxc.mock_calls == [
+        mock.call.remote_list(),
+    ]


### PR DESCRIPTION
Add configure_buildd_image_remote() helper to add the buildd
remote and return its name.  Calling applications will call
this as part of their setup code prior to launching
an instance.

Add launcher integration tests for the 16.04 and 18.04 buildd
images.  Xenial is currently unsupported because its
/etc/apt/sources.list does not include the -updates
or -security suites, breaking an assumption that snapd is updated
in the buildd image (it ships 2.0.2).  Further work will be
required to support it properly.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Requires #54 and #53 for integration tests to pass.
