### PR TITLE
buildd base: configure apt to error on fetch failures (CRAFT-344)

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -280,7 +280,14 @@ class BuilddBase(Base):
         _check_deadline(deadline)
         executor.push_file_io(
             destination=pathlib.Path("/etc/apt/apt.conf.d/00no-recommends"),
-            content=io.BytesIO('Apt::Install-Recommends "false";\n'.encode()),
+            content=io.BytesIO('APT::Install-Recommends "false";\n'.encode()),
+            file_mode="0644",
+        )
+
+        _check_deadline(deadline)
+        executor.push_file_io(
+            destination=pathlib.Path("/etc/apt/apt.conf.d/00update-errors"),
+            content=io.BytesIO('APT::Update::Error-Mode "any";\n'.encode()),
             file_mode="0644",
         )
 

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -185,7 +185,14 @@ def test_setup(  # pylint: disable=too-many-arguments
         ),
         dict(
             destination="/etc/apt/apt.conf.d/00no-recommends",
-            content=b'Apt::Install-Recommends "false";\n',
+            content=b'APT::Install-Recommends "false";\n',
+            file_mode="0644",
+            group="root",
+            user="root",
+        ),
+        dict(
+            destination="/etc/apt/apt.conf.d/00update-errors",
+            content=b'APT::Update::Error-Mode "any";\n',
             file_mode="0644",
             group="root",
             user="root",


### PR DESCRIPTION
apt update will return exit code 0 if it fails to fetch updates due to
networking issues.  This is problematic because it can silently fail
during use if networking is not available when running update.

Use the option APT::Update::Error-Mode="any" to catch any fetch failures
and exit with error.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
