### PR TITLE
bases: ensure BuilddBase hostname is valid

### DIFF
--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -903,8 +903,8 @@ def test_set_hostname_unchanged(hostname, logs):
         ),
         # this name is longer than 63 characters, so it gets converted
         (
-            "this-is-70-characters-with-valid-characters-xxxxxxxxxxxxxxxxxxXxxxxxxx",
-            "this-is-70-characters-with-valid-characters-xxxxxxxxxxxxxxxxxxX",
+            "this-is-64-characters-with-valid-characters-xxxxxxxxxxxxxxxxxxXx",
+            "this-is-64-characters-with-valid-characters-xxxxxxxxxxxxxxxxxxX",
         ),
     ],
 )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This PR ensures that the `hostname` is valid, which was previously raising an error.

`BuilddBase`'s `hostname` parameter has similar naming conventions to [LXD instance names](https://github.com/canonical/craft-providers/pull/134).  Yet, the naming convention is different enough that I didn't combine the functionality between the two.

(CRAFT-1234)