### PR TITLE
lxd: use LXD-compatible instance names

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -77,7 +77,7 @@ def _publish_snapshot(
 
     lxc.publish(
         alias=snapshot_name,
-        instance_name=instance.name,
+        instance_name=instance.instance_name,
         force=True,
         project=instance.project,
         remote=instance.remote,

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,10 +17,12 @@
 
 """LXD Instance Executor."""
 
+import hashlib
 import io
 import logging
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import tempfile
@@ -48,6 +50,17 @@ class LXDInstance(Executor):
         remote: str = "local",
         lxc: Optional[LXC] = None,
     ):
+        """Create an LXD executor.
+
+        To comply with LXD naming conventions, the supplied name is converted to a
+        LXD-compatible name before creating the instance.
+
+        :param name: Unique name of the lxd instance
+        :param default_command_environment: command environment
+        :param project: name of lxd project
+        :param remote: name of lxd remote
+        :param lxc: LXC instance object
+        """
         super().__init__()
 
         if default_command_environment is not None:
@@ -56,6 +69,7 @@ class LXDInstance(Executor):
             self.default_command_environment = {}
 
         self.name = name
+        self._set_instance_name()
         self.project = project
         self.remote = remote
 
@@ -63,6 +77,55 @@ class LXDInstance(Executor):
             self.lxc = LXC()
         else:
             self.lxc = lxc
+
+    def _set_instance_name(self) -> None:
+        """Convert a name to a LXD-compatible name.
+
+        LXD naming convention:
+        - be between 1 and 63 characters long
+        - be made up exclusively of letters, numbers and dashes from the ASCII table
+        - not start with a digit or a dash
+        - not end with a dash
+
+        To create a LXD-compatible name, forbidden characters are removed, the name is
+        truncated to 40 characters, then a hash is appended:
+        <truncated-name>-<hash-of-name>
+        └     1 - 40   ┘1└     20     ┘
+
+        :param name: name of instance
+        :raises LXDError: if name contains no alphanumeric characters
+        """
+        # remove anything that is not an alphanumeric characters or dash
+        name_with_valid_chars = re.sub(r"[^\w-]", "", self.name)
+        if name_with_valid_chars == "":
+            raise LXDError(
+                brief=(f"failed to create LXD instance with name {self.name!r}."),
+                details="name must contain at least one alphanumeric character",
+            )
+
+        # trim digits and dashes from the beginning and dashes from the end
+        trimmed_name = re.compile(r"^[0-9-]*(?P<valid_part_of_name>.*?)[-]*$").search(
+            name_with_valid_chars
+        )
+        if not trimmed_name or trimmed_name.group("valid_part_of_name") == "":
+            raise LXDError(
+                brief=(f"failed to create LXD instance with name {self.name!r}."),
+                details="name must contain at least one alphanumeric character",
+            )
+
+        # truncate to 40 characters
+        truncated_name = trimmed_name.group("valid_part_of_name")[:40]
+
+        # if the name is unchanged, then use the original name
+        if self.name == truncated_name:
+            self.instance_name = self.name
+        else:
+            # hash the entire name, not the truncated name
+            hasher = hashlib.sha1()
+            hasher.update(self.name.encode())
+            hashed_name = hasher.hexdigest()[:20]
+
+            self.instance_name = f"{truncated_name}-{hashed_name}"
 
     def _finalize_lxc_command(
         self,
@@ -117,7 +180,7 @@ class LXDInstance(Executor):
 
         temp_path = pathlib.Path(temp_file.name)
         self.lxc.file_push(
-            instance_name=self.name,
+            instance_name=self.instance_name,
             source=temp_path,
             destination=destination,
             mode=file_mode,
@@ -137,7 +200,7 @@ class LXDInstance(Executor):
             raise LXDError(
                 brief=(
                     f"Failed to create file {destination.as_posix()!r}"
-                    f" in instance {self.name!r}."
+                    f" in instance {self.instance_name!r}."
                 ),
                 details=errors.details_from_called_process_error(error),
             ) from error
@@ -152,7 +215,7 @@ class LXDInstance(Executor):
         :raises LXDError: On unexpected error.
         """
         return self.lxc.delete(
-            instance_name=self.name,
+            instance_name=self.instance_name,
             project=self.project,
             remote=self.remote,
             force=force,
@@ -184,7 +247,7 @@ class LXDInstance(Executor):
             cwd_path = cwd.as_posix()
 
         return self.lxc.exec(
-            instance_name=self.name,
+            instance_name=self.instance_name,
             command=self._finalize_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
@@ -222,7 +285,7 @@ class LXDInstance(Executor):
             cwd_path = cwd.as_posix()
 
         return self.lxc.exec(
-            instance_name=self.name,
+            instance_name=self.instance_name,
             command=self._finalize_lxc_command(command=command, env=env),
             project=self.project,
             remote=self.remote,
@@ -243,7 +306,7 @@ class LXDInstance(Executor):
     def _get_disk_devices(self) -> Dict[str, Any]:
         """Query instance and return dictionary of disk devices."""
         devices = self.lxc.config_device_show(
-            instance_name=self.name, project=self.project, remote=self.remote
+            instance_name=self.instance_name, project=self.project, remote=self.remote
         )
 
         disks = {}
@@ -271,7 +334,7 @@ class LXDInstance(Executor):
         instances = self.lxc.list(project=self.project, remote=self.remote)
 
         for instance in instances:
-            if instance["name"] == self.name:
+            if instance["name"] == self.instance_name:
                 return instance
 
         return None
@@ -305,7 +368,7 @@ class LXDInstance(Executor):
         """
         state = self._get_state()
         if state is None:
-            raise LXDError(brief=f"Instance {self.name!r} does not exist.")
+            raise LXDError(brief=f"Instance {self.instance_name!r} does not exist.")
 
         return state.get("status") == "Running"
 
@@ -342,7 +405,7 @@ class LXDInstance(Executor):
         self.lxc.launch(
             config_keys=config_keys,
             ephemeral=ephemeral,
-            instance_name=self.name,
+            instance_name=self.instance_name,
             image=image,
             image_remote=image_remote,
             project=self.project,
@@ -374,7 +437,7 @@ class LXDInstance(Executor):
             device_name = "disk-" + target.as_posix()
 
         self.lxc.config_device_add_disk(
-            instance_name=self.name,
+            instance_name=self.instance_name,
             source=host_source,
             path=target,
             device=device_name,
@@ -417,7 +480,7 @@ class LXDInstance(Executor):
             raise FileNotFoundError(f"Directory not found: {str(destination.parent)!r}")
 
         self.lxc.file_pull(
-            instance_name=self.name,
+            instance_name=self.instance_name,
             source=source,
             destination=destination,
             project=self.project,
@@ -449,7 +512,7 @@ class LXDInstance(Executor):
         # Copy into target with uid/gid 0, rather than copying the IDs from the
         # host file.
         self.lxc.file_push(
-            instance_name=self.name,
+            instance_name=self.instance_name,
             source=source,
             destination=destination,
             project=self.project,
@@ -464,7 +527,7 @@ class LXDInstance(Executor):
         :raises LXDError: on unexpected error.
         """
         self.lxc.start(
-            instance_name=self.name, project=self.project, remote=self.remote
+            instance_name=self.instance_name, project=self.project, remote=self.remote
         )
 
     def stop(self) -> None:
@@ -472,7 +535,9 @@ class LXDInstance(Executor):
 
         :raises LXDError: on unexpected error.
         """
-        self.lxc.stop(instance_name=self.name, project=self.project, remote=self.remote)
+        self.lxc.stop(
+            instance_name=self.instance_name, project=self.project, remote=self.remote
+        )
 
     def supports_mount(self) -> bool:
         """Check if instance supports mounting from host.
@@ -494,7 +559,7 @@ class LXDInstance(Executor):
         for name, config in disks.items():
             if config["path"] == target.as_posix():
                 self.lxc.config_device_remove(
-                    instance_name=self.name,
+                    instance_name=self.instance_name,
                     device=name,
                     project=self.project,
                     remote=self.remote,
@@ -505,7 +570,7 @@ class LXDInstance(Executor):
             raise LXDError(
                 brief=(
                     f"Failed to unmount {target.as_posix()!r}"
-                    f" in instance {self.name!r} - no such disk."
+                    f" in instance {self.instance_name!r} - no such disk."
                 ),
                 details=f"* Disk device configuration: {disks!r}",
             )
@@ -519,7 +584,7 @@ class LXDInstance(Executor):
 
         for name, _ in disks.items():
             self.lxc.config_device_remove(
-                instance_name=self.name,
+                instance_name=self.instance_name,
                 device=name,
                 project=self.project,
                 remote=self.remote,

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -82,12 +82,12 @@ class LXDInstance(Executor):
         """Convert a name to a LXD-compatible name.
 
         LXD naming convention:
-        - be between 1 and 63 characters long
-        - be made up exclusively of letters, numbers and dashes from the ASCII table
-        - not start with a digit or a dash
-        - not end with a dash
+        - between 1 and 63 characters long
+        - made up exclusively of letters, numbers, and hyphens from the ASCII table
+        - not begin with a digit or a hyphen
+        - not end with a hyphen
 
-        To create a LXD-compatible name, forbidden characters are removed, the name is
+        To create a LXD-compatible name, invalid characters are removed, the name is
         truncated to 40 characters, then a hash is appended:
         <truncated-name>-<hash-of-name>
         └     1 - 40   ┘1└     20     ┘
@@ -95,24 +95,24 @@ class LXDInstance(Executor):
         :param name: name of instance
         :raises LXDError: if name contains no alphanumeric characters
         """
-        # remove anything that is not an alphanumeric characters or dash
+        # remove anything that is not an alphanumeric characters or hyphen
         name_with_valid_chars = re.sub(r"[^\w-]", "", self.name)
         if name_with_valid_chars == "":
             raise LXDError(
-                brief=(f"failed to create LXD instance with name {self.name!r}."),
+                brief=f"failed to create LXD instance with name {self.name!r}.",
                 details="name must contain at least one alphanumeric character",
             )
 
-        # trim digits and dashes from the beginning and dashes from the end
-        trimmed_name = re.compile(r"^[0-9-]*(?P<valid_part_of_name>.*?)[-]*$").search(
+        # trim digits and hyphens from the beginning and hyphens from the end
+        trimmed_name = re.compile(r"^[0-9-]*(?P<valid_name>.*?)[-]*$").search(
             name_with_valid_chars
         )
-        if not trimmed_name or trimmed_name.group("valid_part_of_name") == "":
+        if not trimmed_name or trimmed_name.group("valid_name") == "":
             raise LXDError(
-                brief=(f"failed to create LXD instance with name {self.name!r}."),
+                brief=f"failed to create LXD instance with name {self.name!r}.",
                 details="name must contain at least one alphanumeric character",
             )
-        valid_name = trimmed_name.group("valid_part_of_name")
+        valid_name = trimmed_name.group("valid_name")
 
         # if the original name meets LXD's naming convention, then use the original name
         if self.name == valid_name and len(self.name) <= 63:

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -112,24 +112,22 @@ class LXDInstance(Executor):
                 brief=(f"failed to create LXD instance with name {self.name!r}."),
                 details="name must contain at least one alphanumeric character",
             )
+        valid_name = trimmed_name.group("valid_part_of_name")
 
         # if the original name meets LXD's naming convention, then use the original name
-        if (
-            self.name == trimmed_name.group("valid_part_of_name")
-            and len(self.name) <= 63
-        ):
+        if self.name == valid_name and len(self.name) <= 63:
             instance_name = self.name
 
         # else, continue converting the name
         else:
             # truncate to 40 characters
-            truncated_name = trimmed_name.group("valid_part_of_name")[:40]
+            truncated_name = valid_name[:40]
             # hash the entire name, not the truncated name
             hashed_name = hashlib.sha1(self.name.encode()).hexdigest()[:20]
             instance_name = f"{truncated_name}-{hashed_name}"
 
         self.instance_name = instance_name
-        logger.debug("Set LXD instance name to %s")
+        logger.debug("Set LXD instance name to %r", instance_name)
 
     def _finalize_lxc_command(
         self,

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -28,6 +28,7 @@ import pytest
 
 from craft_providers.lxd import LXC
 from craft_providers.lxd import project as lxc_project
+from craft_providers.lxd.lxd_instance import LXDInstance
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -55,7 +56,7 @@ def installed_lxd_without_init(uninstalled_lxd):
 @contextmanager
 def tmp_instance(
     *,
-    instance_name: str,
+    name: str,
     config_keys: Optional[Dict[str, Any]] = None,
     ephemeral: bool = True,
     image: str = "16.04",
@@ -66,6 +67,14 @@ def tmp_instance(
 ):
     if config_keys is None:
         config_keys = {}
+
+    instance = LXDInstance(
+        name=name,
+        project=project,
+        remote=remote,
+        lxc=lxc,
+    )
+    instance_name = instance.instance_name
 
     lxc.launch(
         instance_name=instance_name,

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -31,12 +31,12 @@ from . import conftest
 @pytest.fixture()
 def core20_instance(instance_name):
     with conftest.tmp_instance(
-        instance_name=instance_name,
+        name=instance_name,
         image="20.04",
         image_remote="ubuntu",
         project="default",
-    ) as tmp_instance:
-        instance = lxd.LXDInstance(name=tmp_instance)
+    ):
+        instance = lxd.LXDInstance(name=instance_name)
 
         yield instance
 

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -28,7 +28,7 @@ from . import conftest
 @pytest.fixture()
 def instance(instance_name, project):
     with conftest.tmp_instance(
-        instance_name=instance_name,
+        name=instance_name,
         project=project,
     ) as tmp_instance:
         yield tmp_instance

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -161,6 +161,34 @@ def test_launch(instance_name):
         instance.delete()
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "test-name",
+        "more-than-63-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "more-than-63-characters-and-invalid-characters-$$$xxxxxxxxxxxxxxxxxxxx",
+        "invalid-characters-$$$",
+    ],
+)
+def test_launch_with_name(instance_name, name):
+    """Verify we can launch an instance even when we pass in an invalid name."""
+    # prepend the tester's random instance name
+    name = f"{instance_name}-{name}"
+    instance = LXDInstance(name=name)
+
+    assert instance.exists() is False
+
+    instance.launch(
+        image="20.04",
+        image_remote="ubuntu",
+    )
+
+    try:
+        assert instance.exists() is True
+    finally:
+        instance.delete()
+
+
 def test_mount_unmount(reusable_instance, tmp_path):
     tmp_path.chmod(0o755)
 

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -29,7 +29,7 @@ from . import conftest
 @pytest.fixture()
 def instance(instance_name, project):
     with conftest.tmp_instance(
-        instance_name=instance_name,
+        name=instance_name,
         project=project,
     ):
         instance = LXDInstance(name=instance_name, project=project)
@@ -41,7 +41,7 @@ def instance(instance_name, project):
 def reusable_instance(reusable_instance_name):
     """Reusable instance for tests that don't require a fresh instance."""
     with conftest.tmp_instance(
-        instance_name=reusable_instance_name,
+        name=reusable_instance_name,
         ephemeral=False,
         project="default",
     ):

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -46,7 +46,9 @@ def mock_lxd_instance():
         "craft_providers.lxd.launcher.LXDInstance",
         spec=lxd.LXDInstance,
     ) as mock_instance:
-        mock_instance.return_value.name = "test-instance"
+        mock_instance.return_value.name = "test-instance-$"
+        # the name has an invalid character, so the instance_name will be different
+        mock_instance.return_value.instance_name = "test-instance-fa2d407652a1c51f6019"
         mock_instance.return_value.project = "test-project"
         mock_instance.return_value.remote = "test-remote"
         yield mock_instance
@@ -112,7 +114,7 @@ def test_launch_making_initial_snapshot(
         ),
         mock.call.publish(
             alias="snapshot-image-remote-image-name-mock-compat-tag-v100",
-            instance_name="test-instance",
+            instance_name="test-instance-fa2d407652a1c51f6019",
             force=True,
             project="test-project",
             remote="test-remote",

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -31,7 +31,7 @@ from logassert import Exact  # type: ignore
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, LXDInstance
 
-# These names include forbidden characters so a lxd-compatible instance_name
+# These names include invalid characters so a lxd-compatible instance_name
 # is generated. This ensures an Instance's `name` and `instance_name` are
 # differentiated when testing.
 _TEST_INSTANCE = {
@@ -914,7 +914,7 @@ def test_set_instance_name_unchanged(logs, mock_lxc, name):
         ("$1test", "test"),
         ("test-$", "test"),
         # this name contains invalid characters so it gets converted, even
-        # though it is less than 63 characters
+        # though it is 63 characters
         (
             "this-is-63-characters-with-invalid-characters-$$$xxxxxxxxxxxxxX",
             "this-is-63-characters-with-invalid-chara",

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,6 +14,8 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+
+import hashlib
 import io
 import os
 import pathlib
@@ -28,6 +30,24 @@ import pytest
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, LXDInstance
 
+# These names include forbidden characters so a lxd-compatible instance_name
+# is generated. This ensures an Instance's `name` and `instance_name` are
+# differentiated when testing.
+_TEST_INSTANCE = {
+    "name": "test-instance-$",
+    "instance-name": "test-instance-fa2d407652a1c51f6019",
+}
+
+_STOPPED_INSTANCE = {
+    "name": "stopped-instance-$",
+    "instance-name": "stopped-instance-b4598eebe37eb50c4612",
+}
+
+_INVALID_INSTANCE = {
+    "name": "invalid-instance-$",
+    "instance-name": "invalid-instance-86be3150e96a80a04e31",
+}
+
 
 @pytest.fixture
 def project_path(tmp_path):
@@ -40,8 +60,8 @@ def project_path(tmp_path):
 def mock_lxc(project_path):
     with mock.patch("craft_providers.lxd.lxd_instance.LXC", spec=LXC) as lxc:
         lxc.list.return_value = [
-            {"name": "test-instance", "status": "Running"},
-            {"name": "stopped-instance", "status": "Stopped"},
+            {"name": _TEST_INSTANCE["instance-name"], "status": "Running"},
+            {"name": _STOPPED_INSTANCE["instance-name"], "status": "Stopped"},
         ]
         lxc.config_device_show.return_value = {
             "test_mount": {
@@ -85,7 +105,7 @@ def mock_os_unlink():
 
 @pytest.fixture
 def instance(mock_lxc):
-    yield LXDInstance(name="test-instance", lxc=mock_lxc)
+    yield LXDInstance(name=_TEST_INSTANCE["name"], lxc=mock_lxc)
 
 
 def test_push_file_io(
@@ -110,7 +130,7 @@ def test_push_file_io(
 
     assert mock_lxc.mock_calls == [
         mock.call.file_push(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             source=pathlib.Path("test-tmp-file"),
             destination=pathlib.Path("/etc/test.conf"),
             mode="0644",
@@ -118,7 +138,7 @@ def test_push_file_io(
             remote=instance.remote,
         ),
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=[
                 "chown",
                 "root:root",
@@ -158,7 +178,10 @@ def test_push_file_io_error(mock_lxc, instance):
         )
 
     assert exc_info.value == LXDError(
-        brief="Failed to create file '/etc/test.conf' in instance 'test-instance'.",
+        brief=(
+            "Failed to create file '/etc/test.conf' "
+            f"in instance '{_TEST_INSTANCE['instance-name']}'."
+        ),
         details=errors.details_from_called_process_error(error),
     )
 
@@ -168,7 +191,7 @@ def test_delete(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.delete(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
             force=True,
@@ -181,7 +204,7 @@ def test_execute_popen(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["test-command", "flags"],
             cwd=None,
             project=instance.project,
@@ -199,7 +222,7 @@ def test_execute_popen_with_cwd(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["test-command", "flags"],
             cwd="/tmp",
             project=instance.project,
@@ -215,7 +238,7 @@ def test_execute_popen_with_env(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["env", "foo=bar", "test-command", "flags"],
             cwd=None,
             project=instance.project,
@@ -230,7 +253,7 @@ def test_execute_run(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["test-command", "flags"],
             cwd=None,
             project=instance.project,
@@ -248,7 +271,7 @@ def test_execute_run_with_cwd(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["test-command", "flags"],
             cwd="/tmp",
             project=instance.project,
@@ -261,7 +284,7 @@ def test_execute_run_with_cwd(mock_lxc, instance):
 
 def test_execute_run_with_default_command_env(mock_lxc):
     instance = LXDInstance(
-        name="test-instance",
+        name=_TEST_INSTANCE["name"],
         default_command_environment={"env_key": "some-value"},
         lxc=mock_lxc,
     )
@@ -270,7 +293,7 @@ def test_execute_run_with_default_command_env(mock_lxc):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["env", "env_key=some-value", "foo=bar", "test-command", "flags"],
             cwd=None,
             project=instance.project,
@@ -282,7 +305,7 @@ def test_execute_run_with_default_command_env(mock_lxc):
 
 def test_execute_run_with_default_command_env_unset(mock_lxc):
     instance = LXDInstance(
-        name="test-instance",
+        name=_TEST_INSTANCE["name"],
         default_command_environment={"env_key": "some-value"},
         lxc=mock_lxc,
     )
@@ -293,7 +316,7 @@ def test_execute_run_with_default_command_env_unset(mock_lxc):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["env", "-u", "env_key", "foo=bar", "test-command", "flags"],
             cwd=None,
             project=instance.project,
@@ -308,7 +331,7 @@ def test_execute_run_with_env(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=["env", "foo=bar", "test-command", "flags"],
             cwd=None,
             project=instance.project,
@@ -325,7 +348,7 @@ def test_execute_run_with_env_unset(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name="test-instance",
+            instance_name=instance.instance_name,
             command=[
                 "env",
                 "foo=bar",
@@ -411,7 +434,7 @@ def test_is_mounted_false(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         )
@@ -429,7 +452,7 @@ def test_is_mounted_true(mock_lxc, instance, project_path):
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         )
@@ -437,7 +460,7 @@ def test_is_mounted_true(mock_lxc, instance, project_path):
 
 
 def test_is_running_false(mock_lxc):
-    instance = LXDInstance(name="stopped-instance", lxc=mock_lxc)
+    instance = LXDInstance(name=_STOPPED_INSTANCE["name"], lxc=mock_lxc)
 
     assert instance.is_running() is False
 
@@ -455,13 +478,13 @@ def test_is_running_true(mock_lxc, instance):
 
 
 def test_is_running_error(mock_lxc):
-    instance = LXDInstance(name="invalid-instance", lxc=mock_lxc)
+    instance = LXDInstance(name=_INVALID_INSTANCE["name"], lxc=mock_lxc)
 
     with pytest.raises(LXDError) as exc_info:
         instance.is_running()
 
     assert exc_info.value == LXDError(
-        brief="Instance 'invalid-instance' does not exist.",
+        brief=f"Instance '{_INVALID_INSTANCE['instance-name']}' does not exist.",
     )
 
 
@@ -476,7 +499,7 @@ def test_launch(mock_lxc, instance):
         mock.call.launch(
             config_keys={},
             ephemeral=False,
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             image="20.04",
             image_remote="ubuntu",
             project=instance.project,
@@ -500,7 +523,7 @@ def test_launch_all_opts(mock_lxc, instance):
         mock.call.launch(
             config_keys={"raw.idmap": f"both {uid} 0"},
             ephemeral=True,
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             image="20.04",
             image_remote="ubuntu",
             project=instance.project,
@@ -526,7 +549,7 @@ def test_launch_with_mknod(mock_lxc, instance):
                 "security.syscalls.intercept.mknod": "true",
             },
             ephemeral=False,
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             image="20.04",
             image_remote="ubuntu",
             project=instance.project,
@@ -540,12 +563,12 @@ def test_mount(mock_lxc, tmp_path, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         ),
         mock.call.config_device_add_disk(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             source=tmp_path,
             path=pathlib.Path("/mnt/foo"),
             device="disk-/mnt/foo",
@@ -562,12 +585,12 @@ def test_mount_all_opts(mock_lxc, tmp_path, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         ),
         mock.call.config_device_add_disk(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             source=tmp_path,
             path=pathlib.Path("/mnt/foo"),
             device="disk-xfoo",
@@ -585,7 +608,7 @@ def test_mount_already_mounted(mock_lxc, instance, project_path):
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         )
@@ -605,7 +628,7 @@ def test_pull_file(mock_lxc, instance, tmp_path):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             command=["test", "-f", "/tmp/src.txt"],
             cwd=None,
             project=instance.project,
@@ -614,7 +637,7 @@ def test_pull_file(mock_lxc, instance, tmp_path):
             check=False,
         ),
         mock.call.file_pull(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             source=source,
             destination=destination,
             project=instance.project,
@@ -637,7 +660,7 @@ def test_pull_file_no_source(mock_lxc, instance, tmp_path):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             command=["test", "-f", "/tmp/src.txt"],
             cwd=None,
             project=instance.project,
@@ -663,7 +686,7 @@ def test_pull_file_no_parent_directory(mock_lxc, instance, tmp_path):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             command=["test", "-f", "/tmp/src.txt"],
             cwd=None,
             project=instance.project,
@@ -689,7 +712,7 @@ def test_push_file(mock_lxc, instance, tmp_path):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             command=["test", "-d", "/tmp"],
             cwd=None,
             project=instance.project,
@@ -698,7 +721,7 @@ def test_push_file(mock_lxc, instance, tmp_path):
             check=False,
         ),
         mock.call.file_push(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             source=source,
             destination=destination,
             project=instance.project,
@@ -738,7 +761,7 @@ def test_push_file_no_parent_directory(mock_lxc, instance, tmp_path):
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             command=["test", "-d", "/tmp"],
             cwd=None,
             project=instance.project,
@@ -755,7 +778,7 @@ def test_start(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.start(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         )
@@ -767,7 +790,7 @@ def test_stop(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.stop(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         )
@@ -789,12 +812,12 @@ def test_unmount(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         ),
         mock.call.config_device_remove(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             device="test_mount",
             project=instance.project,
             remote=instance.remote,
@@ -807,18 +830,18 @@ def test_unmount_all(mock_lxc, instance):
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
         ),
         mock.call.config_device_remove(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             device="test_mount",
             project=instance.project,
             remote=instance.remote,
         ),
         mock.call.config_device_remove(
-            instance_name=instance.name,
+            instance_name=instance.instance_name,
             device="disk-/target",
             project=instance.project,
             remote=instance.remote,
@@ -841,10 +864,107 @@ def test_unmount_error(mock_lxc, instance):
     assert exc_info.value == LXDError(
         brief=(
             "Failed to unmount 'not-mounted'"
-            " in instance 'test-instance' - no such disk."
+            f" in instance '{_TEST_INSTANCE['instance-name']}' - no such disk."
         ),
         details=(
             "* Disk device configuration: {'disk-/target':"
             " {'path': '/target', 'source': '/source', 'type': 'disk'}}"
         ),
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "t",
+        "test",
+        "test1",
+        "test-1",
+        "this-is-40-characters-xxxxxxxxxxxxxxxxxX",
+    ],
+)
+def test_set_instance_name_unchanged(mock_lxc, name):
+    """Verify names that are already compliant are not changed."""
+    instance = LXDInstance(
+        name=name,
+        lxc=mock_lxc,
+    )
+
+    assert instance.instance_name == name
+
+
+@pytest.mark.parametrize(
+    "name, expected_name",
+    [
+        # trim away invalid beginning characters
+        ("1test", "test"),
+        ("123test", "test"),
+        ("-test", "test"),
+        ("1-2-3-test", "test"),
+        # trim away invalid ending characters
+        ("test-", "test"),
+        ("test--", "test"),
+        ("test1-", "test1"),
+        # trim away invalid characters
+        ("test$", "test"),
+        ("test-!@#$%^&*()test", "test-test"),
+        ("$1test", "test"),
+        ("test-$", "test"),
+        # truncate at 40 characters
+        (
+            "this-is-41-characters-xxxxxxxxxxxxxxxxxXx",
+            "this-is-41-characters-xxxxxxxxxxxxxxxxxX",
+        ),
+    ],
+)
+def test_set_instance_name(mock_lxc, name, expected_name):
+    """Verify name is compliant with LXD naming conventions."""
+    instance = LXDInstance(
+        name=name,
+        lxc=mock_lxc,
+    )
+
+    # compute hash
+    hasher = hashlib.sha1()
+    hasher.update(name.encode())
+    hashed_name = hasher.hexdigest()[:20]
+
+    assert instance.instance_name == f"{expected_name}-{hashed_name}"
+    assert len(instance.instance_name) <= 63
+
+
+def test_set_instance_name_hash_value(mock_lxc):
+    """Verify hash is formatted as expected.
+
+    The first 20 characters of the SHA-1 hash of
+    "hello-world$" is 'b993dc52118c0f489570'
+
+    The name "hello-world$" should be hashed, not the trimmed name "hello-world".
+    """
+    instance = LXDInstance(
+        name="hello-world$",
+        lxc=mock_lxc,
+    )
+
+    assert instance.instance_name == "hello-world-b993dc52118c0f489570"
+    assert len(instance.instance_name) <= 63
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "-",
+        "$$$",
+        "-$-$-",
+    ],
+)
+def test_set_instance_name_invalid(mock_lxc, name):
+    """Verify invalid names raise an error."""
+    with pytest.raises(LXDError) as error:
+        LXDInstance(name=name, lxc=mock_lxc)
+
+    assert error.value == LXDError(
+        brief=f"failed to create LXD instance with name {name!r}.",
+        details="name must contain at least one alphanumeric character",
     )

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -26,6 +26,7 @@ import tempfile
 from unittest import mock
 
 import pytest
+from logassert import Exact  # type: ignore
 
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, LXDInstance
@@ -884,7 +885,7 @@ def test_unmount_error(mock_lxc, instance):
         "this-is-63-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     ],
 )
-def test_set_instance_name_unchanged(mock_lxc, name):
+def test_set_instance_name_unchanged(logs, mock_lxc, name):
     """Verify names that are already compliant are not changed."""
     instance = LXDInstance(
         name=name,
@@ -892,6 +893,7 @@ def test_set_instance_name_unchanged(mock_lxc, name):
     )
 
     assert instance.instance_name == name
+    assert Exact(f"Set LXD instance name to {name!r}") in logs.debug
 
 
 @pytest.mark.parametrize(
@@ -924,7 +926,7 @@ def test_set_instance_name_unchanged(mock_lxc, name):
         ),
     ],
 )
-def test_set_instance_name(mock_lxc, name, expected_name):
+def test_set_instance_name(logs, mock_lxc, name, expected_name):
     """Verify name is compliant with LXD naming conventions."""
     instance = LXDInstance(
         name=name,
@@ -936,6 +938,7 @@ def test_set_instance_name(mock_lxc, name, expected_name):
 
     assert instance.instance_name == f"{expected_name}-{hashed_name}"
     assert len(instance.instance_name) <= 63
+    assert Exact(f"Set LXD instance name to {instance.instance_name!r}") in logs.debug
 
 
 def test_set_instance_name_hash_value(mock_lxc):


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
### Overview
The provided name for a LXD executor object is converted to comply with [LXD naming conventions](https://linuxcontainers.org/lxd/docs/master/instances/) for instances.

### Problem
LXC has a 63 character limit on instance names.  [This snapcraft commit](https://github.com/snapcore/snapcraft/commit/21cb1ab9ae26cf3322356c190eb555ed05f2d498) adds 18-20 characters to the image name.  This is blocking snaps with long names from upgrading to core22.

Charmcraft has the [same issue](https://github.com/canonical/charmcraft/issues/629).

#### Snapcraft naming convention
```
snapcraft-<project-name>-on-<build-on>-for-<build-for>-<project-path-inode>
└  10   ┘└   2 - 41     ┘└   8-11    ┘└    9-12       ┘└       10         ┘
```
Min size: 10 + 2 + 8 + 9 + 10 = 39
Max size: 10 + 41 + 11 + 12 + 10 = 84

#### Charmcraft naming convention
```
charmcraft-<project-name>-<project-path-inode>-<bases-index>-<build-on-index>-<build-for>
└  11   ┘└    2 - ∞      ┘└       10          ┘└     2      ┘└      2        ┘└    7    ┘
```
Min size:   11 + 2 + 10 + 2 + 2 + 7 = 34
Max size: unbound

### Solution
`craft-providers` is responsible for complying with each provider’s specific requirements.
For LXD, `craft-providers` will:
1. truncate the first 40 characters name
2. remove forbidden characters
3. append a hash of the name
```
<truncated-name>-<hash-of-name>
└    1 - 40    ┘1└     20     ┘
```
Min size: 1 + 1 + 20 = 22
Max size: 40 + 1 + 20 = 61


Note: This is an internal change.  Applications using `craft-providers` should continue to choose their own unique names for instances.  The only restriction is that the name must contain at least one alphanumeric character.

LP: #[1981205](https://bugs.launchpad.net/snapcraft/+bug/1981205)
(CRAFT-1235)