### PR TITLE
buildd: avoid getent hangs

### DIFF
--- a/craft_providers/bases/errors.py
+++ b/craft_providers/bases/errors.py
@@ -26,6 +26,15 @@ class BaseConfigurationError(ProviderError):
     """Error configuring the base."""
 
 
+class NetworkError(ProviderError):
+    """Network error when configuring the base."""
+
+    def __init__(self) -> None:
+        brief = "A network related operation failed in a context of no network access."
+        resolution = "Verify that the environment has internet connectivity."
+        super().__init__(brief=brief, resolution=resolution)
+
+
 class BaseCompatibilityError(ProviderError):
     """Base configuration compatibility error.
 


### PR DESCRIPTION
Also removed several `capture_output=True` for the cases where the captured output was actually not used.