### PR TITLE
static: bump pylint to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,7 @@ test_requires = [
     "isort",
     "mypy",
     "pydocstyle",
-    # Incompatible with current pylint-fixme-info==1.0.2
-    # https://github.com/PyCQA/pylint/issues/5390
-    "pylint<2.12.0",
+    "pylint",
     "pylint-fixme-info",
     "pylint-pytest",
     "pytest",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Bump pylint to latest version, since `pylint-fixme-info` v1.0.3 was released.

The same change was applied to [craft-parts](https://github.com/canonical/craft-parts/commit/b2544d8fff7f0d8128174c717d5978f4fc6ad410#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7).