### PR TITLE
lxd: ensure user is permitted to use lxd (CRAFT-374)     

### DIFF
--- a/craft_providers/lxd/__init__.py
+++ b/craft_providers/lxd/__init__.py
@@ -18,7 +18,13 @@
 """LXD environment provider."""
 
 from .errors import LXDError, LXDInstallationError  # noqa: F401
-from .installer import install, is_initialized, is_installed  # noqa: F401
+from .installer import (  # noqa: F401
+    ensure_lxd_is_ready,
+    install,
+    is_initialized,
+    is_installed,
+    is_user_permitted,
+)
 from .launcher import launch  # noqa: F401
 from .lxc import LXC  # noqa: F401
 from .lxd import LXD  # noqa: F401

--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -107,9 +107,8 @@ def is_user_permitted() -> bool:
 
     :returns: True if user has correct permissions.
     """
-    return (
-        any(grp.getgrgid(g).gr_name == "lxd" for g in os.getgroups())
-        or os.geteuid() == 0
+    return os.geteuid() == 0 or any(
+        grp.getgrgid(g).gr_name == "lxd" for g in os.getgroups()
     )
 
 

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -22,7 +22,6 @@ import logging
 from craft_providers import Base, bases
 
 from .errors import LXDError
-from .installer import is_initialized
 from .lxc import LXC
 from .lxd_instance import LXDInstance
 from .project import create_with_default_profile
@@ -155,12 +154,6 @@ def launch(
     :raises BaseConfigurationError: on unexpected error configuration base.
     :raises LXDError: on unexpected LXD error.
     """
-    if not is_initialized(lxc=lxc, remote=remote):
-        raise LXDError(
-            brief="LXD has not been properly initialized.",
-            resolution="Consider executing 'lxd init --auto' to initialize LXD.",
-        )
-
     _ensure_project_exists(
         create=auto_create_project, project=project, remote=remote, lxc=lxc
     )

--- a/tests/integration/lxd/test_installer.py
+++ b/tests/integration/lxd/test_installer.py
@@ -17,6 +17,8 @@
 
 import shutil
 
+import pytest
+
 from craft_providers import lxd
 
 
@@ -41,3 +43,13 @@ def test_install(uninstalled_lxd):  # pylint: disable=unused-argument
 
     assert lxd.is_installed() is True
     assert lxd_version is not None
+
+
+def test_ensure_lxd_is_ready(installed_lxd_without_init):
+    with pytest.raises(lxd.LXDError) as exc_info:
+        lxd.ensure_lxd_is_ready()
+
+    assert exc_info.value == lxd.LXDError(
+        brief="LXD has not been properly initialized.",
+        resolution="Consider executing 'lxd init --auto' to initialize LXD.",
+    )

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -324,22 +324,3 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
 
     assert core20_instance.exists() is True
     assert core20_instance.is_running() is True
-
-
-def test_launch_errors_with_uninitialized_lxd(
-    installed_lxd_without_init, instance_name
-):
-    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
-
-    with pytest.raises(lxd.LXDError) as exc_info:
-        lxd.launch(
-            name=instance_name,
-            base_configuration=base_configuration,
-            image_name="20.04",
-            image_remote="ubuntu",
-        )
-
-    assert exc_info.value == lxd.LXDError(
-        brief="LXD has not been properly initialized.",
-        resolution="Consider executing 'lxd init --auto' to initialize LXD.",
-    )

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -52,19 +52,7 @@ def mock_lxd_instance():
         yield mock_instance
 
 
-@pytest.fixture(autouse=True)
-def mock_is_initialized():
-    with mock.patch(
-        "craft_providers.lxd.launcher.is_initialized",
-        spec=lxd.LXDInstance,
-    ) as mock_is_initialized:
-        mock_is_initialized.return_value = True
-        yield mock_is_initialized
-
-
-def test_launch(
-    mock_base_configuration, mock_is_initialized, mock_lxc, mock_lxd_instance
-):
+def test_launch(mock_base_configuration, mock_lxc, mock_lxd_instance):
     mock_lxd_instance.return_value.exists.return_value = False
 
     lxd.launch(
@@ -75,7 +63,6 @@ def test_launch(
         lxc=mock_lxc,
     )
 
-    assert mock_is_initialized.mock_calls == [mock.call(lxc=mock_lxc, remote="local")]
     assert mock_lxc.mock_calls == [mock.call.project_list("local")]
     assert mock_lxd_instance.mock_calls == [
         mock.call(
@@ -96,27 +83,6 @@ def test_launch(
         mock.call.get_command_environment(),
         mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
-
-
-def test_launch_lxd_not_initialized(
-    mock_base_configuration, mock_is_initialized, mock_lxc, mock_lxd_instance
-):
-    mock_is_initialized.return_value = False
-
-    with pytest.raises(lxd.LXDError) as exc_info:
-        lxd.launch(
-            "test-instance",
-            base_configuration=mock_base_configuration,
-            image_name="image-name",
-            image_remote="image-remote",
-            lxc=mock_lxc,
-        )
-
-    assert mock_is_initialized.mock_calls == [mock.call(lxc=mock_lxc, remote="local")]
-    assert exc_info.value == lxd.LXDError(
-        brief="LXD has not been properly initialized.",
-        resolution="Consider executing 'lxd init --auto' to initialize LXD.",
-    )
 
 
 def test_launch_making_initial_snapshot(
@@ -221,9 +187,7 @@ def test_launch_using_existing_snapshot(
     ]
 
 
-def test_launch_all_opts(
-    mock_base_configuration, mock_is_initialized, mock_lxc, mock_lxd_instance
-):
+def test_launch_all_opts(mock_base_configuration, mock_lxc, mock_lxd_instance):
     mock_lxd_instance.return_value.exists.return_value = False
 
     lxd.launch(
@@ -240,9 +204,6 @@ def test_launch_all_opts(
         lxc=mock_lxc,
     )
 
-    assert mock_is_initialized.mock_calls == [
-        mock.call(lxc=mock_lxc, remote="test-remote")
-    ]
     assert mock_lxc.mock_calls == [mock.call.project_list("test-remote")]
     assert mock_lxd_instance.mock_calls == [
         mock.call(


### PR DESCRIPTION

    - Introduce is_user_permitted() to check if user has the necessary
      permissions (that is, either root or in the lxd group).
    
    - As the number of checks are increasing, add another interface
      ensure_lxd_is_ready() which craft apps can use to verify the readiness
      of LXD prior to use.
    
    - Add permission check to LXD install to ensure user has necessary
      permissions before continuing.
    
    - Remove the initialization check from the launcher in favor of
      using ensure_lxd_is_ready() to catch potential errors even earlier.