### PR TITLE
ci: add python 3.10 tests (CRAFT-745)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/tests/unit/util/test_env_cmd.py
+++ b/tests/unit/util/test_env_cmd.py
@@ -64,11 +64,8 @@ def test_formulate_command_chdir():
 
 
 def test_formulate_command_all_opts():
-    assert (
-        env_cmd.formulate_command(
-            env={"VAR_A": "1", "VAR_B": "2"},
-            ignore_environment=True,
-            chdir=pathlib.Path("/tmp/foo"),
-        )
-        == ["env", "--chdir=/tmp/foo", "-i", "VAR_A=1", "VAR_B=2"]
-    )
+    assert env_cmd.formulate_command(
+        env={"VAR_A": "1", "VAR_B": "2"},
+        ignore_environment=True,
+        chdir=pathlib.Path("/tmp/foo"),
+    ) == ["env", "--chdir=/tmp/foo", "-i", "VAR_A=1", "VAR_B=2"]


### PR DESCRIPTION
Add Python 3.10 to GHA tests workflow ~~and tox~~.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
