### PR TITLE
tests: remove snapcraft:core

### DIFF
--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -18,7 +18,6 @@
 import io
 import pathlib
 import subprocess
-import sys
 
 import pytest
 
@@ -44,14 +43,6 @@ def core20_instance(instance_name):
 @pytest.mark.parametrize(
     "alias,image_name",
     [
-        # TODO: add test when Multipass supports core on Windows
-        pytest.param(
-            bases.BuilddBaseAlias.XENIAL,
-            "snapcraft:core",
-            marks=pytest.mark.skipif(
-                sys.platform == "win32", reason="unsupported on windows"
-            ),
-        ),
         (bases.BuilddBaseAlias.BIONIC, "snapcraft:core18"),
         (bases.BuilddBaseAlias.FOCAL, "snapcraft:core20"),
         # FIXME: enable after image is available


### PR DESCRIPTION
core has been removed by multipass, craft-providers does not need to
support core so remove the test for it.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
