### PR TITLE
lxd instance: account for command environment (CRAFT-309)

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -19,7 +19,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Dict, Optional
 
 from .executor import Executor
 
@@ -49,9 +49,18 @@ class Base(ABC):
         extend this tag, not overwrite it, e.g.: compatibilty_tag =
         f"{appname}-{Base.compatibility_tag}.{apprevision}" to ensure base
         compatibility levels are maintained.
+
+    :param environment: Command environment.
     """
 
     compatibility_tag: str = "base-v0"
+
+    def __init__(
+        self,
+        *,
+        environment: Dict[str, Optional[str]],
+    ):
+        self.environment = environment
 
     @abstractmethod
     def setup(

--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -49,18 +49,19 @@ class Base(ABC):
         extend this tag, not overwrite it, e.g.: compatibilty_tag =
         f"{appname}-{Base.compatibility_tag}.{apprevision}" to ensure base
         compatibility levels are maintained.
-
-    :param environment: Command environment.
     """
 
     compatibility_tag: str = "base-v0"
 
-    def __init__(
+    @abstractmethod
+    def get_command_environment(
         self,
-        *,
-        environment: Dict[str, Optional[str]],
-    ):
-        self.environment = environment
+    ) -> Dict[str, Optional[str]]:
+        """Get command environment to use when executing commands.
+
+        :returns: Dictionary of environment, allowing None as a value to
+                  indicate that a value should be unset.
+        """
 
     @abstractmethod
     def setup(

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -116,12 +116,12 @@ class BuilddBase(Base):
         environment: Optional[Dict[str, Optional[str]]] = None,
         hostname: str = "craft-buildd-instance",
     ):
-        self.alias: BuilddBaseAlias = alias
-
         if environment is None:
-            self.environment = default_command_environment()
-        else:
-            self.environment = environment
+            environment = default_command_environment()
+
+        super().__init__(environment=environment)
+
+        self.alias: BuilddBaseAlias = alias
 
         self.hostname = hostname
 

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -116,12 +116,12 @@ class BuilddBase(Base):
         environment: Optional[Dict[str, Optional[str]]] = None,
         hostname: str = "craft-buildd-instance",
     ):
-        if environment is None:
-            environment = default_command_environment()
-
-        super().__init__(environment=environment)
-
         self.alias: BuilddBaseAlias = alias
+
+        if environment is None:
+            self.environment = default_command_environment()
+        else:
+            self.environment = environment
 
         self.hostname = hostname
 
@@ -192,6 +192,16 @@ class BuilddBase(Base):
             raise BaseCompatibilityError(
                 reason=f"Expected OS version {compat_version_id!r}, found {version_id!r}"
             )
+
+    def get_command_environment(
+        self,
+    ) -> Dict[str, Optional[str]]:
+        """Get command environment to use when executing commands.
+
+        :returns: Dictionary of environment, allowing None as a value to
+                  indicate that a value should be unset.
+        """
+        return self.environment.copy()
 
     def setup(
         self,

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -157,7 +157,12 @@ def launch(
     _ensure_project_exists(
         create=auto_create_project, project=project, remote=remote, lxc=lxc
     )
-    instance = LXDInstance(name=name, project=project, remote=remote)
+    instance = LXDInstance(
+        name=name,
+        project=project,
+        remote=remote,
+        default_command_environment=base_configuration.environment.copy(),
+    )
 
     if instance.exists():
         # TODO: warn (or auto clean) if ephemeral or map_user_uid is mismatched.

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -161,7 +161,7 @@ def launch(
         name=name,
         project=project,
         remote=remote,
-        default_command_environment=base_configuration.environment.copy(),
+        default_command_environment=base_configuration.get_command_environment(),
     )
 
     if instance.exists():

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -36,34 +36,6 @@ from .lxc import LXC
 logger = logging.getLogger(__name__)
 
 
-def _rootify_lxc_command(
-    command: List[str],
-    *,
-    env: Optional[Dict[str, Optional[str]]] = None,
-) -> List[str]:
-    """Wrap a command to run as root with specified environment.
-
-    Formulate command to:
-
-        - Use sudo to run as root (LXD defaults to root, but doesn't initialize
-          environment like sudo will, e.g. read /etc/environment).  For
-          consistency with Multipass and other providers, always use sudo.
-
-        - Configure sudo to set home directory.
-
-        - Account for environment flags in env, if any.
-
-    :param command: Command to execute.
-    :param env: Additional environment flags to set.
-
-    :returns: List of command strings for multipass exec.
-    """
-    if env is not None:
-        return env_cmd.formulate_command(env) + command
-
-    return command
-
-
 class LXDInstance(Executor):
     """LXD Instance Lifecycle."""
 
@@ -71,11 +43,17 @@ class LXDInstance(Executor):
         self,
         *,
         name: str,
+        default_command_environment: Optional[Dict[str, Optional[str]]] = None,
         project: str = "default",
         remote: str = "local",
         lxc: Optional[LXC] = None,
     ):
         super().__init__()
+
+        if default_command_environment is not None:
+            self.default_command_environment = default_command_environment
+        else:
+            self.default_command_environment = {}
 
         self.name = name
         self.project = project
@@ -85,6 +63,42 @@ class LXDInstance(Executor):
             self.lxc = LXC()
         else:
             self.lxc = lxc
+
+    def _rootify_lxc_command(
+        self,
+        command: List[str],
+        *,
+        env: Optional[Dict[str, Optional[str]]] = None,
+    ) -> List[str]:
+        """Wrap a command to run as root with specified environment.
+
+        Formulate command to:
+
+            - Use sudo to run as root (LXD defaults to root, but doesn't
+              initialize environment like sudo will, e.g. read
+              /etc/environment).  For consistency with Multipass and other
+              providers, always use sudo.
+
+            - Configure sudo to set home directory.
+
+            - Account for environment flags in env, if any.  Use the default
+              environment flags, overridden with the command flags parameter
+              'env'.
+
+        :param command: Command to execute.
+        :param env: Additional environment flags to set/unset.
+
+        :returns: List of command strings for multipass exec.
+        """
+        command_env = self.default_command_environment.copy()
+
+        if env:
+            command_env.update(env)
+
+        if command_env:
+            return env_cmd.formulate_command(command_env) + command
+
+        return command
 
     def push_file_io(
         self,
@@ -168,7 +182,7 @@ class LXDInstance(Executor):
         """
         return self.lxc.exec(
             instance_name=self.name,
-            command=_rootify_lxc_command(command=command, env=env),
+            command=self._rootify_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
             runner=subprocess.Popen,
@@ -198,7 +212,7 @@ class LXDInstance(Executor):
         """
         return self.lxc.exec(
             instance_name=self.name,
-            command=_rootify_lxc_command(command=command, env=env),
+            command=self._rootify_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
             runner=subprocess.run,

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -64,7 +64,7 @@ class LXDInstance(Executor):
         else:
             self.lxc = lxc
 
-    def _rootify_lxc_command(
+    def _finalize_lxc_command(
         self,
         command: List[str],
         *,
@@ -72,18 +72,11 @@ class LXDInstance(Executor):
     ) -> List[str]:
         """Wrap a command to run as root with specified environment.
 
-        Formulate command to:
+        LXD will run commands as root.
 
-            - Use sudo to run as root (LXD defaults to root, but doesn't
-              initialize environment like sudo will, e.g. read
-              /etc/environment).  For consistency with Multipass and other
-              providers, always use sudo.
-
-            - Configure sudo to set home directory.
-
-            - Account for environment flags in env, if any.  Use the default
-              environment flags, overridden with the command flags parameter
-              'env'.
+        Account for the command environment by using the default command
+        environment as the baseline, updating it to reflect the command's env
+        parameter, if any.
 
         :param command: Command to execute.
         :param env: Additional environment flags to set/unset.
@@ -182,7 +175,7 @@ class LXDInstance(Executor):
         """
         return self.lxc.exec(
             instance_name=self.name,
-            command=self._rootify_lxc_command(command=command, env=env),
+            command=self._finalize_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
             runner=subprocess.Popen,
@@ -212,7 +205,7 @@ class LXDInstance(Executor):
         """
         return self.lxc.exec(
             instance_name=self.name,
-            command=self._rootify_lxc_command(command=command, env=env),
+            command=self._finalize_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
             runner=subprocess.run,

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -26,7 +26,7 @@ from craft_providers import Base, bases, lxd
 def mock_base_configuration():
     mock_base = mock.Mock(spec=Base)
     mock_base.compatibility_tag = "mock-compat-tag-v100"
-    mock_base.environment = {"foo": "bar"}
+    mock_base.get_command_environment.return_value = {"foo": "bar"}
     yield mock_base
 
 
@@ -80,7 +80,8 @@ def test_launch(mock_base_configuration, mock_lxc, mock_lxd_instance):
         ),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_lxd_instance.return_value)
+        mock.call.get_command_environment(),
+        mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
 
 
@@ -134,6 +135,7 @@ def test_launch_making_initial_snapshot(
         mock.call().start(),
     ]
     assert mock_base_configuration.mock_calls == [
+        mock.call.get_command_environment(),
         mock.call.setup(executor=mock_lxd_instance.return_value),
         mock.call.wait_until_ready(executor=mock_lxd_instance.return_value),
     ]
@@ -180,6 +182,7 @@ def test_launch_using_existing_snapshot(
         ),
     ]
     assert mock_base_configuration.mock_calls == [
+        mock.call.get_command_environment(),
         mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
 
@@ -218,7 +221,8 @@ def test_launch_all_opts(mock_base_configuration, mock_lxc, mock_lxd_instance):
         ),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_lxd_instance.return_value)
+        mock.call.get_command_environment(),
+        mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
 
 
@@ -287,7 +291,8 @@ def test_launch_create_project(mock_base_configuration, mock_lxc, mock_lxd_insta
         ),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_lxd_instance.return_value)
+        mock.call.get_command_environment(),
+        mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
 
 
@@ -318,7 +323,8 @@ def test_launch_with_existing_instance_not_running(
         mock.call().start(),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_lxd_instance.return_value)
+        mock.call.get_command_environment(),
+        mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
 
 
@@ -348,7 +354,8 @@ def test_launch_with_existing_instance_running(
         mock.call().is_running(),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_lxd_instance.return_value)
+        mock.call.get_command_environment(),
+        mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
 
 
@@ -391,6 +398,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
         ),
     ]
     assert mock_base_configuration.mock_calls == [
+        mock.call.get_command_environment(),
         mock.call.setup(executor=mock_lxd_instance.return_value),
         mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
@@ -428,5 +436,6 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
         mock.call().start(),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_lxd_instance.return_value)
+        mock.call.get_command_environment(),
+        mock.call.setup(executor=mock_lxd_instance.return_value),
     ]

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -219,6 +219,48 @@ def test_execute_run(mock_lxc, instance):
     ]
 
 
+def test_execute_run_with_default_command_env(mock_lxc):
+    instance = LXDInstance(
+        name="test-instance",
+        default_command_environment={"env_key": "some-value"},
+        lxc=mock_lxc,
+    )
+
+    instance.execute_run(command=["test-command", "flags"], env=dict(foo="bar"))
+
+    assert mock_lxc.mock_calls == [
+        mock.call.exec(
+            instance_name="test-instance",
+            command=["env", "env_key=some-value", "foo=bar", "test-command", "flags"],
+            project=instance.project,
+            remote=instance.remote,
+            runner=subprocess.run,
+        )
+    ]
+
+
+def test_execute_run_with_default_command_env_unset(mock_lxc):
+    instance = LXDInstance(
+        name="test-instance",
+        default_command_environment={"env_key": "some-value"},
+        lxc=mock_lxc,
+    )
+
+    instance.execute_run(
+        command=["test-command", "flags"], env={"foo": "bar", "env_key": None}
+    )
+
+    assert mock_lxc.mock_calls == [
+        mock.call.exec(
+            instance_name="test-instance",
+            command=["env", "-u", "env_key", "foo=bar", "test-command", "flags"],
+            project=instance.project,
+            remote=instance.remote,
+            runner=subprocess.run,
+        )
+    ]
+
+
 def test_execute_run_with_env(mock_lxc, instance):
     instance.execute_run(command=["test-command", "flags"], env=dict(foo="bar"))
 


### PR DESCRIPTION
When exec'ing a command through LXD, /etc/environment is not read in
by default as it was when previously using sudo. For now, extend
LXDInstance with the default command environment, which can be
overriden by the execute functions' env= parameter.

- Extend Base definition with 'environment' parameter already present
  in BuilddBase.

- Move _rootify_lxc_command() into LXDInstance and account for the
  default command environment.

- Update LXD launcher to set LXDInstance's environment from the
  existing base configuration.  This way the environment will be
  set for all executed commands.

Future work may change the mechanism used to set the environment
(such as using lxc configuration, or wrapper script).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
