### PR TITLE
refactor: instance_config.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_providers
-	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name
+	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name,protected-access
 
 .PHONY: test-pyright
 test-pyright:

--- a/craft_providers/util/temp_paths.py
+++ b/craft_providers/util/temp_paths.py
@@ -31,3 +31,11 @@ def home_temporary_directory() -> Iterator[pathlib.Path]:
         dir=pathlib.Path.home(),
     ) as tmp_dir:
         yield pathlib.Path(tmp_dir)
+
+
+@contextlib.contextmanager
+def home_temporary_file() -> Iterator[pathlib.Path]:
+    """Create a temporary directory in the home directory where Multipass has access."""
+    with home_temporary_directory() as tmp_dir:
+        with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_file:
+            yield pathlib.Path(tmp_file.name)

--- a/tests/unit/bases/test_instance_config.py
+++ b/tests/unit/bases/test_instance_config.py
@@ -14,14 +14,16 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+
 import pathlib
-import subprocess
+import textwrap
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 
-from craft_providers import Executor, errors
-from craft_providers.bases.errors import BaseConfigurationError
+from craft_providers import Executor
+from craft_providers.bases.errors import BaseConfigurationError, ProviderError
 from craft_providers.bases.instance_config import InstanceConfiguration
 
 
@@ -29,6 +31,45 @@ from craft_providers.bases.instance_config import InstanceConfiguration
 def mock_executor():
     executor_mock = mock.Mock(spec=Executor)
     yield executor_mock
+
+
+@pytest.fixture()
+def config_fixture(mocker, tmpdir):
+    """Creates an instance config file containing data passed to the fixture."""
+
+    def _config_fixture(**kwargs):
+        temp_path = pathlib.Path(tmpdir)
+
+        config_file = temp_path / "craft-instance.conf"
+        config_file.write_text(**kwargs)
+
+        mocker.patch(
+            "craft_providers.bases.instance_config.temp_paths.home_temporary_file",
+            return_value=config_file,
+        )
+
+        return config_file
+
+    yield _config_fixture
+
+
+@pytest.fixture()
+def config_fixture_default(config_fixture):
+    """Creates an instance config file containing default data."""
+
+    def _config_fixture_default():
+        data = textwrap.dedent(
+            """\
+            compatibility_tag: tag-foo-v1
+            snaps:
+              charmcraft:
+                revision: 834
+            """
+        )
+        my_config_fixture = config_fixture(data=data)
+        return my_config_fixture
+
+    yield _config_fixture_default()
 
 
 def test_save(mock_executor):
@@ -49,71 +90,68 @@ def test_save(mock_executor):
     )
 
 
-def test_load_no_config_returns_none(mock_executor):
-    error = subprocess.CalledProcessError(
-        -1, ["test", "-f", "/etc/craft-crafty.conf"], "", ""
+def test_load_missing_config_returns_none(mock_executor):
+    mock_executor.pull_file.side_effect = [FileNotFoundError]
+    config_path = pathlib.Path("/test/foo")
+    config_instance = InstanceConfiguration.load(
+        executor=mock_executor, config_path=config_path
     )
-    mock_executor.execute_run.side_effect = [error]
 
+    assert config_instance is None
+
+
+def test_load_empty_config_returns_none(mock_executor, config_fixture):
+    config_fixture(data="")
     config_path = pathlib.Path("/etc/crafty-crafty.conf")
+    config_instance = InstanceConfiguration.load(
+        executor=mock_executor, config_path=config_path
+    )
 
-    config = InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
-
-    assert config is None
+    assert config_instance is None
 
 
-def test_load_with_valid_config(mock_executor):
-    mock_executor.execute_run.side_effect = [
-        None,
-        mock.Mock(stdout=b"compatibility_tag: foo\n"),
-    ]
+def test_load_with_valid_config(mock_executor, config_fixture_default):
+    config_file = config_fixture_default
     config_path = pathlib.Path("/etc/crafty-crafty.conf")
-
-    config = InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
+    config_instance = InstanceConfiguration.load(
+        executor=mock_executor, config_path=config_path
+    )
 
     assert mock_executor.mock_calls == [
-        mock.call.execute_run(
-            command=["test", "-f", "/etc/crafty-crafty.conf"],
-            capture_output=True,
-            check=True,
-        ),
-        mock.call.execute_run(
-            command=["cat", "/etc/crafty-crafty.conf"],
-            capture_output=True,
-            check=True,
-            text=True,
+        mock.call.pull_file(
+            source=config_path,
+            destination=config_file,
         ),
     ]
 
-    assert config == InstanceConfiguration(compatibility_tag="foo")
+    assert config_instance == {
+        "compatibility_tag": "tag-foo-v1",
+        "snaps": {"charmcraft": {"revision": 834}},
+    }
 
 
-def test_load_with_invalid_config_raises_error(mock_executor):
-    mock_executor.execute_run.side_effect = [
-        None,
-        mock.Mock(stdout=b"invalid: data"),
-    ]
+def test_load_with_invalid_config_raises_error(mock_executor, config_fixture):
+    config_fixture(data="invalid: data")
+
     config_path = pathlib.Path("/etc/crafty-crafty.conf")
 
-    with pytest.raises(BaseConfigurationError) as exc_info:
+    with pytest.raises(ValidationError) as exc_info:
         InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
 
-    assert exc_info.value == BaseConfigurationError(
-        brief="Invalid instance config data.",
-        details="Instance configuration data: {'invalid': 'data'}",
-    )
+    error = exc_info.value.errors()
+    assert len(error) == 1
+    assert error[0]["loc"] == ("invalid",)
+    assert error[0]["type"] == "value_error.extra"
 
 
 def test_load_failure_to_pull_file_raises_error(mock_executor):
-    error = subprocess.CalledProcessError(-1, ["cat", "/etc/craft-crafty.conf"], "", "")
-    mock_executor.execute_run.side_effect = [None, error]
+    mock_executor.pull_file.side_effect = [ProviderError(brief="foo")]
 
-    config_path = pathlib.Path("/etc/crafty-crafty.conf")
+    config_path = pathlib.Path("/test/foo")
 
     with pytest.raises(BaseConfigurationError) as exc_info:
         InstanceConfiguration.load(executor=mock_executor, config_path=config_path)
 
     assert exc_info.value == BaseConfigurationError(
-        brief="Failed to read instance config in environment at /etc/crafty-crafty.conf",
-        details=errors.details_from_called_process_error(error),
+        brief=f"Failed to read instance config in environment at {config_path}",
     )

--- a/tests/unit/util/test_temp_paths.py
+++ b/tests/unit/util/test_temp_paths.py
@@ -26,3 +26,11 @@ def test_home_temporary_directory():
         assert tmp_path.is_dir() is True
 
     assert tmp_path.exists() is False
+
+
+def test_home_temporary_file():
+    with temp_paths.home_temporary_file() as tmp_file:
+        assert tmp_file.relative_to(pathlib.Path.home())
+        assert tmp_file.is_file() is True
+
+    assert tmp_file.exists() is False


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
This is a pre-requisite for CRAFT-970 (caching snap revision installed in an environment).

`instance_config.py` tightly encapsulated the `compatibility_tag` parameter and was not readily usable for storing other data.

Improvements from refactoring:
1. Snap revisions can now be stored in the config file.
2. An existing config can now be updated, instead of just overwriting.
3. `test` and `cat` subprocess commands replaced with `executor.pull_file()`

(CRAFT-969)