### PR TITLE
multipass: introduce ensure_multipass_is_ready() (CRAFT-438)

### DIFF
--- a/craft_providers/multipass/__init__.py
+++ b/craft_providers/multipass/__init__.py
@@ -18,6 +18,7 @@
 """Multipass provider support package."""
 
 from ._launch import launch  # noqa: F401
+from ._ready import ensure_multipass_is_ready  # noqa: F401
 from .errors import MultipassError, MultipassInstallationError  # noqa: F401
 from .installer import install, is_installed  # noqa: F401
 from .multipass import Multipass  # noqa: F401

--- a/craft_providers/multipass/_ready.py
+++ b/craft_providers/multipass/_ready.py
@@ -1,0 +1,48 @@
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""Multipass Provider Readiness Checks."""
+
+import logging
+
+from . import errors
+from .installer import is_installed
+from .multipass import Multipass
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_multipass_is_ready(*, multipass: Multipass = Multipass()) -> None:
+    """Ensure Multipass is ready for use.
+
+    :raises MultipassError: on error.
+    """
+    if not is_installed():
+        raise errors.MultipassError(
+            brief="Multipass is required, but not installed.",
+            resolution="Visit https://multipass.run for instructions on "
+            "installing Multipass for your operating system.",
+        )
+
+    if not multipass.is_supported_version():
+        version = multipass.version()
+        min_version = multipass.minimum_required_version
+        raise errors.MultipassError(
+            brief=f"Multipass {version!r} does not meet the minimum required version {min_version!r}.",
+            resolution="Visit https://multipass.run for instructions on "
+            "installing Multipass for your operating system.",
+        )

--- a/tests/unit/multipass/test_ready.py
+++ b/tests/unit/multipass/test_ready.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+import re
+from unittest import mock
+
+import pytest
+
+from craft_providers.multipass import (
+    Multipass,
+    MultipassError,
+    ensure_multipass_is_ready,
+)
+
+
+@pytest.fixture
+def mock_is_installed():
+    with mock.patch(
+        "craft_providers.multipass._ready.is_installed", return_value=True
+    ) as mock_is_installed:
+        yield mock_is_installed
+
+
+@pytest.fixture
+def mock_multipass():
+    mock_client = mock.Mock(spec=Multipass)
+    mock_client.is_supported_version.return_value = True
+    mock_client.version.return_value = "actual-version.0"
+    mock_client.minimum_required_version = "min-required-version.0"
+    yield mock_client
+
+
+def test_ensure_multipass_is_ready(mock_is_installed, mock_multipass):
+    ensure_multipass_is_ready(multipass=mock_multipass)
+
+
+def test_ensure_multipass_is_ready_fails_incompatible_version(
+    mock_is_installed, mock_multipass
+):
+    mock_multipass.is_supported_version.return_value = False
+    match = re.escape(
+        "Multipass 'actual-version.0' does not meet the minimum required version "
+        "'min-required-version.0'.\nVisit https://multipass.run for instructions "
+        "on installing Multipass for your operating system."
+    )
+
+    with pytest.raises(MultipassError, match=match):
+        ensure_multipass_is_ready(multipass=mock_multipass)
+
+
+def test_ensure_multipass_is_ready_fails_not_installed(
+    mock_is_installed, mock_multipass
+):
+    mock_is_installed.return_value = False
+
+    match = re.escape(
+        "Multipass is required, but not installed.\n"
+        "Visit https://multipass.run for instructions "
+        "on installing Multipass for your operating system."
+    )
+
+    with pytest.raises(MultipassError, match=match):
+        ensure_multipass_is_ready(multipass=mock_multipass)


### PR DESCRIPTION
Add checks to ensure Multipass is ready for use similar to LXD's.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
