### PR TITLE
buildd: set snapd http-proxy and https-proxy

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -350,6 +350,7 @@ class BuilddBase(Base):
         )
         self._setup_apt(executor=executor, deadline=deadline)
         self._setup_snapd(executor=executor, deadline=deadline)
+        self._setup_snapd_proxy(executor=executor, deadline=deadline)
         self._install_snaps(executor=executor, deadline=deadline)
 
     def warmup(
@@ -390,6 +391,7 @@ class BuilddBase(Base):
         self._setup_wait_for_network(
             executor=executor, deadline=deadline, retry_wait=retry_wait
         )
+        self._setup_snapd_proxy(executor=executor, deadline=deadline)
         self._install_snaps(executor=executor, deadline=deadline)
 
     def _disable_automatic_apt(
@@ -756,6 +758,21 @@ class BuilddBase(Base):
                 check=True,
             )
 
+        except subprocess.CalledProcessError as error:
+            raise BaseConfigurationError(
+                brief="Failed to setup snapd.",
+                details=errors.details_from_called_process_error(error),
+            ) from error
+
+    def _setup_snapd_proxy(
+        self, *, executor: Executor, deadline: Optional[float] = None
+    ) -> None:
+        """Configure the snapd proxy.
+
+        :param executor: Executor for target container.
+        :param deadline: Optional time.time() deadline.
+        """
+        try:
             _check_deadline(deadline)
             http_proxy = self.environment.get("http_proxy")
             if http_proxy:
@@ -774,7 +791,7 @@ class BuilddBase(Base):
 
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
-                brief="Failed to setup snapd.",
+                brief="Failed to set the snapd proxy.",
                 details=errors.details_from_called_process_error(error),
             ) from error
 

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -755,6 +755,23 @@ class BuilddBase(Base):
                 capture_output=True,
                 check=True,
             )
+
+            _check_deadline(deadline)
+            http_proxy = self.environment.get("http_proxy")
+            if http_proxy:
+                command = ["snap", "set", "system", f"proxy.http={http_proxy}"]
+            else:
+                command = ["snap", "unset", "system", "proxy.http"]
+            executor.execute_run(command, capture_output=True, check=True)
+
+            _check_deadline(deadline)
+            https_proxy = self.environment.get("https_proxy")
+            if https_proxy:
+                command = ["snap", "set", "system", f"proxy.https={https_proxy}"]
+            else:
+                command = ["snap", "unset", "system", "proxy.https"]
+            executor.execute_run(command, capture_output=True, check=True)
+
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
                 brief="Failed to setup snapd.",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

If the environmental variables `http-proxy` or `https-proxy` are set, then they are configured with `snapd`.

This code was ported from [`snapcraft_legacy`](https://github.com/snapcore/snapcraft/blob/4a66b3b1b7e0cd39ba06dd4ab1c6d21c8cddd969/snapcraft_legacy/internal/build_providers/_base_provider.py#L510).

(CRAFT-1335)