### PR TITLE
executor: add mount method to base Executor class

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -175,3 +175,7 @@ class Executor(ABC):
 
         :returns: True if instance exists.
         """
+
+    @abstractmethod
+    def mount(self, *, host_source: pathlib.Path, target: pathlib.Path) -> None:
+        """Mount host source directory to target mount point."""

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -414,12 +414,7 @@ class LXDInstance(Executor):
             remote=self.remote,
         )
 
-    def mount(
-        self,
-        *,
-        host_source: pathlib.Path,
-        target: pathlib.PurePath,
-    ) -> None:
+    def mount(self, *, host_source: pathlib.Path, target: pathlib.PurePath) -> None:
         """Mount host source directory to target mount point.
 
         Checks first to see if already mounted.
@@ -438,39 +433,6 @@ class LXDInstance(Executor):
             source=host_source,
             path=target,
             device=f"disk-{target.as_posix()}",
-            project=self.project,
-            remote=self.remote,
-        )
-
-    def mount_with_device_name(
-        self,
-        *,
-        host_source: pathlib.Path,
-        target: pathlib.PurePath,
-        device_name: Optional[str] = None,
-    ) -> None:
-        """Mount host source directory to target mount point with a specific name.
-
-        Checks first to see if already mounted.  If no device name is given, it
-        will be generated with the format "disk-{target.as_posix()}".
-
-        :param host_source: Host path to mount.
-        :param target: Instance path to mount to.
-        :param device_name: Name for disk device.
-
-        :raises LXDError: On unexpected error.
-        """
-        if self.is_mounted(host_source=host_source, target=target):
-            return
-
-        if device_name is None:
-            device_name = "disk-" + target.as_posix()
-
-        self.lxc.config_device_add_disk(
-            instance_name=self.instance_name,
-            source=host_source,
-            path=target,
-            device=device_name,
             project=self.project,
             remote=self.remote,
         )

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -430,10 +430,16 @@ class LXDInstance(Executor):
 
         :raises LXDError: On unexpected error.
         """
-        self.mount_with_device_name(
-            host_source=host_source,
-            target=target,
-            device_name=None,
+        if self.is_mounted(host_source=host_source, target=target):
+            return
+
+        self.lxc.config_device_add_disk(
+            instance_name=self.instance_name,
+            source=host_source,
+            path=target,
+            device=f"disk-{target.as_posix()}",
+            project=self.project,
+            remote=self.remote,
         )
 
     def mount_with_device_name(

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -419,9 +419,31 @@ class LXDInstance(Executor):
         *,
         host_source: pathlib.Path,
         target: pathlib.PurePath,
-        device_name: Optional[str] = None,
     ) -> None:
         """Mount host source directory to target mount point.
+
+        Checks first to see if already mounted.
+        The source will be mounted as a disk named "disk-{target.as_posix()}".
+
+        :param host_source: Host path to mount.
+        :param target: Instance path to mount to.
+
+        :raises LXDError: On unexpected error.
+        """
+        self.mount_with_device_name(
+            host_source=host_source,
+            target=target,
+            device_name=None,
+        )
+
+    def mount_with_device_name(
+        self,
+        *,
+        host_source: pathlib.Path,
+        target: pathlib.PurePath,
+        device_name: Optional[str] = None,
+    ) -> None:
+        """Mount host source directory to target mount point with a specific name.
 
         Checks first to see if already mounted.  If no device name is given, it
         will be generated with the format "disk-{target.as_posix()}".

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -216,39 +216,6 @@ def test_mount_unmount(reusable_instance, tmp_path):
     assert reusable_instance.is_mounted(host_source=host_source, target=target) is False
 
 
-def test_mount_with_device_name_unmount(reusable_instance, tmp_path):
-    tmp_path.chmod(0o755)
-
-    host_source = tmp_path
-    target = pathlib.Path("/tmp/mnt")
-    device_name = "test-device-name"
-
-    test_file = host_source / "test.txt"
-    test_file.write_text("this is a test")
-
-    assert reusable_instance.is_mounted(host_source=host_source, target=target) is False
-
-    reusable_instance.mount_with_device_name(
-        host_source=host_source, target=target, device_name=device_name
-    )
-
-    assert reusable_instance.is_mounted(host_source=host_source, target=target) is True
-
-    # pylint: disable-next=protected-access
-    assert "test-device-name" in reusable_instance._get_disk_devices()
-
-    proc = reusable_instance.execute_run(
-        command=["cat", "/tmp/mnt/test.txt"],
-        capture_output=True,
-    )
-
-    assert proc.stdout == test_file.read_bytes()
-
-    reusable_instance.unmount(target=target)
-
-    assert reusable_instance.is_mounted(host_source=host_source, target=target) is False
-
-
 def test_mount_unmount_all(reusable_instance, tmp_path):
     tmp_path.chmod(0o755)
 

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -216,6 +216,39 @@ def test_mount_unmount(reusable_instance, tmp_path):
     assert reusable_instance.is_mounted(host_source=host_source, target=target) is False
 
 
+def test_mount_with_device_name_unmount(reusable_instance, tmp_path):
+    tmp_path.chmod(0o755)
+
+    host_source = tmp_path
+    target = pathlib.Path("/tmp/mnt")
+    device_name = "test-device-name"
+
+    test_file = host_source / "test.txt"
+    test_file.write_text("this is a test")
+
+    assert reusable_instance.is_mounted(host_source=host_source, target=target) is False
+
+    reusable_instance.mount_with_device_name(
+        host_source=host_source, target=target, device_name=device_name
+    )
+
+    assert reusable_instance.is_mounted(host_source=host_source, target=target) is True
+
+    # pylint: disable-next=protected-access
+    assert "test-device-name" in reusable_instance._get_disk_devices()
+
+    proc = reusable_instance.execute_run(
+        command=["cat", "/tmp/mnt/test.txt"],
+        capture_output=True,
+    )
+
+    assert proc.stdout == test_file.read_bytes()
+
+    reusable_instance.unmount(target=target)
+
+    assert reusable_instance.is_mounted(host_source=host_source, target=target) is False
+
+
 def test_mount_unmount_all(reusable_instance, tmp_path):
     tmp_path.chmod(0o755)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,14 +33,17 @@ class FakeExecutor(Executor):
     Provides a fake execution environment meant to be paired with the
     fake_subprocess fixture for complete control over execution behaviors.
 
-    This records push_file_io(), pull_file(), and push_file() in
-    records_of_<name> for introspection, similar to mock_calls.
+    Calls to each method are recorded in `records_of_<method_name>` for introspection,
+    similar to mock_calls.
     """
 
     def __init__(self) -> None:
         self.records_of_push_file_io: List[Dict[str, Any]] = []
         self.records_of_pull_file: List[Dict[str, Any]] = []
         self.records_of_push_file: List[Dict[str, Any]] = []
+        self.records_of_delete: List[Dict[str, Any]] = []
+        self.records_of_exists: List[Dict[str, Any]] = []
+        self.records_of_mount: List[Dict[str, Any]] = []
 
     def push_file_io(
         self,
@@ -114,13 +117,14 @@ class FakeExecutor(Executor):
         )
 
     def delete(self) -> None:
-        return
+        self.records_of_delete.append({})
 
     def exists(self) -> bool:
+        self.records_of_exists.append({})
         return True
 
     def mount(self, *, host_source: pathlib.Path, target: pathlib.Path) -> None:
-        return
+        self.records_of_mount.append(dict(host_source=host_source, target=target))
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -119,6 +119,9 @@ class FakeExecutor(Executor):
     def exists(self) -> bool:
         return True
 
+    def mount(self, *, host_source: pathlib.Path, target: pathlib.Path) -> None:
+        return
+
 
 @pytest.fixture
 def fake_executor():

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -31,6 +31,8 @@ from logassert import Exact  # type: ignore
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, LXDInstance
 
+# pylint: disable=too-many-lines
+
 # These names include invalid characters so a lxd-compatible instance_name
 # is generated. This ensures an Instance's `name` and `instance_name` are
 # differentiated when testing.
@@ -559,20 +561,24 @@ def test_launch_with_mknod(mock_lxc, instance):
     ]
 
 
-def test_mount(mocker, tmp_path, instance):
+def test_mount(mock_lxc, tmp_path, instance):
     """Verify `mount()` calls `mount_with_device_name()`."""
-    mock_mount_with_device_name = mocker.patch(
-        "craft_providers.lxd.lxd_instance.LXDInstance.mount_with_device_name"
-    )
-
     instance.mount(host_source=tmp_path, target=pathlib.Path("/mnt/foo"))
 
-    assert mock_mount_with_device_name.mock_calls == [
-        mock.call(
-            host_source=tmp_path,
-            target=pathlib.Path("/mnt/foo"),
-            device_name=None,
-        )
+    assert mock_lxc.mock_calls == [
+        mock.call.config_device_show(
+            instance_name=instance.instance_name,
+            project=instance.project,
+            remote=instance.remote,
+        ),
+        mock.call.config_device_add_disk(
+            instance_name=instance.instance_name,
+            source=tmp_path,
+            path=pathlib.Path("/mnt/foo"),
+            device="disk-/mnt/foo",
+            project=instance.project,
+            remote=instance.remote,
+        ),
     ]
 
 

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -31,8 +31,6 @@ from logassert import Exact  # type: ignore
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, LXDInstance
 
-# pylint: disable=too-many-lines
-
 # These names include invalid characters so a lxd-compatible instance_name
 # is generated. This ensures an Instance's `name` and `instance_name` are
 # differentiated when testing.
@@ -562,7 +560,7 @@ def test_launch_with_mknod(mock_lxc, instance):
 
 
 def test_mount(mock_lxc, tmp_path, instance):
-    """Verify `mount()` calls `mount_with_device_name()`."""
+    """Verify calls to mount a directory."""
     instance.mount(host_source=tmp_path, target=pathlib.Path("/mnt/foo"))
 
     assert mock_lxc.mock_calls == [
@@ -582,58 +580,9 @@ def test_mount(mock_lxc, tmp_path, instance):
     ]
 
 
-def test_mount_with_device_name(mock_lxc, tmp_path, instance):
-    """Verify calls to mount a directory."""
-    instance.mount_with_device_name(
-        host_source=tmp_path, target=pathlib.Path("/mnt/foo")
-    )
-
-    assert mock_lxc.mock_calls == [
-        mock.call.config_device_show(
-            instance_name=instance.instance_name,
-            project=instance.project,
-            remote=instance.remote,
-        ),
-        mock.call.config_device_add_disk(
-            instance_name=instance.instance_name,
-            source=tmp_path,
-            path=pathlib.Path("/mnt/foo"),
-            device="disk-/mnt/foo",
-            project=instance.project,
-            remote=instance.remote,
-        ),
-    ]
-
-
-def test_mount_with_device_name_specified(mock_lxc, tmp_path, instance):
-    """Parse the `device_name` argument when it is specified."""
-    instance.mount_with_device_name(
-        host_source=tmp_path, target=pathlib.Path("/mnt/foo"), device_name="disk-xfoo"
-    )
-
-    assert mock_lxc.mock_calls == [
-        mock.call.config_device_show(
-            instance_name=instance.instance_name,
-            project=instance.project,
-            remote=instance.remote,
-        ),
-        mock.call.config_device_add_disk(
-            instance_name=instance.instance_name,
-            source=tmp_path,
-            path=pathlib.Path("/mnt/foo"),
-            device="disk-xfoo",
-            project=instance.project,
-            remote=instance.remote,
-        ),
-    ]
-
-
-def test_mount_with_device_name_already_mounted(mock_lxc, instance, project_path):
+def test_mount_already_mounted(mock_lxc, instance, project_path):
     """Do not mount if directory is already mounted."""
-    instance.mount_with_device_name(
-        host_source=project_path,
-        target=pathlib.Path("/root/project"),
-    )
+    instance.mount(host_source=project_path, target=pathlib.Path("/root/project"))
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -559,8 +559,28 @@ def test_launch_with_mknod(mock_lxc, instance):
     ]
 
 
-def test_mount(mock_lxc, tmp_path, instance):
+def test_mount(mocker, tmp_path, instance):
+    """Verify `mount()` calls `mount_with_device_name()`."""
+    mock_mount_with_device_name = mocker.patch(
+        "craft_providers.lxd.lxd_instance.LXDInstance.mount_with_device_name"
+    )
+
     instance.mount(host_source=tmp_path, target=pathlib.Path("/mnt/foo"))
+
+    assert mock_mount_with_device_name.mock_calls == [
+        mock.call(
+            host_source=tmp_path,
+            target=pathlib.Path("/mnt/foo"),
+            device_name=None,
+        )
+    ]
+
+
+def test_mount_with_device_name(mock_lxc, tmp_path, instance):
+    """Verify calls to mount a directory."""
+    instance.mount_with_device_name(
+        host_source=tmp_path, target=pathlib.Path("/mnt/foo")
+    )
 
     assert mock_lxc.mock_calls == [
         mock.call.config_device_show(
@@ -579,8 +599,9 @@ def test_mount(mock_lxc, tmp_path, instance):
     ]
 
 
-def test_mount_all_opts(mock_lxc, tmp_path, instance):
-    instance.mount(
+def test_mount_with_device_name_specified(mock_lxc, tmp_path, instance):
+    """Parse the `device_name` argument when it is specified."""
+    instance.mount_with_device_name(
         host_source=tmp_path, target=pathlib.Path("/mnt/foo"), device_name="disk-xfoo"
     )
 
@@ -601,8 +622,9 @@ def test_mount_all_opts(mock_lxc, tmp_path, instance):
     ]
 
 
-def test_mount_already_mounted(mock_lxc, instance, project_path):
-    instance.mount(
+def test_mount_with_device_name_already_mounted(mock_lxc, instance, project_path):
+    """Do not mount if directory is already mounted."""
+    instance.mount_with_device_name(
         host_source=project_path,
         target=pathlib.Path("/root/project"),
     )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add `mount()` method to base Executor class.  This is required so applications can use these functions in the child classes.  This is similar to https://github.com/canonical/craft-providers/pull/140.

LXD's mount method was renamed to make room for new inherited `mount` method while still allowing access to the old method.

`LXDInstance.mount(host_source, target, device_name)` is now `LXDInstance.mount_with_device_name(host_source, target, device_name)`

None of the *craft applications use the `device_name` parameter, so there should be no impact.  

First usage will be in [rockcraft](https://github.com/canonical/rockcraft/pull/82).

(CRAFT-1383)