### PR TITLE
multipass instance: use env's chdir for exec cwd (CRAFT-450)

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -33,6 +33,8 @@ class Executor(ABC):
     def execute_popen(
         self,
         command: List[str],
+        *,
+        cwd: Optional[pathlib.Path] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         **kwargs,
     ) -> subprocess.Popen:
@@ -53,6 +55,8 @@ class Executor(ABC):
     def execute_run(
         self,
         command: List[str],
+        *,
+        cwd: Optional[pathlib.Path] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         **kwargs,
     ) -> subprocess.CompletedProcess:

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -158,6 +158,8 @@ class LXDInstance(Executor):
     def execute_popen(
         self,
         command: List[str],
+        *,
+        cwd: Optional[pathlib.Path] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         **kwargs,
     ) -> subprocess.Popen:
@@ -173,18 +175,26 @@ class LXDInstance(Executor):
 
         :returns: Popen instance.
         """
+        if cwd is None:
+            cwd_path = None
+        else:
+            cwd_path = cwd.as_posix()
+
         return self.lxc.exec(
             instance_name=self.name,
             command=self._finalize_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
             runner=subprocess.Popen,
+            cwd=cwd_path,
             **kwargs,
         )
 
     def execute_run(
         self,
         command: List[str],
+        *,
+        cwd: Optional[pathlib.Path] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         **kwargs,
     ) -> subprocess.CompletedProcess:
@@ -203,12 +213,18 @@ class LXDInstance(Executor):
         :raises subprocess.CalledProcessError: if command fails and check is
             True.
         """
+        if cwd is None:
+            cwd_path = None
+        else:
+            cwd_path = cwd.as_posix()
+
         return self.lxc.exec(
             instance_name=self.name,
             command=self._finalize_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
             runner=subprocess.run,
+            cwd=cwd_path,
             **kwargs,
         )
 

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -17,6 +17,7 @@
 
 import io
 import pathlib
+import subprocess
 
 import pytest
 
@@ -88,6 +89,50 @@ def test_delete(instance):
     instance.delete()
 
     assert instance.exists() is False
+
+
+def test_execute_popen(reusable_instance):
+    with reusable_instance.execute_popen(
+        command=["pwd"],
+        stdout=subprocess.PIPE,
+        text=True,
+    ) as proc:
+        stdout, _ = proc.communicate()
+
+    assert stdout.strip() == "/root"
+
+
+def test_execute_popen_cwd(reusable_instance):
+    with reusable_instance.execute_popen(
+        command=["pwd"],
+        cwd=pathlib.Path("/"),
+        stdout=subprocess.PIPE,
+        text=True,
+    ) as proc:
+        stdout, _ = proc.communicate()
+
+    assert stdout.strip() == "/"
+
+
+def test_execute_run(reusable_instance):
+    proc = reusable_instance.execute_run(
+        command=["pwd"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.stdout.strip() == "/root"
+
+
+def test_execute_run_cwd(reusable_instance):
+    proc = reusable_instance.execute_run(
+        command=["pwd"],
+        cwd=pathlib.Path("/"),
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.stdout.strip() == "/"
 
 
 def test_exists(reusable_instance):

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -105,13 +105,13 @@ def test_execute_popen(reusable_instance):
 def test_execute_popen_cwd(reusable_instance):
     with reusable_instance.execute_popen(
         command=["pwd"],
-        cwd=pathlib.Path("/"),
+        cwd=pathlib.Path("/tmp"),
         stdout=subprocess.PIPE,
         text=True,
     ) as proc:
         stdout, _ = proc.communicate()
 
-    assert stdout.strip() == "/"
+    assert stdout.strip() == "/tmp"
 
 
 def test_execute_run(reusable_instance):

--- a/tests/integration/multipass/test_multipass_instance.py
+++ b/tests/integration/multipass/test_multipass_instance.py
@@ -17,6 +17,7 @@
 
 import io
 import pathlib
+import subprocess
 
 import pytest
 
@@ -76,6 +77,50 @@ def test_delete(instance):
     instance.delete()
 
     assert instance.exists() is False
+
+
+def test_execute_popen(reusable_instance):
+    with reusable_instance.execute_popen(
+        command=["pwd"],
+        stdout=subprocess.PIPE,
+        text=True,
+    ) as proc:
+        stdout, _ = proc.communicate()
+
+    assert stdout.strip() == "/home/ubuntu"
+
+
+def test_execute_popen_cwd(reusable_instance):
+    with reusable_instance.execute_popen(
+        command=["pwd"],
+        cwd=pathlib.Path("/"),
+        stdout=subprocess.PIPE,
+        text=True,
+    ) as proc:
+        stdout, _ = proc.communicate()
+
+    assert stdout.strip() == "/"
+
+
+def test_execute_run(reusable_instance):
+    proc = reusable_instance.execute_run(
+        command=["pwd"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.stdout.strip() == "/home/ubuntu"
+
+
+def test_execute_run_cwd(reusable_instance):
+    proc = reusable_instance.execute_run(
+        command=["pwd"],
+        cwd=pathlib.Path("/"),
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.stdout.strip() == "/"
 
 
 def test_exists(reusable_instance):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,13 +63,15 @@ class FakeExecutor(Executor):
     def execute_popen(
         self,
         command: List[str],
+        *,
+        cwd: Optional[pathlib.Path] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         **kwargs,
     ) -> subprocess.Popen:
         if env is None:
             env_args = []
         else:
-            env_args = env_cmd.formulate_command(env)
+            env_args = env_cmd.formulate_command(env, chdir=cwd)
 
         final_cmd = ["fake-executor"] + env_args + command
         return subprocess.Popen(  # pylint: disable=consider-using-with
@@ -79,13 +81,15 @@ class FakeExecutor(Executor):
     def execute_run(
         self,
         command: List[str],
+        *,
+        cwd: Optional[pathlib.Path] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         **kwargs,
     ) -> subprocess.CompletedProcess:
         if env is None:
             env_args = []
         else:
-            env_args = env_cmd.formulate_command(env)
+            env_args = env_cmd.formulate_command(env, chdir=cwd)
 
         final_cmd = ["fake-executor"] + env_args + command
         return subprocess.run(  # pylint: disable=subprocess-run-check

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -124,6 +124,7 @@ def test_push_file_io(
                 "root:root",
                 "/etc/test.conf",
             ],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -182,6 +183,25 @@ def test_execute_popen(mock_lxc, instance):
         mock.call.exec(
             instance_name="test-instance",
             command=["test-command", "flags"],
+            cwd=None,
+            project=instance.project,
+            remote=instance.remote,
+            runner=subprocess.Popen,
+            input="foo",
+        )
+    ]
+
+
+def test_execute_popen_with_cwd(mock_lxc, instance):
+    instance.execute_popen(
+        command=["test-command", "flags"], cwd=pathlib.Path("/tmp"), input="foo"
+    )
+
+    assert mock_lxc.mock_calls == [
+        mock.call.exec(
+            instance_name="test-instance",
+            command=["test-command", "flags"],
+            cwd="/tmp",
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.Popen,
@@ -197,6 +217,7 @@ def test_execute_popen_with_env(mock_lxc, instance):
         mock.call.exec(
             instance_name="test-instance",
             command=["env", "foo=bar", "test-command", "flags"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.Popen,
@@ -211,6 +232,25 @@ def test_execute_run(mock_lxc, instance):
         mock.call.exec(
             instance_name="test-instance",
             command=["test-command", "flags"],
+            cwd=None,
+            project=instance.project,
+            remote=instance.remote,
+            runner=subprocess.run,
+            input="foo",
+        )
+    ]
+
+
+def test_execute_run_with_cwd(mock_lxc, instance):
+    instance.execute_run(
+        command=["test-command", "flags"], cwd=pathlib.Path("/tmp"), input="foo"
+    )
+
+    assert mock_lxc.mock_calls == [
+        mock.call.exec(
+            instance_name="test-instance",
+            command=["test-command", "flags"],
+            cwd="/tmp",
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -232,6 +272,7 @@ def test_execute_run_with_default_command_env(mock_lxc):
         mock.call.exec(
             instance_name="test-instance",
             command=["env", "env_key=some-value", "foo=bar", "test-command", "flags"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -254,6 +295,7 @@ def test_execute_run_with_default_command_env_unset(mock_lxc):
         mock.call.exec(
             instance_name="test-instance",
             command=["env", "-u", "env_key", "foo=bar", "test-command", "flags"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -268,6 +310,7 @@ def test_execute_run_with_env(mock_lxc, instance):
         mock.call.exec(
             instance_name="test-instance",
             command=["env", "foo=bar", "test-command", "flags"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -291,6 +334,7 @@ def test_execute_run_with_env_unset(mock_lxc, instance):
                 "test-command",
                 "flags",
             ],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -557,6 +601,7 @@ def test_pull_file(mock_lxc, instance, tmp_path):
         mock.call.exec(
             instance_name=instance.name,
             command=["test", "-f", "/tmp/src.txt"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -588,6 +633,7 @@ def test_pull_file_no_source(mock_lxc, instance, tmp_path):
         mock.call.exec(
             instance_name=instance.name,
             command=["test", "-f", "/tmp/src.txt"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -613,6 +659,7 @@ def test_pull_file_no_parent_directory(mock_lxc, instance, tmp_path):
         mock.call.exec(
             instance_name=instance.name,
             command=["test", "-f", "/tmp/src.txt"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -638,6 +685,7 @@ def test_push_file(mock_lxc, instance, tmp_path):
         mock.call.exec(
             instance_name=instance.name,
             command=["test", "-d", "/tmp"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,
@@ -686,6 +734,7 @@ def test_push_file_no_parent_directory(mock_lxc, instance, tmp_path):
         mock.call.exec(
             instance_name=instance.name,
             command=["test", "-d", "/tmp"],
+            cwd=None,
             project=instance.project,
             remote=instance.remote,
             runner=subprocess.run,

--- a/tests/unit/multipass/test_multipass_instance.py
+++ b/tests/unit/multipass/test_multipass_instance.py
@@ -205,6 +205,29 @@ def test_execute_popen(mock_multipass, instance):
     ]
 
 
+def test_execute_popen_with_cwd(mock_multipass, instance):
+    instance.execute_popen(
+        command=["test-command", "flags"], cwd=pathlib.Path("/tmp"), input="foo"
+    )
+
+    assert mock_multipass.mock_calls == [
+        mock.call.exec(
+            instance_name="test-instance",
+            command=[
+                "sudo",
+                "-H",
+                "--",
+                "env",
+                "--chdir=/tmp",
+                "test-command",
+                "flags",
+            ],
+            runner=subprocess.Popen,
+            input="foo",
+        )
+    ]
+
+
 def test_execute_popen_with_env(mock_multipass, instance):
     instance.execute_popen(command=["test-command", "flags"], env=dict(foo="bar"))
 

--- a/tests/unit/multipass/test_multipass_instance.py
+++ b/tests/unit/multipass/test_multipass_instance.py
@@ -230,6 +230,26 @@ def test_execute_run(mock_multipass, instance):
     ]
 
 
+def test_execute_run_with_cwd(mock_multipass, instance, tmp_path):
+    instance.execute_run(command=["test-command", "flags"], cwd=tmp_path)
+
+    assert mock_multipass.mock_calls == [
+        mock.call.exec(
+            instance_name="test-instance",
+            command=[
+                "sudo",
+                "-H",
+                "--",
+                "env",
+                f"--chdir={tmp_path.as_posix()}",
+                "test-command",
+                "flags",
+            ],
+            runner=subprocess.run,
+        )
+    ]
+
+
 def test_execute_run_with_env(mock_multipass, instance):
     instance.execute_run(command=["test-command", "flags"], env=dict(foo="bar"))
 


### PR DESCRIPTION
To support the use of `cwd` keyword arg for execute functions,
use env_cmd's chdir functionality.  This does not support all
OSs (works on 18.04+), but since it will otherwise fail
unexpectedly, this is a reasonable measure for the interim.

Applications needing support for older OSes can use their own
custom launcher script or avoid `cwd` altogether.

A better long term solution is to ask Multipass for additional
interfaces like --cwd <dir> (and --user <user> even) to match
what is available in LXD.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
