### PR TITLE
lint: ignore `warmup` in codespell 2.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ universal = 1
 [codespell]
 quiet-level = 3
 skip = .direnv,.git,.mypy_cache,.pytest_cache,.venv,__pycache__,venv
+ignore-words-list = warmup
 
 [flake8]
 exclude = .direnv .git .mypy_cache .pytest_cache .venv __pycache__ venv


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Release of codespell 2.2.0 is now flagging the word `warmup`.