### PR TITLE
snap installer: get assertion for the publisher's account id

### DIFF
--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -75,7 +75,7 @@ def config_fixture(request, tmp_path, mocker):
     )
 
 
-@pytest.fixture(params=[{"revision": "2", "id": "3"}])
+@pytest.fixture(params=[{"revision": "2", "id": "3", "publisher": {"id": "4"}}])
 def mock_get_host_snap_info(request, mocker):
     """Mocks the get_host_snap_revision() function
 
@@ -122,7 +122,7 @@ def test_inject_from_host_classic(
     tmp_path,
 ):
     # register 'snap known' calls
-    for _ in range(3):
+    for _ in range(4):
         fake_process.register_subprocess(["snap", "known", fake_process.any()])
     fake_process.register_subprocess(
         [
@@ -150,7 +150,7 @@ def test_inject_from_host_classic(
         "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"
     )
 
-    assert len(fake_process.calls) == 5
+    assert len(fake_process.calls) == 6
     assert Exact("Installing snap 'test-name' from host (classic=True)") in logs.debug
     assert "Revisions found: host='2', target='1'" in logs.debug
 
@@ -178,7 +178,7 @@ def test_inject_from_host_strict(
     tmp_path,
 ):
     # register 'snap known' calls
-    for _ in range(3):
+    for _ in range(4):
         fake_process.register_subprocess(["snap", "known", fake_process.any()])
     fake_process.register_subprocess(
         [
@@ -205,7 +205,7 @@ def test_inject_from_host_strict(
         "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"
     )
 
-    assert len(fake_process.calls) == 5
+    assert len(fake_process.calls) == 6
     assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug
     assert "Revisions found: host='2', target='1'" in logs.debug
 
@@ -306,6 +306,14 @@ def test_inject_from_host_not_dangerous(
     )
     fake_process.register_subprocess(
         [
+            "snap",
+            "known",
+            "account",
+            "account-id=4",
+        ]
+    )
+    fake_process.register_subprocess(
+        [
             "fake-executor",
             "snap",
             "ack",
@@ -329,7 +337,7 @@ def test_inject_from_host_not_dangerous(
         "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"
     )
 
-    assert len(fake_process.calls) == 5
+    assert len(fake_process.calls) == 6
     assert Exact("Installing snap 'test-name' from host (classic=False)") in logs.debug
     assert "Revisions found: host='2', target='1'" in logs.debug
 
@@ -420,7 +428,7 @@ def test_inject_from_host_snapd_connection_error_using_pack_fallback(
         ]
     )
     # register 'snap known' calls
-    for _ in range(3):
+    for _ in range(4):
         fake_process.register_subprocess(["snap", "known", fake_process.any()])
     fake_process.register_subprocess(
         [
@@ -446,7 +454,7 @@ def test_inject_from_host_snapd_connection_error_using_pack_fallback(
     assert mock_requests.mock_calls == [
         mock.call.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps/test-name/file"),
     ]
-    assert len(fake_process.calls) == 6
+    assert len(fake_process.calls) == 7
 
 
 def test_inject_from_host_snapd_http_error_using_pack_fallback(
@@ -469,7 +477,7 @@ def test_inject_from_host_snapd_http_error_using_pack_fallback(
         ]
     )
     # register 'snap known' calls
-    for _ in range(3):
+    for _ in range(4):
         fake_process.register_subprocess(["snap", "known", fake_process.any()])
     fake_process.register_subprocess(
         [
@@ -497,7 +505,7 @@ def test_inject_from_host_snapd_http_error_using_pack_fallback(
         mock.call.get().raise_for_status(),
     ]
 
-    assert len(fake_process.calls) == 6
+    assert len(fake_process.calls) == 7
 
 
 def test_inject_from_host_install_failure(
@@ -759,7 +767,7 @@ def test_add_assertions_from_host_error_on_push(
     )
 
     # register 'snap known' calls
-    for _ in range(3):
+    for _ in range(4):
         fake_process.register_subprocess(["snap", "known", fake_process.any()])
 
     with pytest.raises(snap_installer.SnapInstallationError) as exc_info:
@@ -773,6 +781,7 @@ def test_add_assertions_from_host_error_on_push(
         details="error copying snap assert file into target environment",
     )
     assert exc_info.value.__cause__ is not None
+    assert len(fake_process.calls) == 4
 
 
 def test_add_assertions_from_host_error_on_ack(
@@ -789,7 +798,7 @@ def test_add_assertions_from_host_error_on_ack(
     )
 
     # register 'snap known' calls
-    for _ in range(3):
+    for _ in range(4):
         fake_process.register_subprocess(["snap", "known", fake_process.any()])
 
     with pytest.raises(snap_installer.SnapInstallationError) as exc_info:
@@ -804,7 +813,7 @@ def test_add_assertions_from_host_error_on_ack(
         ),
     )
 
-    assert len(fake_process.calls) == 4
+    assert len(fake_process.calls) == 5
 
 
 def test_get_target_snap_revision_from_snapd_process_error(fake_process, fake_executor):


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
### Overview
Adds another assertion when injecting a snap into a provider.

### Details
@tigarmo and I saw this problem with revision 309 of rockcraft.  The snap's publisher was unverified and produced the error:
```
error: cannot assert: assert failed: cannot resolve prerequisite assertion: account (pMLNwd28ezFdozetvrAOlLj3UqC9HKpe)
```

Looking into `rockcraft`'s snap info, it contains a publisher with a matching account id:
```
'publisher': {
  'id': 'pMLNwd28ezFdozetvrAOlLj3UqC9HKpe',
  'username': 'sergiusens',
  'display-name': 'Sergio Schvezov',
  'validation': 'unproven'
}
```
I assume the key `'validation': 'unproven'` is causing the error.

To resolve this, `craft-providers` now collects the publisher account with `snap known account account-id=pMLNwd28ezFdozetvrAOlLj3UqC9HKpe`

The assertion looks like this:
```
type: account
authority-id: canonical
revision: 223
account-id: pMLNwd28ezFdozetvrAOlLj3UqC9HKpe
display-name: Sergio Schvezov
timestamp: 2022-09-23T08:30:19.896972Z
username: sergiusens
validation: unproven
sign-key-sha3-384: BWDEoaqyr25nF5SNCvEv2v7QnM9QsfCc0PBMYD_i2NGSQ32EF2d4D0hqUel3m8ul

...
```

It appears to be a working and valid solution for the current rockcraft snap.  There are no regressions for snapcraft or charmcraft.