### PR TITLE
buildd: just warm up already existing instances

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -78,8 +78,8 @@ class Base(ABC):
         of the installed dependencies required for subsequent use by the
         application.
 
-        Setup may be called more than once in a given instance to refresh/update
-        the environment.
+        Setup should not be called more than once in a given instance to
+        refresh/update the environment, use `warmup` for that.
 
         If timeout is specified, abort operation if time has been exceeded.
 
@@ -88,7 +88,30 @@ class Base(ABC):
             required).
         :param timeout: Timeout in seconds.
 
-        :raises ProviderError: on timeout or unexpected error.
+        :raises BaseCompatibilityError: if instance is incompatible.
+        :raises BaseConfigurationError: on other unexpected error.
+        """
+
+    @abstractmethod
+    def warmup(
+        self,
+        *,
+        executor: Executor,
+        retry_wait: float = 0.25,
+        timeout: Optional[float] = None,
+    ) -> None:
+        """Prepare a previously created and setup instance for use by the application.
+
+        Ensure the instance is still valid and wait for environment to become ready.
+
+        If timeout is specified, abort operation if time has been exceeded.
+
+        :param executor: Executor for target container.
+        :param retry_wait: Duration to sleep() between status checks (if required).
+        :param timeout: Timeout in seconds.
+
+        :raises BaseCompatibilityError: if instance is incompatible.
+        :raises BaseConfigurationError: on other unexpected error.
         """
 
     @abstractmethod
@@ -114,5 +137,6 @@ class Base(ABC):
             required).
         :param timeout: Timeout in seconds.
 
-        :raises ProviderError: on timeout or unexpected error.
+        :raises BaseCompatibilityError: if instance is incompatible.
+        :raises BaseConfigurationError: on other unexpected error.
         """

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -173,7 +173,7 @@ def launch(
             instance.start()
 
         try:
-            base_configuration.setup(executor=instance)
+            base_configuration.warmup(executor=instance)
             return instance
         except bases.BaseCompatibilityError as error:
             if auto_clean:

--- a/craft_providers/multipass/_launch.py
+++ b/craft_providers/multipass/_launch.py
@@ -60,7 +60,7 @@ def launch(
         # TODO: Warn if existing instance doesn't match cpu/disk/mem specs.
         instance.start()
         try:
-            base_configuration.setup(executor=instance)
+            base_configuration.warmup(executor=instance)
             return instance
         except bases.BaseCompatibilityError as error:
             if auto_clean:

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -330,7 +330,7 @@ def test_launch_with_existing_instance_not_running(
     ]
     assert mock_base_configuration.mock_calls == [
         mock.call.get_command_environment(),
-        mock.call.setup(executor=mock_lxd_instance.return_value),
+        mock.call.warmup(executor=mock_lxd_instance.return_value),
     ]
 
 
@@ -361,7 +361,7 @@ def test_launch_with_existing_instance_running(
     ]
     assert mock_base_configuration.mock_calls == [
         mock.call.get_command_environment(),
-        mock.call.setup(executor=mock_lxd_instance.return_value),
+        mock.call.warmup(executor=mock_lxd_instance.return_value),
     ]
 
 
@@ -370,7 +370,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
 ):
     mock_lxd_instance.return_value.exists.return_value = True
     mock_lxd_instance.return_value.is_running.return_value = False
-    mock_base_configuration.setup.side_effect = [
+    mock_base_configuration.warmup.side_effect = [
         bases.BaseCompatibilityError(reason="foo"),
         None,
     ]
@@ -406,7 +406,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
     ]
     assert mock_base_configuration.mock_calls == [
         mock.call.get_command_environment(),
-        mock.call.setup(executor=mock_lxd_instance.return_value),
+        mock.call.warmup(executor=mock_lxd_instance.return_value),
         mock.call.setup(executor=mock_lxd_instance.return_value),
     ]
 
@@ -416,7 +416,7 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
 ):
     mock_lxd_instance.return_value.exists.return_value = True
     mock_lxd_instance.return_value.is_running.return_value = False
-    mock_base_configuration.setup.side_effect = [
+    mock_base_configuration.warmup.side_effect = [
         bases.BaseCompatibilityError(reason="foo")
     ]
 
@@ -444,5 +444,5 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
     ]
     assert mock_base_configuration.mock_calls == [
         mock.call.get_command_environment(),
-        mock.call.setup(executor=mock_lxd_instance.return_value),
+        mock.call.warmup(executor=mock_lxd_instance.return_value),
     ]

--- a/tests/unit/multipass/test_launch.py
+++ b/tests/unit/multipass/test_launch.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -67,7 +67,7 @@ def test_launch_with_existing_instance(
         mock.call.start(),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_multipass_instance)
+        mock.call.warmup(executor=mock_multipass_instance)
     ]
 
 
@@ -75,7 +75,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
     mock_base_configuration, mock_multipass_instance
 ):
     mock_multipass_instance.exists.return_value = True
-    mock_base_configuration.setup.side_effect = [
+    mock_base_configuration.warmup.side_effect = [
         bases.BaseCompatibilityError(reason="foo"),
         None,
     ]
@@ -97,7 +97,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
         mock.call.launch(cpus=2, disk_gb=64, mem_gb=2, image="30.04"),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_multipass_instance),
+        mock.call.warmup(executor=mock_multipass_instance),
         mock.call.setup(executor=mock_multipass_instance),
     ]
 
@@ -106,7 +106,7 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
     mock_base_configuration, mock_multipass_instance
 ):
     mock_multipass_instance.exists.return_value = True
-    mock_base_configuration.setup.side_effect = [
+    mock_base_configuration.warmup.side_effect = [
         bases.BaseCompatibilityError(reason="foo")
     ]
 
@@ -123,5 +123,5 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
         mock.call.start(),
     ]
     assert mock_base_configuration.mock_calls == [
-        mock.call.setup(executor=mock_multipass_instance)
+        mock.call.warmup(executor=mock_multipass_instance)
     ]


### PR DESCRIPTION
The full setup takes too long and is not needed, so I created a new warmup
method for when the instance already exists (and was fully setup in the
past).
