### PR TITLE
lxd launcher: add auto_create_project flag (CRAFT-150)

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -100,13 +100,17 @@ def _ensure_project_exists(
 
     :raises LXDError: on error.
     """
-    if project in lxc.project_list(remote):
+    projects = lxc.project_list(remote)
+    if project in projects:
         return
 
     if create:
         create_with_default_profile(project=project, remote=remote, lxc=lxc)
     else:
-        raise LXDError(f"LXD project {project!r} not found on remote {remote!r}.")
+        raise LXDError(
+            brief=f"LXD project {project!r} not found on remote {remote!r}.",
+            details=f"Available projects: {projects!r}",
+        )
 
 
 def launch(

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -18,8 +18,10 @@ import logging
 
 from craft_providers import Base, bases
 
+from .errors import LXDError
 from .lxc import LXC
 from .lxd_instance import LXDInstance
+from .project import create_with_default_profile
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +84,31 @@ def _publish_snapshot(
     base_configuration.wait_until_ready(executor=instance)
 
 
+def _ensure_project_exists(
+    *,
+    create: bool,
+    project: str,
+    remote: str,
+    lxc: LXC,
+) -> None:
+    """Check if project exists, optionally creating it if needed.
+
+    :param create: Create project if not found.
+    :param project: LXD project name to create.
+    :param remote: LXD remote to create project on.
+    :param lxc: LXC client.
+
+    :raises LXDError: on error.
+    """
+    if project in lxc.project_list(remote):
+        return
+
+    if create:
+        create_with_default_profile(project=project, remote=remote, lxc=lxc)
+    else:
+        raise LXDError(f"LXD project {project!r} not found on remote {remote!r}.")
+
+
 def launch(
     name: str,
     *,
@@ -89,6 +116,7 @@ def launch(
     image_name: str,
     image_remote: str,
     auto_clean: bool = False,
+    auto_create_project: bool = False,
     ephemeral: bool = False,
     map_user_uid: bool = False,
     use_snapshots: bool = False,
@@ -106,6 +134,7 @@ def launch(
     :param image_name: LXD image to use, e.g. "20.04".
     :param image_remote: LXD image to use, e.g. "ubuntu".
     :param auto_clean: Automatically clean instance, if incompatible.
+    :param auto_create_project: Automatically create LXD project, if needed.
     :param ephemeral: Create ephemeral instance.
     :param map_user_uid: Map current uid/gid to instance's root uid/gid.
     :param use_snapshots: Use LXD snapshots for bootstrapping images.
@@ -118,6 +147,9 @@ def launch(
     :raises BaseConfigurationError: on unexpected error configuration base.
     :raises LXDError: on unexpected LXD error.
     """
+    _ensure_project_exists(
+        create=auto_create_project, project=project, remote=remote, lxc=lxc
+    )
     instance = LXDInstance(name=name, project=project, remote=remote)
 
     if instance.exists():

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -89,9 +89,14 @@ def lxc():
 
 
 @pytest.fixture()
-def project(lxc):
+def project_name():
     """Create temporary LXD project and assert expected properties."""
-    project_name = "ptest-" + "".join(random.choices(string.ascii_uppercase, k=4))
+    yield "ptest-" + "".join(random.choices(string.ascii_uppercase, k=4))
+
+
+@pytest.fixture()
+def project(lxc, project_name):
+    """Create temporary LXD project and assert expected properties."""
     lxc_project.create_with_default_profile(lxc=lxc, project=project_name)
 
     projects = lxc.project_list()

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -19,6 +19,7 @@ import subprocess
 import pytest
 
 from craft_providers import bases, lxd
+from craft_providers.lxd import project as lxd_project
 
 from . import conftest
 
@@ -125,7 +126,7 @@ def test_launch_creating_project(instance_name, project_name):
         assert instance.exists()
         assert project_name in lxc.project_list()
     finally:
-        lxd.project.purge(lxc=lxc, project=project_name)
+        lxd_project.purge(lxc=lxc, project=project_name)
 
 
 def test_launch_with_project_and_snapshots(instance_name, project):

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -105,6 +105,29 @@ def test_launch_with_snapshots(instance_name):
             lxc.image_delete(image=snapshot_name)
 
 
+def test_launch_creating_project(instance_name, project_name):
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+    lxc = lxd.LXC()
+
+    assert project_name not in lxc.project_list()
+
+    try:
+        instance = lxd.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            auto_create_project=True,
+            project=project_name,
+            remote="local",
+        )
+
+        assert instance.exists()
+        assert project_name in lxc.project_list()
+    finally:
+        lxd.project.purge(lxc=lxc, project=project_name)
+
+
 def test_launch_with_project_and_snapshots(instance_name, project):
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
     snapshot_name = "snapshot-ubuntu-20.04-buildd-base-v0"

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -194,6 +194,28 @@ def test_launch_all_opts(mock_base_configuration, mock_lxc, mock_lxd_instance):
     ]
 
 
+def test_launch_missing_project(mock_base_configuration, mock_lxc, mock_lxd_instance):
+    mock_lxd_instance.exists.return_value = False
+
+    with pytest.raises(lxd.LXDError) as exc_info:
+        lxd.launch(
+            "test-instance",
+            base_configuration=mock_base_configuration,
+            image_name="image-name",
+            image_remote="image-remote",
+            auto_create_project=False,
+            project="invalid-project",
+            remote="test-remote",
+            lxc=mock_lxc,
+        )
+
+    assert (
+        exc_info.value.brief
+        == "LXD project 'invalid-project' not found on remote 'test-remote'."
+    )
+    assert exc_info.value.details == "Available projects: ['default', 'test-project']"
+
+
 def test_launch_create_project(mock_base_configuration, mock_lxc, mock_lxd_instance):
     mock_lxd_instance.exists.return_value = False
 


### PR DESCRIPTION
Provide a simple toggle to automatically create the specified
LXD project if not found.  Defaults to False.

With this change, always verify the existence of the project
before continuing, raising LXDError() if not found.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
