### PR TITLE
snap installer: do not remove previous snap file

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -135,6 +135,8 @@ class Executor(ABC):
     def push_file(self, *, source: pathlib.Path, destination: pathlib.PurePath) -> None:
         """Copy a file from the host into the environment.
 
+        The destination file is overwritten if it exists.
+
         :param source: Host file to copy.
         :param destination: Target environment file path to copy to.  Parent
             directory (destination.parent) must exist.

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -492,6 +492,8 @@ class LXDInstance(Executor):
     def push_file(self, *, source: pathlib.Path, destination: pathlib.PurePath) -> None:
         """Copy a file from the host into the environment.
 
+        The destination file is overwritten if it exists.
+
         :param source: Host file to copy.
         :param destination: Target environment file path to copy to.  Parent
             directory (destination.parent) must exist.

--- a/craft_providers/multipass/multipass_instance.py
+++ b/craft_providers/multipass/multipass_instance.py
@@ -345,6 +345,8 @@ class MultipassInstance(Executor):
     def push_file(self, *, source: pathlib.Path, destination: pathlib.PurePath) -> None:
         """Copy a file from the host into the environment.
 
+        The destination file is overwritten if it exists.
+
         :param source: Host file to copy.
         :param destination: Target environment file path to copy to.  Parent
             directory (destination.parent) must exist.


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
#### Overview
Do not remove the previous snap file (i.e. `/tmp/<snap-name>.snap`) before pushing a new snap file into the instance.

Pushing a file into an instance overwrites the previous file, so there is no need to delete the previous file.

#### Reasons to remove
1. This isn't done in `snapcraft_legacy/internal/build_providers`
2. It doesn't need to be done
3. It adds time and complexity

(CRAFT-1370)