### PR TITLE
providers: add Provider, LXDProvider, and MultipassProvider classes

### DIFF
--- a/craft_providers/__init__.py
+++ b/craft_providers/__init__.py
@@ -22,9 +22,11 @@ __version__ = "1.5.1"  # noqa: F401
 from .base import Base  # noqa: F401
 from .errors import ProviderError  # noqa: F401
 from .executor import Executor  # noqa: F401
+from .provider import Provider  # noqa: f401
 
 __all__ = [
     "Base",
     "Executor",
     "ProviderError",
+    "Provider",
 ]

--- a/craft_providers/lxd/__init__.py
+++ b/craft_providers/lxd/__init__.py
@@ -29,6 +29,7 @@ from .launcher import launch  # noqa: F401
 from .lxc import LXC  # noqa: F401
 from .lxd import LXD  # noqa: F401
 from .lxd_instance import LXDInstance  # noqa: F401
+from .lxd_provider import PROVIDER_BASE_TO_LXD_BASE, LXDProvider  # noqa: F401
 from .remotes import configure_buildd_image_remote  # noqa: F401
 
 __all__ = [
@@ -37,6 +38,8 @@ __all__ = [
     "LXDInstance",
     "LXDError",
     "LXDInstallationError",
+    "LXDProvider",
+    "PROVIDER_BASE_TO_LXD_BASE",
     "install",
     "is_installed",
     "is_initialized",

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2022 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """LXD Provider class."""

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -1,0 +1,147 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""LXD Provider class."""
+
+import contextlib
+import logging
+import pathlib
+from typing import Generator
+
+from craft_providers import Executor, Provider
+from craft_providers.base import Base
+from craft_providers.bases import BaseConfigurationError, BuilddBaseAlias
+
+from .errors import LXDError
+from .installer import ensure_lxd_is_ready, install, is_installed
+from .launcher import launch
+from .lxc import LXC
+from .lxd_instance import LXDInstance
+from .remotes import configure_buildd_image_remote
+
+logger = logging.getLogger(__name__)
+
+
+PROVIDER_BASE_TO_LXD_BASE = {
+    BuilddBaseAlias.BIONIC.value: "core18",
+    BuilddBaseAlias.FOCAL.value: "core20",
+    BuilddBaseAlias.JAMMY.value: "core22",
+}
+
+
+class LXDProvider(Provider):
+    """LXD build environment provider.
+
+    This class is not stable and is likely to change. This class will be stable and
+    recommended for use in the release of craft-providers 2.0.
+
+    :param lxc: Optional lxc client to use.
+    :param lxd_project: LXD project to use (default is default).
+    :param lxd_remote: LXD remote to use (default is local).
+    """
+
+    def __init__(
+        self,
+        *,
+        lxc: LXC = LXC(),
+        lxd_project: str = "default",
+        lxd_remote: str = "local",
+    ) -> None:
+        self.lxc = lxc
+        self.lxd_project = lxd_project
+        self.lxd_remote = lxd_remote
+
+    @classmethod
+    def ensure_provider_is_available(cls) -> None:
+        """Ensure provider is available and ready, installing if required.
+
+        :raises LXDInstallationError: if LXD cannot be installed
+        :raises LXDError: if provider is not available
+        """
+        if not is_installed():
+            install()
+        ensure_lxd_is_ready()
+
+    @classmethod
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
+
+        :returns: True if installed.
+        """
+        return is_installed()
+
+    def create_environment(self, *, instance_name: str) -> Executor:
+        """Create a bare environment for specified base.
+
+        No initializing, launching, or cleaning up of the environment occurs.
+
+        :param instance_name: Name of the instance.
+        """
+        return LXDInstance(
+            name=instance_name,
+            project=self.lxd_project,
+            remote=self.lxd_remote,
+        )
+
+    @contextlib.contextmanager
+    def launched_environment(
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        base_configuration: Base,
+        build_base: str,
+        instance_name: str,
+    ) -> Generator[Executor, None, None]:
+        """Configure and launch environment for specified base.
+
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
+
+        :param project_name: Name of project.
+        :param project_path: Path to project.
+        :param base_configuration: Base configuration to apply to instance.
+        :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
+
+        :raises LXDError: if instance cannot be configured and launched
+        """
+        image_remote = configure_buildd_image_remote()
+
+        try:
+            instance = launch(
+                name=instance_name,
+                base_configuration=base_configuration,
+                image_name=PROVIDER_BASE_TO_LXD_BASE[build_base],
+                image_remote=image_remote,
+                auto_clean=True,
+                auto_create_project=True,
+                map_user_uid=True,
+                uid=project_path.stat().st_uid,
+                use_snapshots=True,
+                project=self.lxd_project,
+                remote=self.lxd_remote,
+            )
+        except (BaseConfigurationError) as error:
+            raise LXDError(str(error)) from error
+
+        try:
+            yield instance
+        finally:
+            # Ensure to unmount everything and stop instance upon completion.
+            instance.unmount_all()
+            instance.stop()

--- a/craft_providers/multipass/__init__.py
+++ b/craft_providers/multipass/__init__.py
@@ -23,12 +23,18 @@ from .errors import MultipassError, MultipassInstallationError  # noqa: F401
 from .installer import install, is_installed  # noqa: F401
 from .multipass import Multipass  # noqa: F401
 from .multipass_instance import MultipassInstance  # noqa: F401
+from .multipass_provider import (  # noqa: F401
+    PROVIDER_BASE_TO_MULTIPASS_BASE,
+    MultipassProvider,
+)
 
 __all__ = [
     "Multipass",
     "MultipassInstance",
     "MultipassError",
     "MultipassInstallationError",
+    "MultipassProvider",
+    "PROVIDER_BASE_TO_MULTIPASS_BASE",
     "install",
     "is_installed",
     "ensure_multipass_is_ready",

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2022 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Multipass Provider class."""

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -1,0 +1,122 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Multipass Provider class."""
+
+import contextlib
+import logging
+import pathlib
+from typing import Generator
+
+from craft_providers import Executor, Provider, base, bases
+
+from ._launch import launch
+from ._ready import ensure_multipass_is_ready
+from .errors import MultipassError
+from .installer import install, is_installed
+from .multipass import Multipass
+from .multipass_instance import MultipassInstance
+
+logger = logging.getLogger(__name__)
+
+
+PROVIDER_BASE_TO_MULTIPASS_BASE = {
+    bases.BuilddBaseAlias.BIONIC.value: "snapcraft:18.04",
+    bases.BuilddBaseAlias.FOCAL.value: "snapcraft:20.04",
+    bases.BuilddBaseAlias.JAMMY.value: "snapcraft:22.04",
+}
+
+
+class MultipassProvider(Provider):
+    """Multipass build environment provider.
+
+    This class is not stable and is likely to change. This class will be stable and
+    recommended for use in the release of craft-providers 2.0.
+
+    :param multipass: Optional Multipass client to use.
+    """
+
+    def __init__(self, instance: Multipass = Multipass()) -> None:
+        self.multipass = instance
+
+    @classmethod
+    def ensure_provider_is_available(cls) -> None:
+        """Ensure provider is available, prompting the user to install it if required.
+
+        :raises MultipassError: if provider is not available.
+        """
+        if not is_installed():
+            install()
+        ensure_multipass_is_ready()
+
+    def create_environment(self, *, instance_name: str) -> Executor:
+        """Create a bare environment for specified base.
+
+        No initializing, launching, or cleaning up of the environment occurs.
+
+        :param name: Name of the instance.
+        """
+        return MultipassInstance(name=instance_name)
+
+    @classmethod
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
+
+        :returns: True if installed.
+        """
+        return is_installed()
+
+    @contextlib.contextmanager
+    def launched_environment(
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        base_configuration: base.Base,
+        build_base: str,
+        instance_name: str,
+    ) -> Generator[Executor, None, None]:
+        """Configure and launch environment for specified base.
+
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
+
+        :param project_name: Name of the project.
+        :param project_path: Path to project.
+        :param base_configuration: Base configuration to apply to instance.
+        :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
+        """
+        try:
+            instance = launch(
+                name=instance_name,
+                base_configuration=base_configuration,
+                image_name=PROVIDER_BASE_TO_MULTIPASS_BASE[build_base],
+                cpus=2,
+                disk_gb=64,
+                mem_gb=2,
+                auto_clean=True,
+            )
+        except (bases.BaseConfigurationError) as error:
+            raise MultipassError(str(error)) from error
+
+        try:
+            yield instance
+        finally:
+            # Ensure to unmount everything and stop instance upon completion.
+            instance.unmount_all()
+            instance.stop()

--- a/craft_providers/provider.py
+++ b/craft_providers/provider.py
@@ -1,0 +1,102 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Abstract base class for Providers.
+
+The Provider, LXDProvider, and MultipassProvider classes are not stable and are
+likely to change. These classes will be stable and recommended for use in the release
+of craft-providers 2.0.
+"""
+
+import contextlib
+import logging
+import pathlib
+from abc import ABC, abstractmethod
+from typing import Generator
+
+from .base import Base
+from .executor import Executor
+
+logger = logging.getLogger(__name__)
+
+
+class Provider(ABC):
+    """Build environment provider."""
+
+    def clean_project_environments(self, *, instance_name: str) -> None:
+        """Clean the provider environment.
+
+        :param instance_name: name of the instance to clean
+        """
+        # Nothing to do if provider is not installed.
+        if not self.is_provider_installed():
+            logger.debug(
+                "Not cleaning environment because the provider is not installed."
+            )
+            return
+
+        environment = self.create_environment(instance_name=instance_name)
+        if environment.exists():
+            environment.delete()
+
+    @classmethod
+    @abstractmethod
+    def ensure_provider_is_available(cls) -> None:
+        """Ensure provider is available, prompting the user to install it if required.
+
+        :raises ProviderError: if provider is not available.
+        """
+
+    @classmethod
+    @abstractmethod
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
+
+        :returns: True if installed.
+        """
+
+    @abstractmethod
+    def create_environment(self, *, instance_name: str) -> Executor:
+        """Create a bare environment for specified base.
+
+        No initializing, launching, or cleaning up of the environment occurs.
+
+        :param instance_name: name of the instance to create
+        """
+
+    @abstractmethod
+    @contextlib.contextmanager
+    def launched_environment(
+        self,
+        *,
+        project_name: str,
+        project_path: pathlib.Path,
+        base_configuration: Base,
+        build_base: str,
+        instance_name: str,
+    ) -> Generator[Executor, None, None]:
+        """Configure and launch environment for specified base.
+
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
+
+        :param project_name: Name of project.
+        :param project_path: Path to project.
+        :param base_configuration: Base configuration to apply to instance.
+        :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
+        """

--- a/craft_providers/provider.py
+++ b/craft_providers/provider.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2022 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Abstract base class for Providers.

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -1,0 +1,59 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+from craft_providers.bases import BuilddBase, BuilddBaseAlias
+from craft_providers.lxd import LXDProvider, is_installed
+
+
+def test_ensure_provider_is_available_not_installed(uninstalled_lxd):
+    """Verify lxd is installed and configured."""
+    assert is_installed() is False
+    provider = LXDProvider()
+    provider.ensure_provider_is_available()
+
+
+def test_ensure_provider_is_available_installed(installed_lxd):
+    """Verify lxd is installed and configured."""
+    assert is_installed() is True
+    provider = LXDProvider()
+    provider.ensure_provider_is_available()
+
+
+def test_create_environment(installed_lxd, instance_name):
+    provider = LXDProvider()
+    test_instance = provider.create_environment(instance_name=instance_name)
+    assert test_instance.exists() is False
+
+
+def test_launched_environment(installed_lxd, instance_name, tmp_path):
+    provider = LXDProvider()
+
+    base_configuration = BuilddBase(alias=BuilddBaseAlias.JAMMY)
+
+    with provider.launched_environment(
+        project_name="test-project",
+        project_path=tmp_path,
+        base_configuration=base_configuration,
+        build_base=BuilddBaseAlias.JAMMY.value,
+        instance_name=instance_name,
+    ) as test_instance:
+        assert test_instance.exists() is True
+        assert test_instance.is_running() is True
+
+    assert test_instance.exists() is True
+    assert test_instance.is_running() is False

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -1,0 +1,62 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+from craft_providers.bases import BuilddBase, BuilddBaseAlias
+from craft_providers.multipass import MultipassProvider, is_installed
+
+
+def test_ensure_provider_is_available_not_installed(uninstalled_multipass):
+    """Verify multipass is installed and configured."""
+    assert is_installed() is False
+    provider = MultipassProvider()
+    provider.ensure_provider_is_available()
+
+
+def test_ensure_provider_is_available_installed(installed_multipass):
+    """Verify multipass is installed and configured."""
+    assert is_installed() is True
+    provider = MultipassProvider()
+    provider.ensure_provider_is_available()
+
+
+def test_create_environment(installed_multipass, instance_name):
+    """Verify create environment does not produce an error."""
+    provider = MultipassProvider()
+    test_instance = provider.create_environment(instance_name=instance_name)
+    assert test_instance.exists() is False
+
+
+def test_launched_environment(installed_multipass, instance_name, tmp_path):
+    """Verify `launched_environment()` creates and starts an instance then stops
+    the instance when the method loses context."""
+    provider = MultipassProvider()
+
+    base_configuration = BuilddBase(alias=BuilddBaseAlias.JAMMY)
+
+    with provider.launched_environment(
+        project_name="test-project",
+        project_path=tmp_path,
+        base_configuration=base_configuration,
+        build_base=BuilddBaseAlias.JAMMY.value,
+        instance_name=instance_name,
+    ) as test_instance:
+        assert test_instance.exists() is True
+        assert test_instance.is_running() is True
+
+    assert test_instance.exists() is True
+    assert test_instance.is_running() is False

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2022 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import mock

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -1,0 +1,186 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+import pytest
+
+from craft_providers import bases
+from craft_providers.lxd import LXDError, LXDProvider
+
+
+@pytest.fixture
+def mock_buildd_base_configuration(mocker):
+    mock_base_config = mocker.patch("craft_providers.bases.BuilddBase", autospec=True)
+    mock_base_config.compatibility_tag = "buildd-base-v0"
+    yield mock_base_config
+
+
+@pytest.fixture
+def mock_configure_buildd_image_remote(mocker):
+    yield mocker.patch(
+        "craft_providers.lxd.lxd_provider.configure_buildd_image_remote",
+        return_value="buildd-remote",
+    )
+
+
+@pytest.fixture
+def mock_lxc(mocker):
+    yield mocker.patch("craft_providers.lxd.LXC", autospec=True)
+
+
+@pytest.fixture(autouse=True)
+def mock_ensure_lxd_is_ready(mocker):
+    yield mocker.patch(
+        "craft_providers.lxd.lxd_provider.ensure_lxd_is_ready", return_value=None
+    )
+
+
+@pytest.fixture
+def mock_install(mocker):
+    yield mocker.patch("craft_providers.lxd.lxd_provider.install")
+
+
+@pytest.fixture(autouse=True)
+def mock_is_installed(mocker):
+    yield mocker.patch(
+        "craft_providers.lxd.lxd_provider.is_installed", return_value=True
+    )
+
+
+@pytest.fixture
+def mock_launch(mocker):
+    yield mocker.patch("craft_providers.lxd.lxd_provider.launch", autospec=True)
+
+
+def test_ensure_provider_is_available_installed(
+    mock_is_installed, mock_install, mock_ensure_lxd_is_ready
+):
+    """Verify LXD is installed if it is not already installed."""
+    mock_is_installed.return_value = True
+    provider = LXDProvider()
+
+    provider.ensure_provider_is_available()
+
+    mock_install.assert_not_called()
+    mock_ensure_lxd_is_ready.assert_called_once()
+
+
+def test_ensure_provider_is_available_not_installed(
+    mock_is_installed, mock_install, mock_ensure_lxd_is_ready
+):
+    """Verify LXD is not re-installed if it is already installed."""
+    mock_is_installed.return_value = False
+    provider = LXDProvider()
+
+    provider.ensure_provider_is_available()
+
+    mock_install.assert_called_once()
+    mock_ensure_lxd_is_ready.assert_called_once()
+
+
+@pytest.mark.parametrize("is_installed", [True, False])
+def test_is_provider_installed(is_installed, mock_is_installed):
+    """Verify `is_provider_installed` checks if LXD is actually installed."""
+    mock_is_installed.return_value = is_installed
+    provider = LXDProvider()
+
+    assert provider.is_provider_installed() == is_installed
+
+
+def test_create_environment(mocker):
+    mock_lxd_instance = mocker.patch("craft_providers.lxd.lxd_provider.LXDInstance")
+
+    provider = LXDProvider()
+    provider.create_environment(instance_name="test-name")
+
+    mock_lxd_instance.assert_called_once_with(
+        name="test-name", project="default", remote="local"
+    )
+
+
+@pytest.mark.parametrize(
+    "build_base, lxd_base",
+    [
+        (bases.BuilddBaseAlias.BIONIC.value, "core18"),
+        (bases.BuilddBaseAlias.FOCAL.value, "core20"),
+        (bases.BuilddBaseAlias.JAMMY.value, "core22"),
+    ],
+)
+def test_launched_environment(
+    build_base,
+    lxd_base,
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_launch,
+    tmp_path,
+):
+    provider = LXDProvider()
+
+    with provider.launched_environment(
+        project_name="test-project",
+        project_path=tmp_path,
+        base_configuration=mock_buildd_base_configuration,
+        build_base=build_base,
+        instance_name="test-instance-name",
+    ) as instance:
+        assert instance is not None
+        assert mock_configure_buildd_image_remote.mock_calls == [mock.call()]
+        assert mock_launch.mock_calls == [
+            mock.call(
+                name="test-instance-name",
+                base_configuration=mock_buildd_base_configuration,
+                image_name=lxd_base,
+                image_remote="buildd-remote",
+                auto_clean=True,
+                auto_create_project=True,
+                map_user_uid=True,
+                uid=tmp_path.stat().st_uid,
+                use_snapshots=True,
+                project="default",
+                remote="local",
+            ),
+        ]
+
+        mock_launch.reset_mock()
+
+    assert mock_launch.mock_calls == [
+        mock.call().unmount_all(),
+        mock.call().stop(),
+    ]
+
+
+def test_launched_environment_launch_base_configuration_error(
+    mock_buildd_base_configuration,
+    mock_configure_buildd_image_remote,
+    mock_launch,
+    tmp_path,
+):
+    error = bases.BaseConfigurationError(brief="fail")
+    mock_launch.side_effect = error
+    provider = LXDProvider()
+
+    with pytest.raises(LXDError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2022 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import mock

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -1,0 +1,173 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+import pytest
+
+from craft_providers import bases
+from craft_providers.multipass import MultipassError, MultipassProvider
+
+
+@pytest.fixture
+def mock_buildd_base_configuration(mocker):
+    mock_base_config = mocker.patch("craft_providers.bases.BuilddBase", autospec=True)
+    mock_base_config.compatibility_tag = "buildd-base-v0"
+    yield mock_base_config
+
+
+@pytest.fixture
+def mock_multipass(mocker):
+    yield mocker.patch("craft_providers.multipass.Multipass", autospec=True)
+
+
+@pytest.fixture(autouse=True)
+def mock_ensure_multipass_is_ready(mocker):
+    yield mocker.patch(
+        "craft_providers.multipass.multipass_provider.ensure_multipass_is_ready",
+        return_value=None,
+    )
+
+
+@pytest.fixture
+def mock_install(mocker):
+    yield mocker.patch("craft_providers.multipass.multipass_provider.install")
+
+
+@pytest.fixture(autouse=True)
+def mock_is_installed(mocker):
+    yield mocker.patch(
+        "craft_providers.multipass.multipass_provider.is_installed", return_value=True
+    )
+
+
+@pytest.fixture
+def mock_launch(mocker):
+    yield mocker.patch(
+        "craft_providers.multipass.multipass_provider.launch", autospec=True
+    )
+
+
+def test_ensure_provider_is_available_installed(
+    mock_is_installed, mock_install, mock_ensure_multipass_is_ready
+):
+    """Verify multipass is installed if it is not already installed."""
+    mock_is_installed.return_value = True
+    provider = MultipassProvider()
+
+    provider.ensure_provider_is_available()
+
+    mock_is_installed.assert_called_once()
+    mock_install.assert_not_called()
+    mock_ensure_multipass_is_ready.assert_called_once()
+
+
+def test_ensure_provider_is_available_not_installed(
+    mock_is_installed, mock_install, mock_ensure_multipass_is_ready
+):
+    """Verify multipass is not re-installed if it is already installed."""
+    mock_is_installed.return_value = False
+    provider = MultipassProvider()
+
+    provider.ensure_provider_is_available()
+
+    mock_is_installed.assert_called_once()
+    mock_install.assert_called_once()
+    mock_ensure_multipass_is_ready.assert_called_once()
+
+
+@pytest.mark.parametrize("is_installed", [True, False])
+def test_is_provider_installed(is_installed, mock_is_installed):
+    """Verify `is_provider_installed` checks if Multipass is actually installed."""
+    mock_is_installed.return_value = is_installed
+    provider = MultipassProvider()
+
+    assert provider.is_provider_installed() == is_installed
+
+
+def test_create_environment(mocker):
+    mock_multipass_instance = mocker.patch(
+        "craft_providers.multipass.multipass_provider.MultipassInstance"
+    )
+
+    provider = MultipassProvider()
+    provider.create_environment(instance_name="test-name")
+
+    mock_multipass_instance.assert_called_once_with(name="test-name")
+
+
+@pytest.mark.parametrize(
+    "build_base, multipass_base",
+    [
+        (bases.BuilddBaseAlias.BIONIC.value, "snapcraft:18.04"),
+        (bases.BuilddBaseAlias.FOCAL.value, "snapcraft:20.04"),
+        (bases.BuilddBaseAlias.JAMMY.value, "snapcraft:22.04"),
+    ],
+)
+def test_launched_environment(
+    build_base,
+    multipass_base,
+    mock_buildd_base_configuration,
+    mock_launch,
+    tmp_path,
+):
+    provider = MultipassProvider()
+
+    with provider.launched_environment(
+        project_name="test-project",
+        project_path=tmp_path,
+        base_configuration=mock_buildd_base_configuration,
+        build_base=build_base,
+        instance_name="test-instance-name",
+    ) as instance:
+        assert instance is not None
+        assert mock_launch.mock_calls == [
+            mock.call(
+                name="test-instance-name",
+                base_configuration=mock_buildd_base_configuration,
+                image_name=multipass_base,
+                cpus=2,
+                disk_gb=64,
+                mem_gb=2,
+                auto_clean=True,
+            ),
+        ]
+        mock_launch.reset_mock()
+
+    assert mock_launch.mock_calls == [
+        mock.call().unmount_all(),
+        mock.call().stop(),
+    ]
+
+
+def test_launched_environment_launch_base_configuration_error(
+    mock_buildd_base_configuration, mock_launch, tmp_path
+):
+    error = bases.BaseConfigurationError(brief="fail")
+    mock_launch.side_effect = error
+    provider = MultipassProvider()
+
+    with pytest.raises(MultipassError, match="fail") as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value.__cause__ is error

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,0 +1,142 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pytest
+
+from craft_providers import ProviderError
+from craft_providers.lxd import LXDError, LXDProvider
+from craft_providers.multipass import MultipassError, MultipassProvider
+
+known_provider_classes = [LXDProvider, MultipassProvider]
+
+
+@pytest.fixture(params=known_provider_classes)
+def provider_class(request):
+    return request.param
+
+
+@pytest.fixture(autouse=True)
+def mock_lxd_delete(mocker):
+    yield mocker.patch("craft_providers.lxd.LXDInstance.delete")
+
+
+@pytest.fixture(autouse=True)
+def mock_lxd_exists(mocker):
+    yield mocker.patch("craft_providers.lxd.LXDInstance.exists", return_value=True)
+
+
+@pytest.fixture(autouse=True)
+def mock_lxd_is_installed(mocker):
+    yield mocker.patch(
+        "craft_providers.lxd.lxd_provider.is_installed", return_value=True
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_multipass_delete(mocker):
+    yield mocker.patch("craft_providers.multipass.MultipassInstance.delete")
+
+
+@pytest.fixture(autouse=True)
+def mock_multipass_exists(mocker):
+    yield mocker.patch(
+        "craft_providers.multipass.MultipassInstance.exists", return_value=True
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_multipass_is_installed(mocker):
+    yield mocker.patch(
+        "craft_providers.multipass.multipass_provider.is_installed", return_value=True
+    )
+
+
+def test_clean_project_environment_exists(
+    mock_lxd_delete, mock_multipass_delete, provider_class
+):
+    """Assert instance is deleted if it exists."""
+    provider = provider_class()
+    provider.clean_project_environments(instance_name="test-name")
+
+    if isinstance(provider, LXDProvider):
+        mock_lxd_delete.assert_called_once()
+    else:
+        mock_multipass_delete.assert_called_once()
+
+
+def test_clean_project_environment_does_not_exist(
+    mock_lxd_exists,
+    mock_lxd_delete,
+    mock_multipass_exists,
+    mock_multipass_delete,
+    provider_class,
+):
+    """Assert instance is not deleted if it does not exist."""
+    mock_lxd_exists.return_value = False
+    mock_multipass_exists.return_value = False
+
+    provider = provider_class()
+    provider.clean_project_environments(instance_name="test-name")
+
+    mock_lxd_delete.assert_not_called()
+    mock_multipass_delete.assert_not_called()
+
+
+def test_clean_project_environment_not_installed(
+    mock_lxd_delete,
+    mock_lxd_is_installed,
+    mock_multipass_delete,
+    mock_multipass_is_installed,
+    provider_class,
+):
+    """Assert instance is not deleted if the provider is not installed."""
+    mock_lxd_is_installed.return_value = False
+    mock_multipass_is_installed.return_value = False
+
+    provider = provider_class()
+    provider.clean_project_environments(instance_name="test-name")
+
+    mock_lxd_delete.assert_not_called()
+    mock_multipass_delete.assert_not_called()
+
+
+def test_clean_project_environment_exists_error(
+    mock_lxd_exists, mock_multipass_exists, provider_class
+):
+    """Assert error on `exists` call is caught."""
+    mock_lxd_exists.side_effect = LXDError("fail")
+    mock_multipass_exists.side_effect = MultipassError("fail")
+    provider = provider_class()
+
+    with pytest.raises(ProviderError) as raised:
+        provider.clean_project_environments(instance_name="test-name")
+
+    assert str(raised.value) == "fail"
+
+
+def test_clean_project_environment_delete_error(
+    mock_lxd_delete, mock_multipass_delete, provider_class
+):
+    """Assert error on `delete` call is caught."""
+    mock_lxd_delete.side_effect = LXDError("fail")
+    mock_multipass_delete.side_effect = MultipassError("fail")
+    provider = provider_class()
+
+    with pytest.raises(ProviderError) as raised:
+        provider.clean_project_environments(instance_name="test-name")
+
+    assert str(raised.value) == "fail"

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -2,18 +2,17 @@
 #
 # Copyright 2022 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 
 import pytest
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add Provider, LXDProvider, and MultipassProvider classes.

These classes are near-duplicates of the classes in rockcraft (links for [provider](https://github.com/canonical/rockcraft/blob/4cfd6c8bac0b112127d420c8a3a1c6b0f3033ab5/rockcraft/providers/_provider.py), [lxd](https://github.com/canonical/rockcraft/blob/4cfd6c8bac0b112127d420c8a3a1c6b0f3033ab5/rockcraft/providers/_lxd.py), and [multipass](https://github.com/canonical/rockcraft/blob/4cfd6c8bac0b112127d420c8a3a1c6b0f3033ab5/rockcraft/providers/_multipass.py))

There are a few minor differences:
1. changes to `import` statements and `__init__.py` files
2. Simplified error handling in methods `ensure_provider_is_available()` and `launched_environment()`
    - For example, there is no need to catch a `LXDError` and raise a `ProviderError`, since `LXDError` is a child of a `ProviderError`.  This simplification is completely compatible with error handling inside the *craft tools.
3. New integration tests for the provider classes

I've tested this with rockcraft and it works great!

(CRAFT-1360, CRAFT-1361, CRAFT-1362)