### PR TITLE
snap installer: refactor

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -95,6 +95,7 @@ def get_host_snap_info(snap_name: str) -> Dict[str, str]:
             brief="Unable to connect to snapd service."
         ) from error
     snap_info.raise_for_status()
+    # TODO: represent snap info in a dataclass
     return snap_info.json()["result"]
 
 

--- a/craft_providers/util/snap_cmd.py
+++ b/craft_providers/util/snap_cmd.py
@@ -42,6 +42,22 @@ def formulate_local_install_command(
     return install_cmd
 
 
+def formulate_pack_command(snap_name: str, output_file_path) -> List[str]:
+    """Formulate the command to pack a snap from a directory.
+
+    :param snap_name: The name of the channel.
+    :param output_file_path: File path to the packed snap.
+
+    :returns: List of command parts.
+    """
+    return [
+        "snap",
+        "pack",
+        f"/snap/{snap_name}/current/",
+        f"--filename={output_file_path}",
+    ]
+
+
 def formulate_remote_install_command(
     snap_name: str, channel: str, classic: bool
 ) -> List[str]:
@@ -70,8 +86,7 @@ def formulate_refresh_command(snap_name: str, channel: str) -> List[str]:
 
     :returns: List of command parts.
     """
-    install_cmd = ["snap", "refresh", snap_name, "--channel", channel]
-    return install_cmd
+    return ["snap", "refresh", snap_name, "--channel", channel]
 
 
 def formulate_remove_command(snap_name: str) -> List[str]:
@@ -81,5 +96,4 @@ def formulate_remove_command(snap_name: str) -> List[str]:
 
     :returns: List of command parts.
     """
-    install_cmd = ["snap", "remove", snap_name]
-    return install_cmd
+    return ["snap", "remove", snap_name]

--- a/tests/integration/actions/test_snap_installer.py
+++ b/tests/integration/actions/test_snap_installer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -22,6 +22,7 @@ from craft_providers.actions import snap_installer
 
 
 def test_inject_from_host(core20_lxd_instance, installed_snap, caplog):
+    """Verify a snap can be injected from the host."""
     core20_lxd_instance.execute_run(
         ["test", "!", "-d", "/snap/hello-world"], check=True
     )
@@ -36,9 +37,28 @@ def test_inject_from_host(core20_lxd_instance, installed_snap, caplog):
     assert caplog.records == []
 
 
+def test_inject_from_host_dangerous(
+    core20_lxd_instance, dangerously_installed_snap, caplog
+):
+    """Verify a dangerously installed snap can be injected from the host."""
+    core20_lxd_instance.execute_run(
+        ["test", "!", "-d", "/snap/hello-world"], check=True
+    )
+
+    with dangerously_installed_snap("hello-world"):
+        snap_installer.inject_from_host(
+            executor=core20_lxd_instance, snap_name="hello-world", classic=False
+        )
+
+    core20_lxd_instance.execute_run(["test", "-d", "/snap/hello-world"], check=True)
+
+    assert caplog.records == []
+
+
 def test_inject_from_host_using_pack_fallback(
     core20_lxd_instance, empty_test_snap, caplog
 ):
+    """Verify a snap is packed if the local download fails."""
     snap_installer.inject_from_host(
         executor=core20_lxd_instance,
         snap_name=empty_test_snap,
@@ -56,6 +76,7 @@ def test_inject_from_host_using_pack_fallback(
 
 
 def test_install_from_store_strict(core20_lxd_instance, installed_snap, caplog):
+    """Verify a strictly confined snap from the store can be installed."""
     core20_lxd_instance.execute_run(
         ["test", "!", "-d", "/snap/hello-world"], check=True
     )
@@ -73,6 +94,7 @@ def test_install_from_store_strict(core20_lxd_instance, installed_snap, caplog):
 
 
 def test_install_from_store_classic(core20_lxd_instance, installed_snap, caplog):
+    """Verify a classicly confined snap from the store can be installed."""
     core20_lxd_instance.execute_run(["test", "!", "-d", "/snap/charmcraft"], check=True)
 
     snap_installer.install_from_store(
@@ -88,6 +110,7 @@ def test_install_from_store_classic(core20_lxd_instance, installed_snap, caplog)
 
 
 def test_install_from_store_channel(core20_lxd_instance, installed_snap, caplog):
+    """Verify a channel can be specified when installing from the store"""
     core20_lxd_instance.execute_run(["test", "!", "-d", "/snap/go"], check=True)
 
     snap_installer.install_from_store(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,6 +21,7 @@ import contextlib
 import os
 import pathlib
 import random
+import re
 import shutil
 import string
 import subprocess
@@ -31,11 +32,22 @@ from typing import Optional
 import pytest
 
 from craft_providers import bases, lxd, multipass
+from craft_providers.actions.snap_installer import get_host_snap_info
 
 
 def generate_instance_name():
     """Generate a random instance name."""
     return "itest-" + "".join(random.choices(string.ascii_uppercase, k=8))
+
+
+def snap_exists(snap_name: str) -> bool:
+    """Returns true if a snap exists."""
+    return os.path.exists(f"/snap/{snap_name}/current")
+
+
+def is_installed_dangerously(snap_name: str) -> bool:
+    """Returns true if a snap is installed dangerously."""
+    return get_host_snap_info(snap_name)["revision"].startswith("x")
 
 
 @pytest.fixture()
@@ -186,12 +198,12 @@ def installed_snap():
 
     @contextlib.contextmanager
     def _installed_snap(snap_name, *, try_path: Optional[pathlib.Path] = None):
-        """Ensure snap is installed, or skip test."""
+        """Ensure snap is installed or skip test."""
         if shutil.which("snap") is None or sys.platform != "linux":
             pytest.skip("requires linux and snapd")
 
-        if os.path.exists(f"/snap/{snap_name}/current"):
-            # Already installed, nothing to do.
+        # do nothing if already installed and not dangerous
+        if snap_exists(snap_name) and not is_installed_dangerously(snap_name):
             yield
         else:
             # Install it, if enabled to do so by environment.
@@ -200,12 +212,66 @@ def installed_snap():
 
             if try_path:
                 subprocess.run(["sudo", "snap", "try", str(try_path)], check=True)
+            # if snap is already installed dangerously, use 'snap refresh'
+            elif snap_exists(snap_name) and is_installed_dangerously(snap_name):
+                subprocess.run(
+                    ["sudo", "snap", "refresh", "--amend", snap_name], check=True
+                )
+            # else use 'snap install'
             else:
                 subprocess.run(["sudo", "snap", "install", snap_name], check=True)
             yield
             subprocess.run(["sudo", "snap", "remove", snap_name], check=True)
 
     return _installed_snap
+
+
+@pytest.fixture()
+def dangerously_installed_snap(tmpdir):
+    """Fixture to provide contextmanager for a dangerously installed snap.
+
+    If the snap is not installed, it would be installed automatically with:
+    CRAFT_PROVIDERS_TESTS_ENABLE_SNAP_INSTALL=1
+    """
+
+    @contextlib.contextmanager
+    def _dangerously_installed_snap(snap_name):
+        """Ensure snap is installed or skip test."""
+        if shutil.which("snap") is None or sys.platform != "linux":
+            pytest.skip("requires linux and snapd")
+
+        # do nothing if the snap is already installed dangerously
+        if snap_exists(snap_name) and is_installed_dangerously(snap_name):
+            yield
+        else:
+            if not os.environ.get("CRAFT_PROVIDERS_TESTS_ENABLE_SNAP_INSTALL") == "1":
+                pytest.skip(f"{snap_name!r} snap not installed, skipped")
+
+            # download the snap
+            output = subprocess.run(
+                ["snap", "download", "--target-directory", tmpdir, snap_name],
+                check=True,
+                capture_output=True,
+            )
+
+            # collect the file name
+            match = re.search(f"{snap_name}_\\d+.snap", str(output))
+            if not match:
+                raise Exception(
+                    "could not parse snap file name from output of "
+                    f"'snap download {snap_name}' (output = {output!r})"
+                )
+            snap_file_path = pathlib.Path(tmpdir / match.group())
+
+            # the `--dangerous` flag will force the snap to be installed dangerously,
+            # even if the assertions exist in snapd
+            subprocess.run(
+                ["sudo", "snap", "install", snap_file_path, "--dangerous"], check=True
+            )
+            yield
+            subprocess.run(["sudo", "snap", "remove", snap_name], check=True)
+
+    return _dangerously_installed_snap
 
 
 @pytest.fixture()

--- a/tests/unit/util/test_snap_cmd.py
+++ b/tests/unit/util/test_snap_cmd.py
@@ -43,6 +43,13 @@ def test_local_install_all_opts(tmp_path):
     ) == ["snap", "install", tmp_path.as_posix(), "--classic", "--dangerous"]
 
 
+def test_pack():
+    command = snap_cmd.formulate_pack_command(
+        snap_name="testsnap", output_file_path="testpath"
+    )
+    assert command == ["snap", "pack", "/snap/testsnap/current/", "--filename=testpath"]
+
+
 def test_remote_install_strict():
     snap_name, channel = "testsnap", "edge"
     cmd = snap_cmd.formulate_remote_install_command(snap_name, channel, classic=False)


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
#### Overview

Minor refactor of `snap_installer`.
https://github.com/canonical/craft-providers/pull/151 needs to be reviewed and merged before this PR.

#### Details
No functional changes.  This is laying groundwork for the next PR to assert snaps.

Notable changes:
1. New integration test to inject a dangerously installed snap
2. Change `get_host_snap_revision()` to a generic function `get_host_snap_info()`, since I'll soon be needing more data than just the revision.
---
CRAFT-1371