### PR TITLE
buildd: Pass on snapd no-CDN configuration if set

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -580,6 +580,22 @@ class BuilddBase(Base):
                 check=True,
             )
 
+            # This file is created by launchpad-buildd to stop snapd from
+            # using the snap store's CDN when running in Canonical's
+            # production build farm, since internet access restrictions may
+            # prevent it from doing so but will allow the non-CDN storage
+            # endpoint.  If this is in place, then we need to propagate it
+            # to containers we create.
+            no_cdn = pathlib.Path("/etc/systemd/system/snapd.service.d/no-cdn.conf")
+            if no_cdn.exists():
+                _check_deadline(deadline)
+                executor.execute_run(
+                    ["mkdir", "-p", no_cdn.parent.as_posix()], check=True
+                )
+
+                _check_deadline(deadline)
+                executor.push_file(source=no_cdn, destination=no_cdn)
+
             _check_deadline(deadline)
             executor.execute_run(
                 ["apt-get", "install", "-y", "snapd"],

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ test_requires = [
     "mypy",
     "logassert",
     "pydocstyle",
+    "pyfakefs",
     "pylint",
     "pylint-fixme-info",
     "pylint-pytest",


### PR DESCRIPTION
launchpad-buildd sets up some specialized configuration to stop snapd
from using the snap store's CDN when running in Canonical's production
build farm, since there are restrictions in place there on general
internet access but the non-CDN storage endpoint is always allowed.  If
this is in place, then we need to propagate it to containers we create.

I encountered this in an lpcraft build, but I think any of the *craft
tools could in principle hit the same problem when running in Launchpad.
launchpad-buildd normally passes HTTP proxy configuration allowing `snap
install` to work, but that doesn't necessarily apply to downloads
initiated by snapd itself, such as base snap downloads.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
