### PR TITLE
lxd launcher: enable configuration of project & remote (CRAFT-304)

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -73,6 +73,8 @@ def _publish_snapshot(
         alias=snapshot_name,
         instance_name=instance.name,
         force=True,
+        project=instance.project,
+        remote=instance.remote,
     )
 
     # Restart container and ensure it is ready.
@@ -90,6 +92,8 @@ def launch(
     ephemeral: bool = False,
     map_user_uid: bool = False,
     use_snapshots: bool = False,
+    project: str = "default",
+    remote: str = "local",
     lxc: LXC = LXC(),
 ) -> LXDInstance:
     """Create, start, and configure instance.
@@ -105,6 +109,8 @@ def launch(
     :param ephemeral: Create ephemeral instance.
     :param map_user_uid: Map current uid/gid to instance's root uid/gid.
     :param use_snapshots: Use LXD snapshots for bootstrapping images.
+    :param project: LXD project to create instance in.
+    :param remote: LXD remote to create instance on.
     :param lxc: LXC client.
 
     :returns: LXD instance.
@@ -112,7 +118,7 @@ def launch(
     :raises BaseConfigurationError: on unexpected error configuration base.
     :raises LXDError: on unexpected LXD error.
     """
-    instance = LXDInstance(name=name)
+    instance = LXDInstance(name=name, project=project, remote=remote)
 
     if instance.exists():
         # TODO: warn (or auto clean) if ephemeral or map_user_uid is mismatched.
@@ -139,10 +145,12 @@ def launch(
         image_remote=image_remote,
         compatibility_tag=base_configuration.compatibility_tag,
     )
-    if use_snapshots and lxc.has_image(image_name=snapshot_name):
+    if use_snapshots and lxc.has_image(
+        image_name=snapshot_name, project=project, remote=remote
+    ):
         logger.debug("Using compatible snapshot %r.", snapshot_name)
         image_name = snapshot_name
-        image_remote = "local"
+        image_remote = remote
 
         # Don't re-publish this snapshot later.
         use_snapshots = False

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -105,6 +105,43 @@ def test_launch_with_snapshots(instance_name):
             lxc.image_delete(image=snapshot_name)
 
 
+def test_launch_with_project_and_snapshots(instance_name, project):
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+    snapshot_name = "snapshot-ubuntu-20.04-buildd-base-v0"
+    lxc = lxd.LXC()
+
+    instance = lxd.launch(
+        name=instance_name,
+        base_configuration=base_configuration,
+        image_name="20.04",
+        image_remote="ubuntu",
+        use_snapshots=True,
+        project=project,
+        remote="local",
+    )
+
+    try:
+        instance.delete()
+
+        assert lxc.has_image(snapshot_name, project=project, remote="local") is True
+
+        instance = lxd.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            use_snapshots=True,
+            project=project,
+            remote="local",
+        )
+    finally:
+        if instance.exists():
+            instance.delete()
+
+        if lxc.has_image(snapshot_name, project=project, remote="local"):
+            lxc.image_delete(image=snapshot_name, project=project, remote="local")
+
+
 def test_launch_ephemeral(instance_name):
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
 

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -42,6 +42,8 @@ def mock_lxd_instance():
         spec=lxd.LXDInstance,
     ) as mock_instance:
         mock_instance.return_value.name = "test-instance"
+        mock_instance.return_value.project = "test-project"
+        mock_instance.return_value.remote = "test-remote"
         yield mock_instance.return_value
 
 
@@ -81,17 +83,23 @@ def test_launch_making_initial_snapshot(
         image_name="image-name",
         image_remote="image-remote",
         use_snapshots=True,
+        project="test-project",
+        remote="test-remote",
         lxc=mock_lxc,
     )
 
     assert mock_lxc.mock_calls == [
         mock.call.has_image(
-            image_name="snapshot-image-remote-image-name-mock-compat-tag-v100"
+            image_name="snapshot-image-remote-image-name-mock-compat-tag-v100",
+            project="test-project",
+            remote="test-remote",
         ),
         mock.call.publish(
             alias="snapshot-image-remote-image-name-mock-compat-tag-v100",
             instance_name="test-instance",
             force=True,
+            project="test-project",
+            remote="test-remote",
         ),
     ]
     assert mock_lxd_instance.mock_calls == [
@@ -123,19 +131,23 @@ def test_launch_using_existing_snapshot(
         image_name="image-name",
         image_remote="image-remote",
         use_snapshots=True,
+        project="test-project",
+        remote="test-remote",
         lxc=mock_lxc,
     )
 
     assert mock_lxc.mock_calls == [
         mock.call.has_image(
-            image_name="snapshot-image-remote-image-name-mock-compat-tag-v100"
+            image_name="snapshot-image-remote-image-name-mock-compat-tag-v100",
+            project="test-project",
+            remote="test-remote",
         ),
     ]
     assert mock_lxd_instance.mock_calls == [
         mock.call.exists(),
         mock.call.launch(
             image="snapshot-image-remote-image-name-mock-compat-tag-v100",
-            image_remote="local",
+            image_remote="test-remote",
             ephemeral=False,
             map_user_uid=False,
         ),


### PR DESCRIPTION
While LXD supported configuration of project & remote, the
launcher did not.  Extend launcher logic to support these.

Update unit tests and add integration test coverage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
