### PR TITLE
bases: fix bug in BuilddBase hostname validation logic

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -185,8 +185,11 @@ class BuilddBase(Base):
         :raises BaseConfigurationError: if the hostname contains no
           alphanumeric characters
         """
+        # truncate to 63 characters
+        truncated_name = hostname[:63]
+
         # remove anything that is not an alphanumeric character or hyphen
-        name_with_valid_chars = re.sub(r"[^\w-]", "", hostname)
+        name_with_valid_chars = re.sub(r"[^\w-]", "", truncated_name)
 
         # trim hyphens from the beginning and end
         trimmed_name = re.compile(r"^[-]*(?P<valid_name>.*?)[-]*$").search(
@@ -199,11 +202,8 @@ class BuilddBase(Base):
             )
         valid_name = trimmed_name.group("valid_name")
 
-        # truncate to 63 characters
-        truncated_name = valid_name[:63]
-
-        logger.debug("Using hostname %r", truncated_name)
-        self.hostname = truncated_name
+        logger.debug("Using hostname %r", valid_name)
+        self.hostname = valid_name
 
     def _ensure_instance_config_compatible(
         self, *, executor: Executor, deadline: Optional[float]

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -192,15 +192,12 @@ class BuilddBase(Base):
         name_with_valid_chars = re.sub(r"[^\w-]", "", truncated_name)
 
         # trim hyphens from the beginning and end
-        trimmed_name = re.compile(r"^[-]*(?P<valid_name>.*?)[-]*$").search(
-            name_with_valid_chars
-        )
-        if not trimmed_name or trimmed_name.group("valid_name") == "":
+        valid_name = name_with_valid_chars.strip("-")
+        if not valid_name:
             raise BaseConfigurationError(
                 brief=f"failed to create base with hostname {hostname!r}.",
                 details="hostname must contain at least one alphanumeric character",
             )
-        valid_name = trimmed_name.group("valid_name")
 
         logger.debug("Using hostname %r", valid_name)
         self.hostname = valid_name

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -1129,6 +1129,16 @@ def test_set_hostname_unchanged(hostname, logs):
             "this-is-64-characters-with-valid-characters-xxxxxxxxxxxxxxxxxxXx",
             "this-is-64-characters-with-valid-characters-xxxxxxxxxxxxxxxxxxX",
         ),
+        # trim away away invalid characters and truncate to 63 characters
+        (
+            "-this-is-64-characters-and-has-invalid-characters-$$$xxxxxxxxxx-",
+            "this-is-64-characters-and-has-invalid-characters-xxxxxxxxxx",
+        ),
+        # ensure invalid ending characters are removed after truncating
+        (
+            "this-is-64-characters-and-has-a-hyphen-at-character-63-xxxxxxx-x",
+            "this-is-64-characters-and-has-a-hyphen-at-character-63-xxxxxxx",
+        ),
     ],
 )
 def test_set_hostname(hostname, expected_hostname, logs):


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
I made a mistake in hostname validation logic!  

This fixes a bug where hostnames longer than 64 characters may not have trailing hyphens removed.