### PR TITLE
actions: do not re-install same revision of snap on target

### DIFF
--- a/tests/integration/actions/test_snap_installer.py
+++ b/tests/integration/actions/test_snap_installer.py
@@ -51,7 +51,7 @@ def test_inject_from_host_using_pack_fallback(
 
     log_messages = [r.message for r in caplog.records]
     assert log_messages == [
-        "Failed to fetch snap from snapd, falling back to `snap pack` to recreate."
+        "Failed to fetch snap from snapd, falling back to `snap pack` to recreate"
     ]
 
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
### Overview
Cache snap revision in the target's `InstanceConfiguration`.
If the revision on the target matches the revision on the host, then the snap will not be re-injected or re-installed on the target.

### Testing

- Snap is injected: **5.6 seconds**
- Store installed from store: **12.8 seconds**
- Snap injection/installation is skipped: **0.5 seconds**

These are informal results performed on a somewhat fast laptop.
I would expect an average charm developer to see build times cut by 5-15 seconds.

### Note on assertations
I ended up removing the `snap known` and `snap ack` calls from this PR.  I was struggling to get the code to work consistently and the unit testing was proving to be even more challenging.  

In retrospect, a better approach may have been to completely port over the data structures in `snapcraft/internal/repo/snaps.py` and `snapcraft/internal/build_providers/_snap.py` rather than add functionality piece-by-piece to the existing data structures.

(CRAFT-970)