### PR TITLE
buildd: check internet after network command fails (CRAFT-1461)

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -80,9 +80,9 @@ def _check_deadline(
 
 def _network_connected(executor):
     """Check if the network is connected."""
-    # check if the port is open using bash's built-in tcp-client (1.1.1.1 is a well
-    # known DNS server, 53 is the DNS port)
-    command = ["bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"]
+    # check if the port is open using bash's built-in tcp-client, communicating with
+    # the to HTTPS port on our site
+    command = ["bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"]
     try:
         # timeout quickly, so it's representative of current state (we don't
         # want for it to hang a lot and then succeed 45 seconds later if network

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -81,7 +81,7 @@ def _check_deadline(
 def _network_connected(executor):
     """Check if the network is connected."""
     # check if the port is open using bash's built-in tcp-client, communicating with
-    # the to HTTPS port on our site
+    # the HTTPS port on our site
     command = ["bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"]
     try:
         # timeout quickly, so it's representative of current state (we don't

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -19,6 +19,7 @@
 import enum
 import io
 import logging
+import os
 import pathlib
 import re
 import subprocess
@@ -80,6 +81,12 @@ def _check_deadline(
 
 def _network_connected(executor):
     """Check if the network is connected."""
+    # bypass the network verification if there is a proxy set for HTTPS (because we're
+    # hitting port 443), as bash's TCP functionality will not use it (supporting
+    # both lowercase and uppercase names, which is what most applications do)
+    if os.getenv("HTTPS_PROXY") or os.getenv("https_proxy"):
+        return True
+
     # check if the port is open using bash's built-in tcp-client, communicating with
     # the HTTPS port on our site
     command = ["bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"]

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -86,7 +86,7 @@ def _network_connected(executor):
     try:
         # timeout quickly, so it's representative of current state (we don't
         # want for it to hang a lot and then succeed 45 seconds later if network
-        # came back)
+        # came back); capture the output just for it to not pollute the terminal
         proc = executor.execute_run(
             command, check=False, timeout=1, capture_output=True
         )

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -35,7 +35,7 @@ from craft_providers import Base, Executor, errors
 from craft_providers.actions import snap_installer
 from craft_providers.util.os_release import parse_os_release
 
-from .errors import BaseCompatibilityError, BaseConfigurationError
+from .errors import BaseCompatibilityError, BaseConfigurationError, NetworkError
 from .instance_config import InstanceConfiguration
 
 logger = logging.getLogger(__name__)
@@ -76,6 +76,57 @@ def _check_deadline(
     """
     if deadline is not None and time.time() >= deadline:
         raise BaseConfigurationError(brief=message)
+
+
+def _network_connected(executor):
+    """Check if the network is connected."""
+    # check if the port is open using bash's built-in tcp-client (1.1.1.1 is a well
+    # known DNS server, 53 is the DNS port)
+    command = ["bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"]
+    try:
+        # timeout quickly, so it's representative of current state (we don't
+        # want for it to hang a lot and then succeed 45 seconds later if network
+        # came back)
+        proc = executor.execute_run(
+            command, check=False, timeout=1, capture_output=True
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    return proc.returncode == 0
+
+
+def _execute_run(
+    executor: Executor,
+    command: List[str],
+    *,
+    check: bool = True,
+    capture_output: bool = True,
+    text: bool = False,
+    verify_network=False,
+) -> subprocess.CompletedProcess:
+    """Run a command through the executor.
+
+    This is a helper to simplify most common calls and provide extra network
+    verification (if indicated) in a central place.
+
+    The default of capture_output is True because it's useful for error reports
+    (if the command failed) even if the output is not really wanted as a result
+    of the execution.
+    """
+    if not check and verify_network:
+        # if check is False, the caller needs the process result no matter what, it's
+        # wrong to also request to verify network, which may raise a different exception
+        raise RuntimeError("Invalid check and verify_network combination.")
+
+    try:
+        proc = executor.execute_run(
+            command, check=check, capture_output=capture_output, text=text
+        )
+    except subprocess.CalledProcessError as exc:
+        if verify_network and not _network_connected(executor):
+            raise NetworkError() from exc
+        raise
+    return proc
 
 
 class BuilddBaseAlias(enum.Enum):
@@ -512,11 +563,7 @@ class BuilddBase(Base):
 
         try:
             _check_deadline(deadline)
-            executor.execute_run(
-                ["apt-get", "update"],
-                capture_output=True,
-                check=True,
-            )
+            _execute_run(executor, ["apt-get", "update"], verify_network=True)
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
                 brief="Failed to update apt cache.",
@@ -530,11 +577,8 @@ class BuilddBase(Base):
 
         try:
             _check_deadline(deadline)
-            executor.execute_run(
-                ["apt-get", "install", "-y"] + packages_to_install,
-                capture_output=True,
-                check=True,
-            )
+            command = ["apt-get", "install", "-y"] + packages_to_install
+            _execute_run(executor, command, verify_network=True)
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
                 brief="Failed to install packages.",
@@ -583,11 +627,7 @@ class BuilddBase(Base):
 
         try:
             _check_deadline(deadline)
-            executor.execute_run(
-                ["hostname", "-F", "/etc/hostname"],
-                capture_output=True,
-                check=True,
-            )
+            _execute_run(executor, ["hostname", "-F", "/etc/hostname"])
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
                 brief="Failed to set hostname.",
@@ -636,18 +676,10 @@ class BuilddBase(Base):
 
         try:
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "enable", "systemd-networkd"],
-                capture_output=True,
-                check=True,
-            )
+            _execute_run(executor, ["systemctl", "enable", "systemd-networkd"])
 
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "restart", "systemd-networkd"],
-                check=True,
-                capture_output=True,
-            )
+            _execute_run(executor, ["systemctl", "restart", "systemd-networkd"])
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
                 brief="Failed to setup systemd-networkd.",
@@ -662,30 +694,19 @@ class BuilddBase(Base):
         """
         try:
             _check_deadline(deadline)
-            executor.execute_run(
-                [
-                    "ln",
-                    "-sf",
-                    "/run/systemd/resolve/resolv.conf",
-                    "/etc/resolv.conf",
-                ],
-                check=True,
-                capture_output=True,
-            )
+            command = [
+                "ln",
+                "-sf",
+                "/run/systemd/resolve/resolv.conf",
+                "/etc/resolv.conf",
+            ]
+            _execute_run(executor, command)
 
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "enable", "systemd-resolved"],
-                check=True,
-                capture_output=True,
-            )
+            _execute_run(executor, ["systemctl", "enable", "systemd-resolved"])
 
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "restart", "systemd-resolved"],
-                check=True,
-                capture_output=True,
-            )
+            _execute_run(executor, ["systemctl", "restart", "systemd-resolved"])
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
                 brief="Failed to setup systemd-resolved.",
@@ -702,31 +723,13 @@ class BuilddBase(Base):
         """
         try:
             _check_deadline(deadline)
-            executor.execute_run(
-                [
-                    "apt-get",
-                    "install",
-                    "-y",
-                    "fuse",
-                    "udev",
-                ],
-                check=True,
-                capture_output=True,
-            )
+            command = ["apt-get", "install", "-y", "fuse", "udev"]
+            _execute_run(executor, command, verify_network=True)
 
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "enable", "systemd-udevd"],
-                capture_output=True,
-                check=True,
-            )
-
+            _execute_run(executor, ["systemctl", "enable", "systemd-udevd"])
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "start", "systemd-udevd"],
-                capture_output=True,
-                check=True,
-            )
+            _execute_run(executor, ["systemctl", "start", "systemd-udevd"])
 
             # This file is created by launchpad-buildd to stop snapd from
             # using the snap store's CDN when running in Canonical's
@@ -737,42 +740,26 @@ class BuilddBase(Base):
             no_cdn = pathlib.Path("/etc/systemd/system/snapd.service.d/no-cdn.conf")
             if no_cdn.exists():
                 _check_deadline(deadline)
-                executor.execute_run(
-                    ["mkdir", "-p", no_cdn.parent.as_posix()], check=True
-                )
+                _execute_run(executor, ["mkdir", "-p", no_cdn.parent.as_posix()])
 
                 _check_deadline(deadline)
                 executor.push_file(source=no_cdn, destination=no_cdn)
 
             _check_deadline(deadline)
-            executor.execute_run(
-                ["apt-get", "install", "-y", "snapd"],
-                capture_output=True,
-                check=True,
+            _execute_run(
+                executor, ["apt-get", "install", "-y", "snapd"], verify_network=True
             )
 
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "start", "snapd.socket"],
-                capture_output=True,
-                check=True,
-            )
+            _execute_run(executor, ["systemctl", "start", "snapd.socket"])
 
             # Restart, not start, the service in case the environment
             # has changed and the service is already running.
             _check_deadline(deadline)
-            executor.execute_run(
-                ["systemctl", "restart", "snapd.service"],
-                capture_output=True,
-                check=True,
-            )
+            _execute_run(executor, ["systemctl", "restart", "snapd.service"])
 
             _check_deadline(deadline)
-            executor.execute_run(
-                ["snap", "wait", "system", "seed.loaded"],
-                capture_output=True,
-                check=True,
-            )
+            _execute_run(executor, ["snap", "wait", "system", "seed.loaded"])
 
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
@@ -795,7 +782,7 @@ class BuilddBase(Base):
                 command = ["snap", "set", "system", f"proxy.http={http_proxy}"]
             else:
                 command = ["snap", "unset", "system", "proxy.http"]
-            executor.execute_run(command, capture_output=True, check=True)
+            _execute_run(executor, command)
 
             _check_deadline(deadline)
             https_proxy = self.environment.get("https_proxy")
@@ -803,7 +790,7 @@ class BuilddBase(Base):
                 command = ["snap", "set", "system", f"proxy.https={https_proxy}"]
             else:
                 command = ["snap", "unset", "system", "proxy.https"]
-            executor.execute_run(command, capture_output=True, check=True)
+            _execute_run(executor, command)
 
         except subprocess.CalledProcessError as error:
             raise BaseConfigurationError(
@@ -827,12 +814,9 @@ class BuilddBase(Base):
         logger.debug("Waiting for networking to be ready...")
 
         _check_deadline(deadline)
+        command = ["getent", "hosts", "snapcraft.io"]
         while True:
-            proc = executor.execute_run(
-                ["getent", "hosts", "snapcraft.io"],
-                capture_output=True,
-                check=False,
-            )
+            proc = _execute_run(executor, command, check=False)
             if proc.returncode == 0:
                 return
 
@@ -858,7 +842,8 @@ class BuilddBase(Base):
 
         _check_deadline(deadline)
         while True:
-            proc = executor.execute_run(
+            proc = _execute_run(
+                executor,
                 ["systemctl", "is-system-running"],
                 capture_output=True,
                 check=False,

--- a/craft_providers/bases/errors.py
+++ b/craft_providers/bases/errors.py
@@ -39,3 +39,12 @@ class BaseCompatibilityError(ProviderError):
         resolution = "Clean incompatible instance and retry the requested operation."
 
         super().__init__(brief=brief, details=details, resolution=resolution)
+
+
+class NetworkError(ProviderError):
+    """Network error when configuring the base."""
+
+    def __init__(self) -> None:
+        brief = "A network related operation failed in a context of no network access."
+        resolution = "Verify that the environment has internet connectivity."
+        super().__init__(brief=brief, resolution=resolution)

--- a/craft_providers/bases/errors.py
+++ b/craft_providers/bases/errors.py
@@ -46,5 +46,10 @@ class NetworkError(ProviderError):
 
     def __init__(self) -> None:
         brief = "A network related operation failed in a context of no network access."
-        resolution = "Verify that the environment has internet connectivity."
+        # XXX Facundo 2022-12-13: need to improve the URL here once
+        # we have the online docs updated
+        resolution = (
+            "Verify that the environment has internet connectivity; "
+            "see https://craft-providers.readthedocs.io/ for further reference."
+        )
         super().__init__(brief=brief, resolution=resolution)

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -1413,6 +1413,8 @@ def test_network_connectivity_timeouts(fake_executor, fake_process):
     """
     cmd = ["bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"]
     timeout_expired = subprocess.TimeoutExpired(cmd, timeout=5)
-    with patch.object(fake_executor, "execute_run", side_effect=timeout_expired) as mock:
+    with patch.object(
+        fake_executor, "execute_run", side_effect=timeout_expired
+    ) as mock:
         assert buildd._network_connected(fake_executor) is False
     mock.assert_called_with(cmd, check=False, capture_output=True, timeout=1)

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -845,7 +845,7 @@ def test_setup_snapd_failures(fake_process, fake_executor, fail_index):
     # some of the commands below are network related and will verify if internet
     # is fine after failing; let't not make this a factor in this test
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"],
+        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"],
         returncode=0,
     )
 
@@ -1357,7 +1357,7 @@ def test_execute_run_verify_network_connectivity_ok(fake_process, fake_executor)
     command = ["the", "command"]
 
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"],
+        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"],
         returncode=0,
     )
     fake_process.register_subprocess([*DEFAULT_FAKE_CMD] + command, returncode=1)
@@ -1371,7 +1371,7 @@ def test_execute_run_verify_network_connectivity_missing(fake_process, fake_exec
     command = ["the", "command"]
 
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"],
+        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"],
         returncode=1,
     )
     fake_process.register_subprocess([*DEFAULT_FAKE_CMD] + command, returncode=1)
@@ -1390,7 +1390,7 @@ def test_execute_run_bad_check_verifynetwork_combination(fake_executor):
 def test_network_connectivity_yes(fake_executor, fake_process):
     """Connectivity is ok."""
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"],
+        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"],
         returncode=0,
     )
     assert buildd._network_connected(fake_executor) is True
@@ -1399,7 +1399,7 @@ def test_network_connectivity_yes(fake_executor, fake_process):
 def test_network_connectivity_no(fake_executor, fake_process):
     """Connectivity missing."""
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"],
+        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"],
         returncode=1,
     )
     assert buildd._network_connected(fake_executor) is False
@@ -1412,7 +1412,7 @@ def test_network_connectivity_timeouts(fake_executor, fake_process):
     verificaton will fail fast, being more representative.
     """
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/1.1.1.1/53"],
+        [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"],
         returncode=0,
         wait=2,
     )


### PR DESCRIPTION
For this I centralized the command run in a helper, that simplifies all the calls and makes the verification easier. Note that I have another PR in mind to simplify the code more.

I tested this IRL, the resulting exception is much more clear than the obscure failings we had in the past:
```
2022-11-11 13:57:44.915 charmcraft internal error: NetworkError(brief='A network related operation failed in a context of no network access.', details=None, resolution='Verify that the environment has internet connectivity.')                                                                                                                                                                                  
2022-11-11 13:57:44.917 Traceback (most recent call last):                                                                                                                                               
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/craft_providers/bases/buildd.py", line 114, in _execute_run                                                                                      
2022-11-11 13:57:44.917     proc = executor.execute_run(command, check=check, capture_output=capture_output, text=text)                                                                                  
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/craft_providers/lxd/lxd_instance.py", line 289, in execute_run                                                                                   
2022-11-11 13:57:44.917     return self.lxc.exec(                                                                                                                                                        
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/craft_providers/lxd/lxc.py", line 329, in exec                                                                                                   
2022-11-11 13:57:44.917     return runner(final_cmd, **kwargs)  # pylint: disable=subprocess-run-check                                                                                                   
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/usr/lib/python3.8/subprocess.py", line 516, in run                                                                                                   
2022-11-11 13:57:44.917     raise CalledProcessError(retcode, process.args,                                                                                                                              
2022-11-11 13:57:44.917 subprocess.CalledProcessError: Command '['lxc', '--project', 'charmcraft', 'exec', 'local:charmcraft-my-super-charm-27791466-0-0-amd64', '--', 'env', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin', 'CHARMCRAFT_MANAGED_MODE=1', 'apt-get', 'update']' returned non-zero exit status 100.                                                                 
2022-11-11 13:57:44.917                                                                                                                                                                                  
2022-11-11 13:57:44.917 The above exception was the direct cause of the following exception:                                                                                                             
2022-11-11 13:57:44.917 Traceback (most recent call last):                                                                                                                                               
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/charmcraft/main.py", line 184, in main                                                                                                           
2022-11-11 13:57:44.917     retcode = dispatcher.run()                                                                                                                                                   
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/craft_cli/dispatcher.py", line 448, in run                                                                                                       
2022-11-11 13:57:44.917     return self._loaded_command.run(self._parsed_command_args)                                                                                                                   
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/charmcraft/commands/pack.py", line 133, in run                                                                                                   
2022-11-11 13:57:44.917     pack_method(parsed_args)                                                                                                                                                     
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/charmcraft/commands/pack.py", line 165, in _pack_charm                                                                                           
2022-11-11 13:57:44.917     charms = builder.run(                                                                                                                                                        
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/charmcraft/instrum.py", line 152, in _f                                                                                                          
2022-11-11 13:57:44.917     return func(*args, **kwargs)                                                                                                                                                 
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/charmcraft/commands/build.py", line 292, in run                                                                                                  
2022-11-11 13:57:44.917     charm_name = self.pack_charm_in_instance(                                                                                                                                    
2022-11-11 13:57:44.917   File "/snap/charmcraft/x2/lib/charmcraft/commands/build.py", line 357, in pack_charm_in_instance                                                                               
2022-11-11 13:57:44.918     with self.provider.launched_environment(                                                                                                                                     
2022-11-11 13:57:44.918   File "/snap/charmcraft/x2/usr/lib/python3.8/contextlib.py", line 113, in __enter__                                                                                             
2022-11-11 13:57:44.918     return next(self.gen)                                                                                                                                                        
2022-11-11 13:57:44.918   File "/snap/charmcraft/x2/lib/craft_providers/lxd/lxd_provider.py", line 126, in launched_environment                                                                          
2022-11-11 13:57:44.918     instance = launch(                                                                                                                                                           
2022-11-11 13:57:44.918   File "/snap/charmcraft/x2/lib/craft_providers/lxd/launcher.py", line 212, in launch                                                                                            
2022-11-11 13:57:44.918     base_configuration.setup(executor=instance)                                                                                                                                  
2022-11-11 13:57:44.918   File "/snap/charmcraft/x2/lib/craft_providers/bases/buildd.py", line 392, in setup                                                                                             
2022-11-11 13:57:44.918     self._setup_apt(executor=executor, deadline=deadline)                                                                                                                        
2022-11-11 13:57:44.918   File "/snap/charmcraft/x2/lib/craft_providers/bases/buildd.py", line 556, in _setup_apt                                                                                        
2022-11-11 13:57:44.918     _execute_run(executor, ["apt-get", "update"], verify_network=True)                                                                                                           
2022-11-11 13:57:44.918   File "/snap/charmcraft/x2/lib/craft_providers/bases/buildd.py", line 117, in _execute_run                                                                                      
2022-11-11 13:57:44.918     raise NetworkError() from exc                                                                                                                                                
2022-11-11 13:57:44.918 craft_providers.bases.errors.NetworkError: A network related operation failed in a context of no network access.                                                                 
2022-11-11 13:57:44.918 Verify that the environment has internet connectivity.                                                                                                                           
2022-11-11 13:57:44.918 Full execution log: '/home/facundo/snap/charmcraft/common/cache/charmcraft/log/charmcraft-20221111-135607.196724.log'                      
```

That said, we will talk about Craft Provider errors not being "crashes" but "failures", but that discussion exceeds this PR.