### PR TITLE
lxc: add subprocess parameter for stdin

### DIFF
--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -16,6 +16,7 @@
 #
 import pathlib
 import subprocess
+from unittest.mock import call
 
 import pytest
 
@@ -23,6 +24,105 @@ from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, lxc
 
 # pylint: disable=too-many-lines
+
+
+def test_lxc_run_default(mocker, tmp_path):
+    """Test _lxc_run with default arguments."""
+    mock_run = mocker.patch("subprocess.run")
+
+    LXC()._run_lxc(
+        command=["test-command"],
+        check=True,
+    )
+
+    assert mock_run.mock_calls[:1] == [
+        call(
+            ["lxc", "test-command"],
+            check=True,
+            stdin=subprocess.DEVNULL,
+        ),
+    ]
+
+
+def test_lxc_run_with_project(mocker, tmp_path):
+    """Test _lxc_run with project."""
+    mock_run = mocker.patch("subprocess.run")
+
+    LXC()._run_lxc(
+        command=["test-command"],
+        check=True,
+        project="test-project",
+    )
+
+    assert mock_run.mock_calls[:1] == [
+        call(
+            ["lxc", "--project", "test-project", "test-command"],
+            check=True,
+            stdin=subprocess.DEVNULL,
+        ),
+    ]
+
+
+def test_lxc_run_with_stdin(mocker, tmp_path):
+    """Test _lxc_run with stdin argument."""
+    mock_run = mocker.patch("subprocess.run")
+
+    LXC()._run_lxc(
+        command=["test-command"],
+        check=True,
+        project="test-project",
+        stdin=lxc.StdinType.NULL,
+    )
+
+    assert mock_run.mock_calls[:1] == [
+        call(
+            ["lxc", "--project", "test-project", "test-command"],
+            check=True,
+            stdin=None,
+        ),
+    ]
+
+
+def test_lxc_run_with_input(mocker, tmp_path):
+    """Test _lxc_run with input argument."""
+    mock_run = mocker.patch("subprocess.run")
+
+    LXC()._run_lxc(
+        command=["test-command"],
+        check=True,
+        project="test-project",
+        stdin=lxc.StdinType.NULL,
+        input="test-input",
+    )
+
+    assert mock_run.mock_calls[:1] == [
+        call(
+            ["lxc", "--project", "test-project", "test-command"],
+            check=True,
+            input="test-input",
+        ),
+    ]
+
+
+def test_lxc_run_with_input_and_stdin(mocker, tmp_path):
+    """`stdin` argument is ignored when `input` is passed."""
+    mock_run = mocker.patch("subprocess.run")
+
+    LXC()._run_lxc(
+        command=["test-command"],
+        check=True,
+        project="test-project",
+        stdin=lxc.StdinType.NULL,
+        input="test-input",
+    )
+
+    assert mock_run.mock_calls[:1] == [
+        call(
+            ["lxc", "--project", "test-project", "test-command"],
+            check=True,
+            input="test-input",
+        ),
+    ]
 
 
 def test_config_device_add_disk(fake_process, tmp_path):


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add `stdin` parameter to lxc's `subprocess` call.  Snapcraft 7 + core22 was hanging on github workflow using action-build.

Todo: Add unit tests for `_run_lxc`

Source: https://github.com/snapcore/action-build/issues/37
(CRAFT-1102)