### PR TITLE
api: declare public api names (CRAFT-570)

### DIFF
--- a/craft_providers/__init__.py
+++ b/craft_providers/__init__.py
@@ -22,3 +22,9 @@ __version__ = "1.0.3"  # noqa: F401
 from .base import Base  # noqa: F401
 from .errors import ProviderError  # noqa: F401
 from .executor import Executor  # noqa: F401
+
+__all__ = [
+    "Base",
+    "Executor",
+    "ProviderError",
+]

--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -21,3 +21,10 @@ from .buildd import BuilddBase  # noqa: F401
 from .buildd import BuilddBaseAlias  # noqa: F401
 from .errors import BaseCompatibilityError  # noqa: F401
 from .errors import BaseConfigurationError  # noqa: F401
+
+__all__ = [
+    "BuilddBase",
+    "BuilddBaseAlias",
+    "BaseCompatibilityError",
+    "BaseConfigurationError",
+]

--- a/craft_providers/lxd/__init__.py
+++ b/craft_providers/lxd/__init__.py
@@ -30,3 +30,18 @@ from .lxc import LXC  # noqa: F401
 from .lxd import LXD  # noqa: F401
 from .lxd_instance import LXDInstance  # noqa: F401
 from .remotes import configure_buildd_image_remote  # noqa: F401
+
+__all__ = [
+    "LXC",
+    "LXD",
+    "LXDInstance",
+    "LXDError",
+    "LXDInstallationError",
+    "install",
+    "is_installed",
+    "is_initialized",
+    "is_user_permitted",
+    "ensure_lxd_is_ready",
+    "configure_buildd_image_remote",
+    "launch",
+]

--- a/craft_providers/multipass/__init__.py
+++ b/craft_providers/multipass/__init__.py
@@ -23,3 +23,14 @@ from .errors import MultipassError, MultipassInstallationError  # noqa: F401
 from .installer import install, is_installed  # noqa: F401
 from .multipass import Multipass  # noqa: F401
 from .multipass_instance import MultipassInstance  # noqa: F401
+
+__all__ = [
+    "Multipass",
+    "MultipassInstance",
+    "MultipassError",
+    "MultipassInstallationError",
+    "install",
+    "is_installed",
+    "ensure_multipass_is_ready",
+    "launch",
+]


### PR DESCRIPTION
Explicitly export public API names. This is enforced by pyright in
packages with the PEP-561 `py.typed` marker.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
