### PR TITLE
util/env_cmd: add support for --chdir (CRAFT-449)

### DIFF
--- a/craft_providers/util/env_cmd.py
+++ b/craft_providers/util/env_cmd.py
@@ -16,11 +16,15 @@
 #
 
 """Helper(s) for env command."""
+import pathlib
 from typing import Dict, List, Optional
 
 
 def formulate_command(
-    env: Optional[Dict[str, Optional[str]]] = None, *, ignore_environment: bool = False
+    env: Optional[Dict[str, Optional[str]]] = None,
+    *,
+    chdir: Optional[pathlib.Path] = None,
+    ignore_environment: bool = False,
 ) -> List[str]:
     """Create an env command with the specified environment.
 
@@ -31,12 +35,19 @@ def formulate_command(
 
     An empty environment will simply yield the env command.
 
+    NOTE: not all versions of `env` support --chdir, it is up to the caller to
+    ensure compatibility.
+
     :param env: Environment flags to set/unset.
+    :param chdir: Optional directory to run in.
     :param ignore_environment: Start with an empty environment.
 
     :returns: List of env command strings.
     """
     env_cmd = ["env"]
+
+    if chdir:
+        env_cmd.append(f"--chdir={chdir.as_posix()}")
 
     if ignore_environment:
         env_cmd.append("-i")

--- a/tests/unit/util/test_env_cmd.py
+++ b/tests/unit/util/test_env_cmd.py
@@ -15,6 +15,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+import pathlib
 
 import pytest
 
@@ -53,3 +54,21 @@ def test_formulate_command(env, expected):
 )
 def test_formulate_command_ignore(env, expected):
     assert env_cmd.formulate_command(env, ignore_environment=True) == expected
+
+
+def test_formulate_command_chdir():
+    assert env_cmd.formulate_command(chdir=pathlib.Path("/tmp/foo")) == [
+        "env",
+        "--chdir=/tmp/foo",
+    ]
+
+
+def test_formulate_command_all_opts():
+    assert (
+        env_cmd.formulate_command(
+            env={"VAR_A": "1", "VAR_B": "2"},
+            ignore_environment=True,
+            chdir=pathlib.Path("/tmp/foo"),
+        )
+        == ["env", "--chdir=/tmp/foo", "-i", "VAR_A=1", "VAR_B=2"]
+    )


### PR DESCRIPTION
Extend env command wrapper with option for --chdir.

It is the caller's responsibility to ensure that the env command
supports chdir as older versions do not support it (Ubuntu 16.04).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
