### PR TITLE
Bump version: 1.4.0 → 1.4.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.4.1
 commit = True
 tag = True
 

--- a/craft_providers/__init__.py
+++ b/craft_providers/__init__.py
@@ -17,7 +17,7 @@
 
 """Craft Providers base package."""
 
-__version__ = "1.4.0"  # noqa: F401
+__version__ = "1.4.1"  # noqa: F401
 
 from .base import Base  # noqa: F401
 from .errors import ProviderError  # noqa: F401

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 *********
 
+1.4.1 (2022-08-30)
+------------------
+- Fix bug in BuilddBase where hostnames longer than 64 characters may
+  not having trailing hyphens removed.
+- Allow overriding of compatibility tag in Bases
 
 1.4.0 (2022-08-22)
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ copyright = "2021, Canonical Ltd."
 author = "Canonical Ltd."
 
 # The full version, including alpha/beta/rc tags
-release = "1.4.0"
+release = "1.4.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ extras_requires = {
 
 setup(
     name="craft-providers",
-    version="1.4.0",
+    version="1.4.1",
     description="Craft provider tooling",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This release for craft-providers 1.4.1 primarily addresses a bug in the truncation of long hostnames.