### PR TITLE
lxd: pass id for host mount uid mapping

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -506,7 +506,7 @@ max-bool-expr=5
 max-branches=12
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=16
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -18,6 +18,7 @@
 """LXD Instance Provider."""
 
 import logging
+from typing import Optional
 
 from craft_providers import Base, bases
 
@@ -126,6 +127,7 @@ def launch(
     auto_create_project: bool = False,
     ephemeral: bool = False,
     map_user_uid: bool = False,
+    uid: Optional[int] = None,
     use_snapshots: bool = False,
     project: str = "default",
     remote: str = "local",
@@ -143,7 +145,8 @@ def launch(
     :param auto_clean: Automatically clean instance, if incompatible.
     :param auto_create_project: Automatically create LXD project, if needed.
     :param ephemeral: Create ephemeral instance.
-    :param map_user_uid: Map current uid/gid to instance's root uid/gid.
+    :param map_user_uid: Map host uid/gid to instance's root uid/gid.
+    :param uid: The uid to be mapped, if ``map_user_id`` is enabled.
     :param use_snapshots: Use LXD snapshots for bootstrapping images.
     :param project: LXD project to create instance in.
     :param remote: LXD remote to create instance on.
@@ -204,6 +207,7 @@ def launch(
         image_remote=image_remote,
         ephemeral=ephemeral,
         map_user_uid=map_user_uid,
+        uid=uid,
     )
     base_configuration.setup(executor=instance)
 

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -313,12 +313,14 @@ class LXDInstance(Executor):
         image_remote: str,
         map_user_uid: bool = False,
         ephemeral: bool = False,
+        uid: Optional[int] = None,
     ) -> None:
         """Launch instance.
 
         :param image: Image name to launch.
         :param image_remote: Image remote name.
-        :param uid: Host user ID to map to instance root.
+        :param map_user_id: Whether id mapping should be used.
+        :param uid: If ``map_user_id`` is True, the host user ID to map to instance root.
         :param ephemeral: Flag to enable ephemeral instance.
 
         :raises LXDError: On unexpected error.
@@ -326,7 +328,8 @@ class LXDInstance(Executor):
         config_keys = {}
 
         if map_user_uid:
-            uid = os.getuid()
+            if not uid:
+                uid = os.getuid()
             config_keys["raw.idmap"] = f"both {uid!s} 0"
 
         if self._host_supports_mknod():

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -77,6 +77,7 @@ def test_launch(mock_base_configuration, mock_lxc, mock_lxd_instance):
             image_remote="image-remote",
             ephemeral=False,
             map_user_uid=False,
+            uid=None,
         ),
     ]
     assert mock_base_configuration.mock_calls == [
@@ -130,6 +131,7 @@ def test_launch_making_initial_snapshot(
             image_remote="image-remote",
             ephemeral=False,
             map_user_uid=False,
+            uid=None,
         ),
         mock.call().stop(),
         mock.call().start(),
@@ -179,6 +181,7 @@ def test_launch_using_existing_snapshot(
             image_remote="test-remote",
             ephemeral=False,
             map_user_uid=False,
+            uid=None,
         ),
     ]
     assert mock_base_configuration.mock_calls == [
@@ -199,6 +202,7 @@ def test_launch_all_opts(mock_base_configuration, mock_lxc, mock_lxd_instance):
         auto_create_project=True,
         ephemeral=True,
         map_user_uid=True,
+        uid=1234,
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
@@ -218,6 +222,7 @@ def test_launch_all_opts(mock_base_configuration, mock_lxc, mock_lxd_instance):
             image_remote="image-remote",
             ephemeral=True,
             map_user_uid=True,
+            uid=1234,
         ),
     ]
     assert mock_base_configuration.mock_calls == [
@@ -288,6 +293,7 @@ def test_launch_create_project(mock_base_configuration, mock_lxc, mock_lxd_insta
             image_remote="image-remote",
             ephemeral=False,
             map_user_uid=False,
+            uid=None,
         ),
     ]
     assert mock_base_configuration.mock_calls == [
@@ -395,6 +401,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
             image_remote="image-remote",
             ephemeral=False,
             map_user_uid=False,
+            uid=None,
         ),
     ]
     assert mock_base_configuration.mock_calls == [


### PR DESCRIPTION
Instead of always using the running user's uid for id mapping, allow
the value to be passed by the application so that the uid of the host
directory owner can be used in situations where the two values are
different. Default to the current user's uid to keep compatibility
with existing behavior.

CRAFT-893, fixes #97

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
