### PR TITLE
executor: add exists and delete function to abstract base class

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -120,3 +120,14 @@ class Executor(ABC):
         :param group: File owner group.
         :param user: File owner user.
         """
+
+    @abstractmethod
+    def delete(self) -> None:
+        """Delete instance."""
+
+    @abstractmethod
+    def exists(self) -> bool:
+        """Check if instance exists.
+
+        :returns: True if instance exists.
+        """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -113,6 +113,12 @@ class FakeExecutor(Executor):
             )
         )
 
+    def delete(self) -> None:
+        return
+
+    def exists(self) -> bool:
+        return True
+
 
 @pytest.fixture
 def fake_executor():


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add 2 functions, `exists()` and `delete()` to the `Executor` abstract base class.

This is required so applications can use these functions in the child classes.

(CRAFT-1251)