### PR TITLE
snap installer: assert injected snaps

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -189,7 +189,7 @@ def _get_assertion(query: List[str]) -> bytes:
     :raises SnapInstallationError: if 'snap known' call fails
     """
     command = snap_cmd.formulate_known_command(query=query)
-    logger.debug("Executing command on host: %s", shlex.join(command))
+    logger.debug("Executing command on host: %s", command)
     try:
         return subprocess.run(command, capture_output=True, check=True).stdout
     except subprocess.CalledProcessError as error:

--- a/craft_providers/util/snap_cmd.py
+++ b/craft_providers/util/snap_cmd.py
@@ -15,10 +15,26 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-"""Helper(s) for snap command."""
+"""Helpers for snap command."""
 
 import pathlib
 from typing import List
+
+
+def formulate_ack_command(snap_assert_path: pathlib.Path) -> List[str]:
+    """Formulate snap ack command to add assertions.
+
+    :returns: List of ack command parts.
+    """
+    return ["snap", "ack", snap_assert_path.as_posix()]
+
+
+def formulate_known_command(query: List[str]) -> List[str]:
+    """Formulate snap known command to retrieve assertions.
+
+    :returns: List of ack command parts.
+    """
+    return ["snap", "known", *query]
 
 
 def formulate_local_install_command(

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -760,11 +760,15 @@ def test_get_assertion_connection_error(mocker):
 
 
 def test_add_assertions_from_host_error_on_push(
-    fake_executor, fake_process, mock_requests
+    fake_executor, fake_process, mock_requests, mocker, tmpdir
 ):
     """Raise SnapInstallationError when assert file cannot be pushed."""
     mock_executor = mock.Mock(spec=fake_executor, wraps=fake_executor)
     mock_executor.push_file.side_effect = ProviderError(brief="foo")
+    mocker.patch(
+        "craft_providers.bases.instance_config.temp_paths.home_temporary_file",
+        return_value=pathlib.Path(tmpdir) / "temp-file",
+    )
 
     # register 'snap known' calls
     for _ in range(3):
@@ -784,12 +788,16 @@ def test_add_assertions_from_host_error_on_push(
 
 
 def test_add_assertions_from_host_error_on_ack(
-    fake_executor, fake_process, mock_requests
+    fake_executor, fake_process, mock_requests, mocker, tmpdir
 ):
     """Raise SnapInstallationError when 'snap ack' fails."""
     fake_process.register_subprocess(
         ["fake-executor", "snap", "ack", "/tmp/test-name.assert"],
         returncode=1,
+    )
+    mocker.patch(
+        "craft_providers.bases.instance_config.temp_paths.home_temporary_file",
+        return_value=pathlib.Path(tmpdir) / "temp-file",
     )
 
     # register 'snap known' calls

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -146,12 +146,9 @@ def test_inject_from_host_classic(
         executor=fake_executor, snap_name="test-name", classic=True
     )
 
-    assert mock_requests.mock_calls == [
-        mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
-        mock.call.get().raise_for_status(),
-        mock.call.get().iter_content(65536),
-        mock.call.get().iter_content().__iter__(),
-    ]
+    mock_requests.get.assert_called_with(
+        "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"
+    )
 
     assert len(fake_process.calls) == 5
     assert Exact("Installing snap 'test-name' from host (classic=True)") in logs.debug
@@ -204,12 +201,9 @@ def test_inject_from_host_strict(
         executor=fake_executor, snap_name="test-name", classic=False
     )
 
-    assert mock_requests.mock_calls == [
-        mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
-        mock.call.get().raise_for_status(),
-        mock.call.get().iter_content(65536),
-        mock.call.get().iter_content().__iter__(),
-    ]
+    mock_requests.get.assert_called_with(
+        "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"
+    )
 
     assert len(fake_process.calls) == 5
     assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug
@@ -253,12 +247,9 @@ def test_inject_from_host_dangerous(
         executor=fake_executor, snap_name="test-name", classic=False
     )
 
-    assert mock_requests.mock_calls == [
-        mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
-        mock.call.get().raise_for_status(),
-        mock.call.get().iter_content(65536),
-        mock.call.get().iter_content().__iter__(),
-    ]
+    mock_requests.get.assert_called_with(
+        "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"
+    )
 
     assert len(fake_process.calls) == 1
     assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug
@@ -334,12 +325,9 @@ def test_inject_from_host_not_dangerous(
         executor=fake_executor, snap_name="test-name", classic=False
     )
 
-    assert mock_requests.mock_calls == [
-        mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
-        mock.call.get().raise_for_status(),
-        mock.call.get().iter_content(65536),
-        mock.call.get().iter_content().__iter__(),
-    ]
+    mock_requests.get.assert_called_with(
+        "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"
+    )
 
     assert len(fake_process.calls) == 5
     assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -17,6 +17,7 @@
 
 import json
 import pathlib
+import subprocess
 import textwrap
 from unittest import mock
 
@@ -74,7 +75,7 @@ def config_fixture(request, tmp_path, mocker):
     )
 
 
-@pytest.fixture(params=[{"revision": "2"}])
+@pytest.fixture(params=[{"revision": "2", "id": "3"}])
 def mock_get_host_snap_info(request, mocker):
     """Mocks the get_host_snap_revision() function
 
@@ -120,6 +121,17 @@ def test_inject_from_host_classic(
     logs,
     tmp_path,
 ):
+    # register 'snap known' calls
+    for _ in range(3):
+        fake_process.register_subprocess(["snap", "known", fake_process.any()])
+    fake_process.register_subprocess(
+        [
+            "fake-executor",
+            "snap",
+            "ack",
+            "/tmp/test-name.assert",
+        ]
+    )
     fake_process.register_subprocess(
         [
             "fake-executor",
@@ -127,7 +139,6 @@ def test_inject_from_host_classic(
             "install",
             "/tmp/test-name.snap",
             "--classic",
-            "--dangerous",
         ]
     )
 
@@ -142,7 +153,7 @@ def test_inject_from_host_classic(
         mock.call.get().iter_content().__iter__(),
     ]
 
-    assert len(fake_process.calls) == 1
+    assert len(fake_process.calls) == 5
     assert Exact("Installing snap 'test-name' from host (classic=True)") in logs.debug
     assert "Revisions found: host='2', target='1'" in logs.debug
 
@@ -161,6 +172,65 @@ def test_inject_from_host_classic(
 
 
 def test_inject_from_host_strict(
+    config_fixture,
+    mock_get_host_snap_info,
+    mock_requests,
+    fake_executor,
+    fake_process,
+    logs,
+    tmp_path,
+):
+    # register 'snap known' calls
+    for _ in range(3):
+        fake_process.register_subprocess(["snap", "known", fake_process.any()])
+    fake_process.register_subprocess(
+        [
+            "fake-executor",
+            "snap",
+            "ack",
+            "/tmp/test-name.assert",
+        ]
+    )
+    fake_process.register_subprocess(
+        [
+            "fake-executor",
+            "snap",
+            "install",
+            "/tmp/test-name.snap",
+        ]
+    )
+
+    snap_installer.inject_from_host(
+        executor=fake_executor, snap_name="test-name", classic=False
+    )
+
+    assert mock_requests.mock_calls == [
+        mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
+        mock.call.get().raise_for_status(),
+        mock.call.get().iter_content(65536),
+        mock.call.get().iter_content().__iter__(),
+    ]
+
+    assert len(fake_process.calls) == 5
+    assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug
+    assert "Revisions found: host='2', target='1'" in logs.debug
+
+    # check saved config
+    (saved_config_record,) = [
+        x
+        for x in fake_executor.records_of_push_file_io
+        if "craft-instance.conf" in x["destination"]
+    ]
+    config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
+    assert config.snaps is not None
+    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+        "revision": "2",
+        "source": snap_installer.SNAP_SRC_HOST,
+    }
+
+
+@pytest.mark.parametrize("mock_get_host_snap_info", [{"revision": "x3"}], indirect=True)
+def test_inject_from_host_dangerous(
     config_fixture,
     mock_get_host_snap_info,
     mock_requests,
@@ -191,6 +261,87 @@ def test_inject_from_host_strict(
     ]
 
     assert len(fake_process.calls) == 1
+    assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug
+    assert "Revisions found: host='x3', target='1'" in logs.debug
+
+    # check saved config
+    (saved_config_record,) = [
+        x
+        for x in fake_executor.records_of_push_file_io
+        if "craft-instance.conf" in x["destination"]
+    ]
+    config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
+    assert config.snaps is not None
+    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+        "revision": "x3",
+        "source": snap_installer.SNAP_SRC_HOST,
+    }
+
+
+def test_inject_from_host_not_dangerous(
+    config_fixture,
+    mock_get_host_snap_info,
+    mock_requests,
+    fake_executor,
+    fake_process,
+    logs,
+    tmp_path,
+):
+    fake_process.register_subprocess(
+        [
+            "snap",
+            "known",
+            "account-key",
+            "public-key-sha3-384=BWDEoaqyr25nF5SNCvEv2v"
+            "7QnM9QsfCc0PBMYD_i2NGSQ32EF2d4D0hqUel3m8ul",
+        ]
+    )
+    fake_process.register_subprocess(
+        [
+            "snap",
+            "known",
+            "snap-declaration",
+            "snap-name=test-name",
+        ]
+    )
+    fake_process.register_subprocess(
+        [
+            "snap",
+            "known",
+            "snap-revision",
+            "snap-revision=2",
+            "snap-id=3",
+        ]
+    )
+    fake_process.register_subprocess(
+        [
+            "fake-executor",
+            "snap",
+            "ack",
+            "/tmp/test-name.assert",
+        ]
+    )
+    fake_process.register_subprocess(
+        [
+            "fake-executor",
+            "snap",
+            "install",
+            "/tmp/test-name.snap",
+        ]
+    )
+
+    snap_installer.inject_from_host(
+        executor=fake_executor, snap_name="test-name", classic=False
+    )
+
+    assert mock_requests.mock_calls == [
+        mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
+        mock.call.get().raise_for_status(),
+        mock.call.get().iter_content(65536),
+        mock.call.get().iter_content().__iter__(),
+    ]
+
+    assert len(fake_process.calls) == 5
     assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug
     assert "Revisions found: host='2', target='1'" in logs.debug
 
@@ -280,13 +431,23 @@ def test_inject_from_host_snapd_connection_error_using_pack_fallback(
             f'--filename={pathlib.Path(tmpdir / "test-name.snap")}',
         ]
     )
+    # register 'snap known' calls
+    for _ in range(3):
+        fake_process.register_subprocess(["snap", "known", fake_process.any()])
+    fake_process.register_subprocess(
+        [
+            "fake-executor",
+            "snap",
+            "ack",
+            "/tmp/test-name.assert",
+        ]
+    )
     fake_process.register_subprocess(
         [
             "fake-executor",
             "snap",
             "install",
             "/tmp/test-name.snap",
-            "--dangerous",
         ]
     )
 
@@ -297,7 +458,7 @@ def test_inject_from_host_snapd_connection_error_using_pack_fallback(
     assert mock_requests.mock_calls == [
         mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
     ]
-    assert len(fake_process.calls) == 2
+    assert len(fake_process.calls) == 6
 
 
 def test_inject_from_host_snapd_http_error_using_pack_fallback(
@@ -319,13 +480,23 @@ def test_inject_from_host_snapd_http_error_using_pack_fallback(
             f'--filename={pathlib.Path(tmpdir / "test-name.snap")}',
         ]
     )
+    # register 'snap known' calls
+    for _ in range(3):
+        fake_process.register_subprocess(["snap", "known", fake_process.any()])
+    fake_process.register_subprocess(
+        [
+            "fake-executor",
+            "snap",
+            "ack",
+            "/tmp/test-name.assert",
+        ]
+    )
     fake_process.register_subprocess(
         [
             "fake-executor",
             "snap",
             "install",
             "/tmp/test-name.snap",
-            "--dangerous",
         ]
     )
 
@@ -338,7 +509,7 @@ def test_inject_from_host_snapd_http_error_using_pack_fallback(
         mock.call.get().raise_for_status(),
     ]
 
-    assert len(fake_process.calls) == 2
+    assert len(fake_process.calls) == 6
 
 
 def test_inject_from_host_install_failure(
@@ -571,6 +742,73 @@ def test_get_host_snap_info_connection_error(responses):
         brief="Unable to connect to snapd service."
     )
     assert exc_info.value.__cause__ is not None
+
+
+def test_get_assertion_connection_error(mocker):
+    """Raise SnapInstallation when 'snap known' call fails."""
+    mocker.patch(
+        "subprocess.run", side_effect=subprocess.CalledProcessError(100, ["error"])
+    )
+
+    with pytest.raises(snap_installer.SnapInstallationError) as exc_info:
+        snap_installer._get_assertion(["test1", "test2"])
+    assert exc_info.value == snap_installer.SnapInstallationError(
+        brief="failed to get assertions for snap",
+        details="* Command that failed: 'error'\n* Command exit code: 100",
+    )
+    assert exc_info.value.__cause__ is not None
+
+
+def test_add_assertions_from_host_error_on_push(
+    fake_executor, fake_process, mock_requests
+):
+    """Raise SnapInstallationError when assert file cannot be pushed."""
+    mock_executor = mock.Mock(spec=fake_executor, wraps=fake_executor)
+    mock_executor.push_file.side_effect = ProviderError(brief="foo")
+
+    # register 'snap known' calls
+    for _ in range(3):
+        fake_process.register_subprocess(["snap", "known", fake_process.any()])
+
+    with pytest.raises(snap_installer.SnapInstallationError) as exc_info:
+        snap_installer._add_assertions_from_host(
+            executor=mock_executor,
+            snap_name="test-name",
+        )
+
+    assert exc_info.value == snap_installer.SnapInstallationError(
+        brief="failed to copy assert file for snap 'test-name'",
+        details="error copying snap assert file into target environment",
+    )
+    assert exc_info.value.__cause__ is not None
+
+
+def test_add_assertions_from_host_error_on_ack(
+    fake_executor, fake_process, mock_requests
+):
+    """Raise SnapInstallationError when 'snap ack' fails."""
+    fake_process.register_subprocess(
+        ["fake-executor", "snap", "ack", "/tmp/test-name.assert"],
+        returncode=1,
+    )
+
+    # register 'snap known' calls
+    for _ in range(3):
+        fake_process.register_subprocess(["snap", "known", fake_process.any()])
+
+    with pytest.raises(snap_installer.SnapInstallationError) as exc_info:
+        snap_installer._add_assertions_from_host(
+            executor=fake_executor, snap_name="test-name"
+        )
+
+    assert exc_info.value == snap_installer.SnapInstallationError(
+        brief="failed to add assertions for snap 'test-name'",
+        details=details_from_called_process_error(
+            exc_info.value.__cause__  # type: ignore
+        ),
+    )
+
+    assert len(fake_process.calls) == 4
 
 
 def test_get_target_snap_revision_from_snapd_process_error(fake_process, fake_executor):

--- a/tests/unit/util/test_snap_cmd.py
+++ b/tests/unit/util/test_snap_cmd.py
@@ -19,6 +19,16 @@
 from craft_providers.util import snap_cmd
 
 
+def test_ack(tmp_path):
+    command = snap_cmd.formulate_ack_command(snap_assert_path=tmp_path)
+    assert command == ["snap", "ack", tmp_path.as_posix()]
+
+
+def test_known(tmp_path):
+    command = snap_cmd.formulate_known_command(query=["test1", "test2"])
+    assert command == ["snap", "known", "test1", "test2"]
+
+
 def test_local_install_strict(tmp_path):
     assert snap_cmd.formulate_local_install_command(
         classic=False, dangerous=False, snap_path=tmp_path


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
### Overview
Assert signed snaps injected into a provider.

### Details
If a snap on the host is signed (not dangerous), then craft-providers will:
1. collect the assertions from the host with `snap known`
2. push the assertions to the instance
3. add the assertions in the instance with `snap ack`

If the snap is unsigned on the host, then the snap is installed dangerously in the instance.  This behavior is unchanged.

The implementation in [snapcraft_legacy](https://github.com/snapcore/snapcraft/blob/433a09262443d645acbae5204b5c9a44433f4b83/snapcraft_legacy/internal/build_providers/_snap.py) was used as a reference.

I tested this manually with snapcraft, switching between dangerous and non-dangerous snaps.  The integration tests here already test for both scenarios too (I added those tests in the [previous PR](https://github.com/canonical/craft-providers/pull/152)).

(CRAFT-1372)