### PR TITLE
Fix description rendering on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     version="1.0.3",
     description="Craft provider tooling",
     long_description=readme,
+    long_description_content_type="text/markdown",
     author="Canonical Ltd.",
     author_email="snapcraft@lists.snapcraft.io",
     url="https://github.com/canonical/craft-providers",


### PR DESCRIPTION
Markdown was rendered as text as the content type was missing,
see https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
not necessary as I am an employee at Canonical

-----
