### PR TITLE
executor: store temporary files in the home directory

### DIFF
--- a/craft_providers/util/temp_paths.py
+++ b/craft_providers/util/temp_paths.py
@@ -27,8 +27,7 @@ from typing import Iterator
 def home_temporary_directory() -> Iterator[pathlib.Path]:
     """Create temporary directory in home directory where Multipass has access."""
     with tempfile.TemporaryDirectory(
-        suffix=".tmp-craft",
-        dir=pathlib.Path.home(),
+        suffix=".tmp-craft", dir=pathlib.Path.home()
     ) as tmp_dir:
         yield pathlib.Path(tmp_dir)
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Multipass has access to the user's home directory, but not to arbitrary directories (e.g. `/mnt/`) due to snap confinement. Files pulled from an executor need to be stored in the home directory.

source: https://forum.snapcraft.io/t/call-for-testing-snapcraft-7-2-0/32171/10