### PR TITLE
snap installer: refactor installation logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_providers
-	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name,protected-access
+	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name,protected-access,too-many-arguments
 
 .PHONY: test-pyright
 test-pyright:

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -344,7 +344,7 @@ class BuilddBase(Base):
         )
 
     def _setup_apt(self, *, executor: Executor, deadline: Optional[float]) -> None:
-        """Configure apt & update cache.
+        """Configure apt, update cache and install needed packages.
 
         :param executor: Executor for target container.
         :param deadline: Optional time.time() deadline.
@@ -379,13 +379,13 @@ class BuilddBase(Base):
         try:
             _check_deadline(deadline)
             executor.execute_run(
-                ["apt-get", "install", "-y", "apt-utils"],
+                ["apt-get", "install", "-y", "apt-utils", "curl"],
                 capture_output=True,
                 check=True,
             )
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
-                brief="Failed to install apt-utils.",
+                brief="Failed to install packages.",
                 details=errors.details_from_called_process_error(error),
             ) from error
 

--- a/craft_providers/util/snap_cmd.py
+++ b/craft_providers/util/snap_cmd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,7 +21,7 @@ import pathlib
 from typing import List
 
 
-def formulate_install_command(
+def formulate_local_install_command(
     classic: bool, dangerous: bool, snap_path: pathlib.Path
 ) -> List[str]:
     """Formulate snap install command.
@@ -39,4 +39,47 @@ def formulate_install_command(
     if dangerous:
         install_cmd.append("--dangerous")
 
+    return install_cmd
+
+
+def formulate_remote_install_command(
+    snap_name: str, channel: str, classic: bool
+) -> List[str]:
+    """Formulate the command to snap install from Store.
+
+    :param snap_name: The name of the channel.
+    :param channel: The channel to install the snap from.
+    :param classic: Flag to enable installation of classic snap.
+    :param dangerous: Flag to enable installation of snap without ack.
+
+    :returns: List of command parts.
+    """
+    install_cmd = ["snap", "install", snap_name, "--channel", channel]
+
+    if classic:
+        install_cmd.append("--classic")
+
+    return install_cmd
+
+
+def formulate_refresh_command(snap_name: str, channel: str) -> List[str]:
+    """Formulate snap refresh command.
+
+    :param snap_name: The name of the channel.
+    :param channel: The channel to install the snap from.
+
+    :returns: List of command parts.
+    """
+    install_cmd = ["snap", "refresh", snap_name, "--channel", channel]
+    return install_cmd
+
+
+def formulate_remove_command(snap_name: str) -> List[str]:
+    """Formulate snap remove command.
+
+    :param snap_name: The name of the channel.
+
+    :returns: List of command parts.
+    """
+    install_cmd = ["snap", "remove", snap_name]
     return install_cmd

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -49,6 +49,7 @@ test_requires = [
     "flake8",
     "isort",
     "mypy",
+    "logassert",
     "pydocstyle",
     "pylint",
     "pylint-fixme-info",
@@ -56,6 +57,7 @@ test_requires = [
     "pytest",
     "pytest-mock",
     "pytest-subprocess",
+    "responses",
     "types-requests",
     "types-setuptools",
     "types-pyyaml",

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -134,7 +134,7 @@ def test_setup(  # pylint: disable=too-many-arguments
     )
     fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "apt-get", "update"])
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "apt-utils"]
+        [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "apt-utils", "curl"]
     )
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "fuse", "udev"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,7 @@ import subprocess
 from typing import Any, Dict, List, Optional
 
 import pytest
+import responses as responses_module
 
 from craft_providers import Executor
 from craft_providers.util import env_cmd
@@ -116,3 +117,10 @@ class FakeExecutor(Executor):
 @pytest.fixture
 def fake_executor():
     yield FakeExecutor()
+
+
+@pytest.fixture
+def responses():
+    """Simple helper to use responses module as a fixture, for easier integration in tests."""
+    with responses_module.RequestsMock() as rsps:
+        yield rsps

--- a/tests/unit/util/test_snap_cmd.py
+++ b/tests/unit/util/test_snap_cmd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -19,25 +19,49 @@
 from craft_providers.util import snap_cmd
 
 
-def test_install_strict(tmp_path):
-    assert snap_cmd.formulate_install_command(
+def test_local_install_strict(tmp_path):
+    assert snap_cmd.formulate_local_install_command(
         classic=False, dangerous=False, snap_path=tmp_path
     ) == ["snap", "install", tmp_path.as_posix()]
 
 
-def test_install_classic(tmp_path):
-    assert snap_cmd.formulate_install_command(
+def test_local_install_classic(tmp_path):
+    assert snap_cmd.formulate_local_install_command(
         classic=True, dangerous=False, snap_path=tmp_path
     ) == ["snap", "install", tmp_path.as_posix(), "--classic"]
 
 
-def test_install_dangerous(tmp_path):
-    assert snap_cmd.formulate_install_command(
+def test_local_install_dangerous(tmp_path):
+    assert snap_cmd.formulate_local_install_command(
         classic=False, dangerous=True, snap_path=tmp_path
     ) == ["snap", "install", tmp_path.as_posix(), "--dangerous"]
 
 
-def test_install_all_opts(tmp_path):
-    assert snap_cmd.formulate_install_command(
+def test_local_install_all_opts(tmp_path):
+    assert snap_cmd.formulate_local_install_command(
         classic=True, dangerous=True, snap_path=tmp_path
     ) == ["snap", "install", tmp_path.as_posix(), "--classic", "--dangerous"]
+
+
+def test_remote_install_strict():
+    snap_name, channel = "testsnap", "edge"
+    cmd = snap_cmd.formulate_remote_install_command(snap_name, channel, classic=False)
+    assert cmd == ["snap", "install", snap_name, "--channel", channel]
+
+
+def test_remote_install_classic():
+    snap_name, channel = "testsnap", "edge"
+    cmd = snap_cmd.formulate_remote_install_command(snap_name, channel, classic=True)
+    assert cmd == ["snap", "install", snap_name, "--channel", channel, "--classic"]
+
+
+def test_refresh():
+    snap_name, channel = "testsnap", "edge"
+    cmd = snap_cmd.formulate_refresh_command(snap_name, channel)
+    assert cmd == ["snap", "refresh", snap_name, "--channel", channel]
+
+
+def test_remove():
+    snap_name = "testsnap"
+    cmd = snap_cmd.formulate_remove_command(snap_name)
+    assert cmd == ["snap", "remove", snap_name]


### PR DESCRIPTION
In detail:

- now `inject_from_store` actually *installs* or *refreshes* the snap directly from the store (no more download and local install); as a side effect, no longer is required to have `snapd` in the host for this operation.

- the situation of changing "from host" to/from "from store" is supported, un-installing the previous snap in that case

- improved (and tested) logs in `inject_from_host` and `inject_from_store`

- added `curl` to what is installed during instance setup (as it's needed to communicate to `snapd` in the target environment)

- some tests improved and made more explicit; lot of tests added to unit-test the helper functions
---
CRAFT-1068