### PR TITLE
base: add optional list of snaps to install

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -22,14 +22,17 @@ import logging
 import pathlib
 import re
 import subprocess
+import sys
 import time
 from textwrap import dedent
 from time import sleep
-from typing import Dict, Optional, Type
+from typing import Dict, List, Optional, Type
 
+import pydantic
 from pydantic import ValidationError
 
 from craft_providers import Base, Executor, errors
+from craft_providers.actions import snap_installer
 from craft_providers.util.os_release import parse_os_release
 
 from .errors import BaseCompatibilityError, BaseConfigurationError
@@ -84,6 +87,37 @@ class BuilddBaseAlias(enum.Enum):
     JAMMY = "22.04"
 
 
+class Snap(pydantic.BaseModel, extra=pydantic.Extra.forbid):
+    """Details of snap to install in the base.
+
+    :param name: name of snap
+    :param channel: snap store channel to install from (default is stable)
+      If channel is `None`, then the snap is injected from the host instead
+      of being installed from the store.
+    :param classic: true if snap is a classic snap (default is false)
+    """
+
+    name: str
+    channel: Optional[str] = "stable"
+    classic: bool = False
+
+    # pylint: disable=no-self-argument
+    @pydantic.validator("channel")
+    def validate_channel(cls, channel):
+        """Validate that channel is not an empty string.
+
+        :raises BaseConfigurationError: if channel is empty
+        """
+        if channel == "":
+            raise BaseConfigurationError(
+                brief="channel cannot be empty",
+                resolution="set channel to a non-empty string or `None`",
+            )
+        return channel
+
+    # pylint: enable=no-self-argument
+
+
 class BuilddBase(Base):
     """Support for Ubuntu minimal buildd images.
 
@@ -105,6 +139,7 @@ class BuilddBase(Base):
     :param alias: Base alias / version.
     :param environment: Environment to set in /etc/environment.
     :param hostname: Hostname to configure.
+    :param snaps: Optional list of snaps to install on the base image.
     """
 
     compatibility_tag: str = f"buildd-{Base.compatibility_tag}"
@@ -117,6 +152,7 @@ class BuilddBase(Base):
         alias: BuilddBaseAlias,
         environment: Optional[Dict[str, Optional[str]]] = None,
         hostname: str = "craft-buildd-instance",
+        snaps: Optional[List[Snap]] = None,
     ):
         self.alias: BuilddBaseAlias = alias
 
@@ -126,6 +162,7 @@ class BuilddBase(Base):
             self.environment = environment
 
         self._set_hostname(hostname)
+        self.snaps = snaps
 
     def _set_hostname(self, hostname: str) -> None:
         """Set hostname.
@@ -270,18 +307,12 @@ class BuilddBase(Base):
         If timeout is specified, abort operation if time has been exceeded.
 
         Guarantees provided by this setup:
-
-            - configured /etc/environment
-
-            - configured hostname
-
-            - networking available (IP & DNS resolution)
-
-            - apt cache up-to-date
-
-            - snapd configured and ready
-
-            - system services are started and ready
+          - configured /etc/environment
+          - configured hostname
+          - networking available (IP & DNS resolution)
+          - apt cache up-to-date
+          - snapd configured and ready
+          - system services are started and ready
 
         :param executor: Executor for target container.
         :param retry_wait: Duration to sleep() between status checks (if
@@ -312,6 +343,7 @@ class BuilddBase(Base):
         )
         self._setup_apt(executor=executor, deadline=deadline)
         self._setup_snapd(executor=executor, deadline=deadline)
+        self._install_snaps(executor=executor, deadline=deadline)
 
     def warmup(
         self,
@@ -325,12 +357,9 @@ class BuilddBase(Base):
         Ensure the instance is still valid and wait for environment to become ready.
 
         Guarantees provided by this wait:
-
-            - OS and instance config are compatible
-
-            - networking available (IP & DNS resolution)
-
-            - system services are started and ready
+          - OS and instance config are compatible
+          - networking available (IP & DNS resolution)
+          - system services are started and ready
 
         If timeout is specified, abort operation if time has been exceeded.
 
@@ -354,6 +383,7 @@ class BuilddBase(Base):
         self._setup_wait_for_network(
             executor=executor, deadline=deadline, retry_wait=retry_wait
         )
+        self._install_snaps(executor=executor, deadline=deadline)
 
     def _disable_automatic_apt(
         self, *, executor: Executor, deadline: Optional[float]
@@ -381,6 +411,75 @@ class BuilddBase(Base):
             content=io.BytesIO(content),
             file_mode="0644",
         )
+
+    def _install_snaps(self, *, executor: Executor, deadline: Optional[float]) -> None:
+        """Install snaps.
+
+        Snaps will either be installed from the store or injected from the host.
+        - If channel is `None` on a linux system, the host snap is injected
+          into the provider.
+        - If channel is `None` on a non-linux system, an error is raised
+          because host injection is not supported on non-linux systems.
+
+        :param executor: Executor for target container.
+        :param deadline: Optional time.time() deadline.
+        :raises BaseConfigurationError: if the snap cannot be installed
+        """
+        if not self.snaps:
+            logger.debug("No snaps to install.")
+            return
+
+        for snap in self.snaps:
+            _check_deadline(deadline)
+            logger.debug(
+                "Installing snap %r with channel=%r and classic=%r",
+                snap.name,
+                snap.channel,
+                snap.classic,
+            )
+
+            # don't inject snaps on non-linux hosts
+            if sys.platform != "linux" and not snap.channel:
+                raise BaseConfigurationError(
+                    brief=(
+                        f"cannot inject snap {snap.name!r} from host on "
+                        "a non-linux system"
+                    ),
+                    resolution=(
+                        "install the snap from the store by setting the "
+                        "'channel' parameter"
+                    ),
+                )
+
+            if snap.channel:
+                try:
+                    snap_installer.install_from_store(
+                        executor=executor,
+                        snap_name=snap.name,
+                        channel=snap.channel,
+                        classic=snap.classic,
+                    )
+                except snap_installer.SnapInstallationError as error:
+                    raise BaseConfigurationError(
+                        brief=(
+                            f"failed to install snap {snap.name!r} from store"
+                            f" channel {snap.channel!r} in target environment."
+                        )
+                    ) from error
+            else:
+                try:
+                    snap_installer.inject_from_host(
+                        executor=executor,
+                        snap_name=snap.name,
+                        classic=snap.classic,
+                    )
+                except snap_installer.SnapInstallationError as error:
+                    raise BaseConfigurationError(
+                        brief=(
+                            f"failed to inject host's snap {snap.name!r} "
+                            "into target environment."
+                        )
+                    ) from error
 
     def _setup_apt(self, *, executor: Executor, deadline: Optional[float]) -> None:
         """Configure apt, update cache and install needed packages.

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -49,16 +49,12 @@ def mock_load(mocker):
 
 @pytest.fixture()
 def mock_install_from_store(mocker):
-    yield mocker.patch(
-        "craft_providers.actions.snap_installer.install_from_store",
-    )
+    yield mocker.patch("craft_providers.actions.snap_installer.install_from_store")
 
 
 @pytest.fixture()
 def mock_inject_from_host(mocker):
-    yield mocker.patch(
-        "craft_providers.actions.snap_installer.inject_from_host",
-    )
+    yield mocker.patch("craft_providers.actions.snap_installer.inject_from_host")
 
 
 @pytest.mark.parametrize(
@@ -306,8 +302,11 @@ def test_install_snaps_install_from_store(fake_executor, mock_install_from_store
     ]
 
 
-def test_install_snaps_inject_from_host_valid(fake_executor, mock_inject_from_host):
+def test_install_snaps_inject_from_host_valid(
+    fake_executor, mock_inject_from_host, mocker
+):
     """Verify installing snaps calls inject_from_host()."""
+    mocker.patch("sys.platform", "linux")
     my_snaps = [
         buildd.Snap(name="snap1", channel=None),
         buildd.Snap(name="snap2", channel=None, classic=True),
@@ -362,6 +361,7 @@ def test_install_snaps_install_from_store_error(fake_executor, mocker):
 
 def test_install_snaps_inject_from_host_error(fake_executor, mocker):
     """Verify install_snaps raises an error when inject_from_host fails."""
+    mocker.patch("sys.platform", "linux")
     mocker.patch(
         "craft_providers.actions.snap_installer.inject_from_host",
         side_effect=SnapInstallationError(brief="test error"),

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -16,12 +16,13 @@
 #
 
 from textwrap import dedent
-from unittest import mock
+from unittest.mock import ANY, call, patch
 
 import pytest
 from logassert import Exact  # type: ignore
 from pydantic import ValidationError
 
+from craft_providers.actions.snap_installer import SnapInstallationError
 from craft_providers.bases import (
     BaseCompatibilityError,
     BaseConfigurationError,
@@ -30,6 +31,8 @@ from craft_providers.bases import (
     instance_config,
 )
 from craft_providers.errors import details_from_called_process_error
+
+# pylint: disable=too-many-lines
 
 DEFAULT_FAKE_CMD = ["fake-executor"]
 
@@ -41,6 +44,20 @@ def mock_load(mocker):
         return_value=instance_config.InstanceConfiguration(
             compatibility_tag="buildd-base-v0"
         ),
+    )
+
+
+@pytest.fixture()
+def mock_install_from_store(mocker):
+    yield mocker.patch(
+        "craft_providers.actions.snap_installer.install_from_store",
+    )
+
+
+@pytest.fixture()
+def mock_inject_from_host(mocker):
+    yield mocker.patch(
+        "craft_providers.actions.snap_installer.inject_from_host",
     )
 
 
@@ -76,6 +93,16 @@ def mock_load(mocker):
         ),
     ],
 )
+@pytest.mark.parametrize(
+    "snaps, expected_snap_call",
+    [
+        (None, []),
+        (
+            [buildd.Snap(name="snap1", channel="edge", classic=True)],
+            [call(executor=ANY, snap_name="snap1", channel="edge", classic=True)],
+        ),
+    ],
+)
 def test_setup(  # pylint: disable=too-many-arguments
     fake_process,
     fake_executor,
@@ -83,7 +110,11 @@ def test_setup(  # pylint: disable=too-many-arguments
     hostname,
     environment,
     etc_environment_content,
+    mock_inject_from_host,
+    mock_install_from_store,
     mock_load,
+    snaps,
+    expected_snap_call,
 ):
     if environment is None:
         environment = buildd.default_command_environment()
@@ -92,6 +123,7 @@ def test_setup(  # pylint: disable=too-many-arguments
         alias=alias,
         environment=environment,
         hostname=hostname,
+        snaps=snaps,
     )
 
     fake_process.register_subprocess(
@@ -240,6 +272,111 @@ def test_setup(  # pylint: disable=too-many-arguments
     ]
     assert fake_executor.records_of_pull_file == []
     assert fake_executor.records_of_push_file == []
+    assert mock_install_from_store.mock_calls == expected_snap_call
+
+
+def test_snaps_no_channel_raises_errors(fake_executor):
+    """Verify the Snap model raises an error when the channel is an empty string."""
+    with pytest.raises(errors.BaseConfigurationError) as exc_info:
+        buildd.Snap(name="snap1", channel="")
+
+    assert exc_info.value == errors.BaseConfigurationError(
+        brief="channel cannot be empty",
+        resolution="set channel to a non-empty string or `None`",
+    )
+
+
+def test_install_snaps_install_from_store(fake_executor, mock_install_from_store):
+    """Verify installing snaps calls install_from_store()."""
+    my_snaps = [
+        buildd.Snap(name="snap1"),
+        buildd.Snap(name="snap2", channel="edge"),
+        buildd.Snap(name="snap3", channel="edge", classic=True),
+    ]
+    base = buildd.BuilddBase(alias=buildd.BuilddBaseAlias.JAMMY, snaps=my_snaps)
+
+    base._install_snaps(executor=fake_executor, deadline=None)
+
+    assert mock_install_from_store.mock_calls == [
+        call(
+            executor=fake_executor, snap_name="snap1", channel="stable", classic=False
+        ),
+        call(executor=fake_executor, snap_name="snap2", channel="edge", classic=False),
+        call(executor=fake_executor, snap_name="snap3", channel="edge", classic=True),
+    ]
+
+
+def test_install_snaps_inject_from_host_valid(fake_executor, mock_inject_from_host):
+    """Verify installing snaps calls inject_from_host()."""
+    my_snaps = [
+        buildd.Snap(name="snap1", channel=None),
+        buildd.Snap(name="snap2", channel=None, classic=True),
+    ]
+    base = buildd.BuilddBase(alias=buildd.BuilddBaseAlias.JAMMY, snaps=my_snaps)
+
+    base._install_snaps(executor=fake_executor, deadline=None)
+
+    assert mock_inject_from_host.mock_calls == [
+        call(executor=fake_executor, snap_name="snap1", classic=False),
+        call(executor=fake_executor, snap_name="snap2", classic=True),
+    ]
+
+
+def test_install_snaps_inject_from_host_not_linux_error(fake_executor, mocker):
+    """Verify install_snaps raises an error when injecting from host on
+    a non-linux system."""
+    mocker.patch("sys.platform", return_value="darwin")
+    my_snaps = [buildd.Snap(name="snap1", channel=None)]
+    base = buildd.BuilddBase(alias=buildd.BuilddBaseAlias.JAMMY, snaps=my_snaps)
+
+    with pytest.raises(errors.BaseConfigurationError) as exc_info:
+        base._install_snaps(executor=fake_executor, deadline=None)
+
+    assert exc_info.value == errors.BaseConfigurationError(
+        brief="cannot inject snap 'snap1' from host on a non-linux system",
+        resolution="install the snap from the store by setting the 'channel' parameter",
+    )
+
+
+def test_install_snaps_install_from_store_error(fake_executor, mocker):
+    """Verify install_snaps raises an error when install_from_store fails."""
+    mocker.patch(
+        "craft_providers.actions.snap_installer.install_from_store",
+        side_effect=SnapInstallationError(brief="test error"),
+    )
+    my_snaps = [
+        buildd.Snap(name="snap1", channel="candidate"),
+    ]
+    base = buildd.BuilddBase(alias=buildd.BuilddBaseAlias.JAMMY, snaps=my_snaps)
+
+    with pytest.raises(errors.BaseConfigurationError) as exc_info:
+        base._install_snaps(executor=fake_executor, deadline=None)
+
+    assert exc_info.value == errors.BaseConfigurationError(
+        brief=(
+            "failed to install snap 'snap1' from store"
+            " channel 'candidate' in target environment."
+        )
+    )
+
+
+def test_install_snaps_inject_from_host_error(fake_executor, mocker):
+    """Verify install_snaps raises an error when inject_from_host fails."""
+    mocker.patch(
+        "craft_providers.actions.snap_installer.inject_from_host",
+        side_effect=SnapInstallationError(brief="test error"),
+    )
+    my_snaps = [
+        buildd.Snap(name="snap1", channel=None),
+    ]
+    base = buildd.BuilddBase(alias=buildd.BuilddBaseAlias.JAMMY, snaps=my_snaps)
+
+    with pytest.raises(errors.BaseConfigurationError) as exc_info:
+        base._install_snaps(executor=fake_executor, deadline=None)
+
+    assert exc_info.value == errors.BaseConfigurationError(
+        brief="failed to inject host's snap 'snap1' into target environment."
+    )
 
 
 def test_ensure_image_version_compatible_failure(
@@ -266,7 +403,7 @@ def test_ensure_image_version_compatible_failure(
     )
 
 
-@mock.patch("time.time", side_effect=[0.0, 1.0])
+@patch("time.time", side_effect=[0.0, 1.0])
 def test_setup_timeout(  # pylint: disable=unused-argument
     mock_time, fake_executor, fake_process, monkeypatch
 ):
@@ -621,7 +758,7 @@ def test_wait_for_system_ready(
     ]
 
 
-@mock.patch("time.time", side_effect=[0.0, 0.0, 1.0])
+@patch("time.time", side_effect=[0.0, 0.0, 1.0])
 @pytest.mark.parametrize(
     "alias",
     [
@@ -655,7 +792,7 @@ def test_wait_for_system_ready_timeout(  # pylint: disable=unused-argument
     )
 
 
-@mock.patch("time.time", side_effect=[0.0, 0.0, 1.0])
+@patch("time.time", side_effect=[0.0, 0.0, 1.0])
 @pytest.mark.parametrize(
     "alias",
     [
@@ -690,7 +827,7 @@ def test_wait_for_system_ready_timeout_in_network(  # pylint: disable=unused-arg
     )
 
 
-@mock.patch(
+@patch(
     "craft_providers.bases.instance_config.InstanceConfiguration.load",
     side_effect=ValidationError("foo", instance_config.InstanceConfiguration),
 )
@@ -707,7 +844,7 @@ def test_ensure_config_compatible_validation_error(fake_executor):
     )
 
 
-@mock.patch(
+@patch(
     "craft_providers.bases.instance_config.InstanceConfiguration.load",
     return_value=None,
 )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
### Overview
New parameter in `BuilddBase` class that installs snaps in the base.

### Details
I created a pydantic model for each snap to be installed.  It gives the application lots of control over how the snap is installed.  For example, it is easy to specify a store channel or inject a snap from the host.

### Usage
I manually tested this with 3 craft tools and it appears to be 100% compatible. (lpcraft wasn't tested, because it doesn't install any snaps)

- [usage in charmcraft](https://github.com/mr-cal/charmcraft/pull/1)
- [usage in rockcraft](https://github.com/mr-cal/rockcraft/pull/1)
- [usage in snapcraft](https://github.com/mr-cal/snapcraft/pull/1)

(CRAFT-1222)