### PR TITLE
lxd: check if LXD is initialized prior to launch (CRAFT-348)

### DIFF
--- a/craft_providers/lxd/__init__.py
+++ b/craft_providers/lxd/__init__.py
@@ -18,7 +18,7 @@
 """LXD environment provider."""
 
 from .errors import LXDError, LXDInstallationError  # noqa: F401
-from .installer import install, is_installed  # noqa: F401
+from .installer import install, is_initialized, is_installed  # noqa: F401
 from .launcher import launch  # noqa: F401
 from .lxc import LXC  # noqa: F401
 from .lxd import LXD  # noqa: F401

--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -26,6 +26,7 @@ import sys
 from craft_providers.errors import details_from_called_process_error
 
 from . import errors
+from .lxc import LXC
 from .lxd import LXD
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,19 @@ def install(sudo: bool = True) -> str:
     lxd.init(auto=True, sudo=sudo)
 
     return lxd.version()
+
+
+def is_initialized(*, remote: str, lxc: LXC) -> bool:
+    """Verify that LXD has been initialized and configuration looks valid.
+
+    If LXD has been installed but the user has not initialized it (lxd init),
+    the default profile won't have devices configured.  Trying to launch an
+    instance or create a project using this profile will result in failures.
+
+    :returns: True if initialized, else False.
+    """
+    devices = lxc.profile_show(profile="default", remote=remote).get("devices")
+    return bool(devices)
 
 
 def is_installed() -> bool:

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -22,6 +22,7 @@ import logging
 from craft_providers import Base, bases
 
 from .errors import LXDError
+from .installer import is_initialized
 from .lxc import LXC
 from .lxd_instance import LXDInstance
 from .project import create_with_default_profile
@@ -154,6 +155,12 @@ def launch(
     :raises BaseConfigurationError: on unexpected error configuration base.
     :raises LXDError: on unexpected LXD error.
     """
+    if not is_initialized(lxc=lxc, remote=remote):
+        raise LXDError(
+            brief="LXD has not been properly initialized.",
+            resolution="Consider executing 'lxd init --auto' to initialize LXD.",
+        )
+
     _ensure_project_exists(
         create=auto_create_project, project=project, remote=remote, lxc=lxc
     )

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -16,8 +16,10 @@
 #
 
 """Fixtures for LXD integration tests."""
+import os
 import random
 import string
+import subprocess
 import time
 from contextlib import contextmanager
 from typing import Any, Dict, Optional
@@ -31,6 +33,23 @@ from craft_providers.lxd import project as lxc_project
 @pytest.fixture(autouse=True, scope="module")
 def installed_lxd_required(installed_lxd):
     """All LXD integration tests required LXD to be installed."""
+
+
+@pytest.fixture
+def installed_lxd_without_init(uninstalled_lxd):
+    """Ensure lxd is installed, but not initialized.
+
+    Initialize LXD on cleanup to ensure it is functional for other tests.
+
+    Requires CRAFT_PROVIDERS_TESTS_ENABLE_LXD_INSTALL=1.
+    """
+    if os.environ.get("CRAFT_PROVIDERS_TESTS_ENABLE_LXD_INSTALL") == "1":
+        subprocess.run(["sudo", "snap", "install", "lxd"], check=True)
+        subprocess.run(["sudo", "lxd", "waitready"], check=True)
+        yield
+        subprocess.run(["sudo", "lxd", "init", "--auto"], check=True)
+    else:
+        pytest.skip("lxd not installed, skipped")
 
 
 @contextmanager

--- a/tests/integration/lxd/test_installer.py
+++ b/tests/integration/lxd/test_installer.py
@@ -20,6 +20,14 @@ import shutil
 from craft_providers import lxd
 
 
+def test_is_initialized(installed_lxd):
+    assert lxd.is_initialized(lxc=lxd.LXC(), remote="local") is True
+
+
+def test_is_initialized_false(installed_lxd_without_init):
+    assert lxd.is_initialized(lxc=lxd.LXC(), remote="local") is False
+
+
 def test_is_installed():
     expected = shutil.which("lxd") is not None
 

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -324,3 +324,22 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
 
     assert core20_instance.exists() is True
     assert core20_instance.is_running() is True
+
+
+def test_launch_errors_with_uninitialized_lxd(
+    installed_lxd_without_init, instance_name
+):
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    with pytest.raises(lxd.LXDError) as exc_info:
+        lxd.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+        )
+
+    assert exc_info.value == lxd.LXDError(
+        brief="LXD has not been properly initialized.",
+        resolution="Consider executing 'lxd init --auto' to initialize LXD.",
+    )

--- a/tests/unit/lxd/test_installer.py
+++ b/tests/unit/lxd/test_installer.py
@@ -18,10 +18,17 @@
 import os
 import shutil
 import sys
+from unittest import mock
 
 import pytest
 
-from craft_providers.lxd import LXDInstallationError, install, is_installed
+from craft_providers.lxd import (
+    LXC,
+    LXDInstallationError,
+    install,
+    is_initialized,
+    is_installed,
+)
 
 
 @pytest.mark.parametrize("platform", ["win32", "darwin", "other"])
@@ -121,6 +128,17 @@ def test_install_requires_sudo(mocker):
     assert exc_info.value == LXDInstallationError(
         "sudo required if not running as root"
     )
+
+
+def test_is_initialized():
+    mock_lxc = mock.Mock(spec=LXC)
+
+    is_initialized(lxc=mock_lxc, remote="some-remote")
+
+    assert mock_lxc.mock_calls == [
+        mock.call.profile_show(profile="default", remote="some-remote"),
+        mock.call.profile_show().get("devices"),
+    ]
 
 
 @pytest.mark.parametrize("which,installed", [("/path/to/lxd", True), (None, False)])


### PR DESCRIPTION
- Add is_initialized() method to installer module to check.

- Run this check when attempting to launch instance, raising an
  LXDError on failure.

- Add unit and integration test coverage.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
