### PR TITLE
executor: add `is_running()` method to base Executor class

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -179,3 +179,10 @@ class Executor(ABC):
     @abstractmethod
     def mount(self, *, host_source: pathlib.Path, target: pathlib.Path) -> None:
         """Mount host source directory to target mount point."""
+
+    @abstractmethod
+    def is_running(self) -> bool:
+        """Check if instance is running.
+
+        :returns: True if instance is running.
+        """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -44,6 +44,7 @@ class FakeExecutor(Executor):
         self.records_of_delete: List[Dict[str, Any]] = []
         self.records_of_exists: List[Dict[str, Any]] = []
         self.records_of_mount: List[Dict[str, Any]] = []
+        self.records_of_is_running: List[Dict[str, Any]] = []
 
     def push_file_io(
         self,
@@ -125,6 +126,10 @@ class FakeExecutor(Executor):
 
     def mount(self, *, host_source: pathlib.Path, target: pathlib.Path) -> None:
         self.records_of_mount.append(dict(host_source=host_source, target=target))
+
+    def is_running(self) -> bool:
+        self.records_of_is_running.append({})
+        return True
 
 
 @pytest.fixture


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add `is_running()` method to base Executor class. 

Needed for this PR: https://github.com/canonical/craft-providers/pull/163