### PR TITLE
lxd: launch instances from local instance instead of image

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -158,11 +158,10 @@ def _launch_existing_instance(
     :param instance: LXD instance to launch
     :param auto_clean: If true, clean incompatible instances.
     :param base_configuration: Base configuration to apply to the instance.
-    :param ephemeral: After the instance is stopped, delete it. Non-ephemeral instances
-    cannot be converted to ephemeral instances, so if the instance already exists, it
-    will be deleted.
+    :param ephemeral: If the instance is ephemeral, it will not be launched.
+    Instead, the instance will be deleted and the function will return false.
 
-    :returns: True if the instance was started and warmed up.
+    :returns: True if the instance was started and warmed up. False otherwise.
 
     :raises BaseCompatibilityError: If the instance is incompatible.
     """
@@ -237,8 +236,9 @@ def launch(
     instance will be deleted and rebuilt. If false and the existing instance is
     incompatible, then a BaseCompatibilityError is raised.
     :param auto_create_project: Automatically create LXD project, if needed.
-    :param ephemeral: If the instance already exists, delete it. After the instance
-    is stopped, delete it.
+    :param ephemeral: After the instance is stopped, delete it. Non-ephemeral instances
+    cannot be converted to ephemeral instances, so if the instance already exists, it
+    will be deleted, then recreated as an ephemeral instance.
     :param map_user_uid: Map host uid/gid to instance's root uid/gid.
     :param uid: The uid to be mapped, if ``map_user_id`` is enabled.
     :param use_base_instance: Use the base instance mechanisms to reduce setup time.

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -158,8 +158,9 @@ def _launch_existing_instance(
     :param instance: LXD instance to launch
     :param auto_clean: If true, clean incompatible instances.
     :param base_configuration: Base configuration to apply to the instance.
-    :param ephemeral: If the instance already exists, delete it. After the instance
-    is stopped, delete it.
+    :param ephemeral: After the instance is stopped, delete it. Non-ephemeral instances
+    cannot be converted to ephemeral instances, so if the instance already exists, it
+    will be deleted.
 
     :returns: True if the instance was started and warmed up.
 

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -20,7 +20,7 @@
 import logging
 from typing import Optional
 
-from craft_providers import Base, bases
+from craft_providers import Base, ProviderError, bases
 
 from .errors import LXDError
 from .lxc import LXC
@@ -30,72 +30,74 @@ from .project import create_with_default_profile
 logger = logging.getLogger(__name__)
 
 
-def _formulate_snapshot_image_name(
-    *, image_name: str, image_remote: str, compatibility_tag: str
-) -> str:
-    """Compute snapshot image's name.
-
-    It must take into account each of the following params list below.  Note
-    that the image_name should incorporate the architecture to ensure uniqueness
-    in case more than one arch is supported on the platform (e.g. LXD cluster).
-
-    :param image_remote: Name of source image's remote (e.g. ubuntu).
-    :param image_name: Name of source imag (e.g. 20.04)
-    :param compatibility_tag: Compatibility tag of base configuration applied to
-        image.
-
-    :returns: Name of (compatible) snapshot to use.
-    """
-    return "-".join(
-        [
-            "snapshot",
-            image_remote,
-            image_name,
-            compatibility_tag,
-        ]
-    )
-
-
-def _publish_snapshot(
+def _create_instance(
     *,
-    lxc: LXC,
-    snapshot_name: str,
     instance: LXDInstance,
+    base_instance: Optional[LXDInstance],
     base_configuration: Base,
-) -> None:
-    """Publish snapshot from instance.
-
-    Stop instance and publish its contents to an image with the specified alias.
-    Once published, restart instance and ensure it is ready for use.
-
-    :param lxc: LXC client.
-    :param snapshot_name: Alias to use for snapshot.
-    :param instance: LXD instance to snapshot from.
-    :param base_configuration: Base configuration for instance.
-    """
-    instance.stop()
-
-    lxc.publish(
-        alias=snapshot_name,
-        instance_name=instance.instance_name,
-        force=True,
-        project=instance.project,
-        remote=instance.remote,
-    )
-
-    # Restart container and ensure it is ready.
-    instance.start()
-    base_configuration.wait_until_ready(executor=instance)
-
-
-def _ensure_project_exists(
-    *,
-    create: bool,
+    image_name: str,
+    image_remote: str,
+    ephemeral: bool,
+    map_user_uid: bool,
+    uid: Optional[int],
     project: str,
     remote: str,
     lxc: LXC,
 ) -> None:
-    """Check if project exists, optionally creating it if needed.
+    """Launch and setup an instance from an image.
+
+    If a base instance is passed, copy the instance to the base instance.
+
+    Preconditions: The LXD project exists and the instance and base instance (if
+    defined) do not exist.
+
+    :param instance: LXD instance to launch and setup
+    :param base_instance: LXD instance to be created as a copy of the instance. If the
+    base_instance is None, a base instance will not be created.
+    :param base_configuration: Base configuration to apply to instance.
+    :param image_name: LXD image to use, e.g. "20.04".
+    :param image_remote: LXD image to use, e.g. "ubuntu".
+    :param ephemeral: After the instance is stopped, delete it.
+    :param map_user_uid: Map host uid/gid to instance's root uid/gid.
+    :param uid: The uid to be mapped, if ``map_user_id`` is enabled.
+    :param project: LXD project to create instance in.
+    :param remote: LXD remote to create instance on.
+    :param lxc: LXC client.
+    """
+    logger.warning(
+        "Creating new instance from image %r from remote %r.", image_name, image_remote
+    )
+    instance.launch(
+        image=image_name,
+        image_remote=image_remote,
+        ephemeral=ephemeral,
+        map_user_uid=map_user_uid,
+        uid=uid,
+    )
+    base_configuration.setup(executor=instance)
+
+    if base_instance is not None:
+        logger.warning(
+            "Creating new base instance %r from instance.", base_instance.instance_name
+        )
+        # stop the instance before copying, to ensure it is in a "good" state
+        instance.stop()
+        lxc.copy(
+            source_remote=remote,
+            source_instance_name=instance.instance_name,
+            destination_remote=remote,
+            destination_instance_name=base_instance.instance_name,
+            project=project,
+        )
+        # now restart and wait for the instance to be ready
+        instance.start()
+        base_configuration.wait_until_ready(executor=instance)
+
+
+def _ensure_project_exists(
+    *, create: bool, project: str, remote: str, lxc: LXC
+) -> None:
+    """Check if project exists and create it if it does not exist.
 
     :param create: Create project if not found.
     :param project: LXD project name to create.
@@ -117,6 +119,81 @@ def _ensure_project_exists(
         )
 
 
+def _formulate_base_instance_name(
+    *, image_name: str, image_remote: str, compatibility_tag: str
+) -> str:
+    """Compute the base instance name.
+
+    :param image_remote: Name of source image's remote (e.g. ubuntu).
+    :param image_name: Name of source image (e.g. 20.04). The image name should include
+    the architecture to ensure uniqueness amongst multiple architectures built on the
+    same platform.
+    :param compatibility_tag: Compatibility tag of base configuration applied to the
+    base instance.
+
+    :returns: Name of (compatible) base instance.
+    """
+    return "-".join(["base-instance", compatibility_tag, image_remote, image_name])
+
+
+# TODO: Implement this stubbed function (CRAFT-1341)
+# pylint: disable-next=unused-argument
+def _is_valid(instance: LXDInstance) -> bool:
+    """Check if a instance is valid (i.e. the base instance is not expired).
+
+    :returns: True if the instance is valid.
+    """
+    return True
+
+
+def _launch_existing_instance(
+    *,
+    instance: LXDInstance,
+    auto_clean: bool,
+    base_configuration: Base,
+    ephemeral: bool,
+) -> bool:
+    """Start and warmup an existing instance.
+
+    :param instance: LXD instance to launch
+    :param auto_clean: If true, clean incompatible instances.
+    :param base_configuration: Base configuration to apply to the instance.
+    :param ephemeral: If the instance already exists, delete it. After the instance
+    is stopped, delete it.
+
+    :returns: True if the instance was started and warmed up.
+
+    :raises BaseCompatibilityError: If the instance is incompatible.
+    """
+    # TODO: auto clean instance if map_user_uid is mismatched
+    if ephemeral:
+        logger.warning("Instance exists and is ephemeral. Cleaning instance.")
+        instance.delete()
+        return False
+
+    if instance.is_running():
+        logger.warning("Instance exists and is running.")
+    else:
+        logger.warning("Instance exists and is not running. Starting instance.")
+        instance.start()
+
+    try:
+        base_configuration.warmup(executor=instance)
+        return True
+    except bases.BaseCompatibilityError as error:
+        # delete the instance and continue on so a new instance can be created
+        if auto_clean:
+            logger.warning(
+                "Cleaning incompatible instance %r (reason: %s).",
+                instance.instance_name,
+                error.reason,
+            )
+            instance.delete()
+            return False
+        raise
+
+
+# pylint: disable-next=too-many-locals
 def launch(
     name: str,
     *,
@@ -128,26 +205,43 @@ def launch(
     ephemeral: bool = False,
     map_user_uid: bool = False,
     uid: Optional[int] = None,
-    use_snapshots: bool = False,
+    use_snapshots: Optional[bool] = None,
+    use_base_instance: Optional[bool] = False,
     project: str = "default",
     remote: str = "local",
     lxc: LXC = LXC(),
 ) -> LXDInstance:
-    """Create, start, and configure instance.
+    """Create, start, and configure an instance.
 
-    If auto_clean is enabled, automatically delete an existing instance that is
-    deemed to be incompatible, rebuilding it with the specified environment.
+    On the first run of an application, an instance will be launched from an image
+    (i.e. an image from  https://cloud-images.ubuntu.com). The instance is setup
+    according to the Base configuration passed to this function.
+
+    After setup, a copy of this instance is saved (or cached) as a 'base instance'.
+    This is done to reduce setup time on subsequent runs. When the application requests
+    a new instance on a subsequent run, the base instance will be copied to create the
+    new instance. This instance is run through a small subset of the setup, which is
+    referred to as 'warmup'.
+
+    TODO: Implement the expiration mechanism described below (CRAFT-1341).
+
+    To keep build environments clean, consistent, and up-to-date, any base instance
+    older than 3 months (90 days) is deleted and recreated.
 
     :param name: Name of instance.
-    :param base_configuration: Base configuration to apply to instance.
+    :param base_configuration: Base configuration to apply to the instance.
     :param image_name: LXD image to use, e.g. "20.04".
     :param image_remote: LXD image to use, e.g. "ubuntu".
-    :param auto_clean: Automatically clean instance, if incompatible.
+    :param auto_clean: If true and the existing instance is incompatible, then the
+    instance will be deleted and rebuilt. If false and the existing instance is
+    incompatible, then a BaseCompatibilityError is raised.
     :param auto_create_project: Automatically create LXD project, if needed.
-    :param ephemeral: Create ephemeral instance.
+    :param ephemeral: If the instance already exists, delete it. After the instance
+    is stopped, delete it.
     :param map_user_uid: Map host uid/gid to instance's root uid/gid.
     :param uid: The uid to be mapped, if ``map_user_id`` is enabled.
-    :param use_snapshots: Use LXD snapshots for bootstrapping images.
+    :param use_base_instance: Use the base instance mechanisms to reduce setup time.
+    :param use_snapshots: Deprecated parameter replaced by `use_base_instance`.
     :param project: LXD project to create instance in.
     :param remote: LXD remote to create instance on.
     :param lxc: LXC client.
@@ -155,8 +249,17 @@ def launch(
     :returns: LXD instance.
 
     :raises BaseConfigurationError: on unexpected error configuration base.
+    :raises BaseCompatibilityError: if instance is incompatible with the base.
     :raises LXDError: on unexpected LXD error.
+    :raises ProviderError: if name of instance collides with base instance name.
     """
+    if use_snapshots:
+        logger.warning(
+            "Deprecated: Parameter 'use_snapshots' is deprecated. "
+            "Use parameter 'use_base_instance' instead."
+        )
+        use_base_instance = use_snapshots
+
     _ensure_project_exists(
         create=auto_create_project, project=project, remote=remote, lxc=lxc
     )
@@ -166,62 +269,134 @@ def launch(
         remote=remote,
         default_command_environment=base_configuration.get_command_environment(),
     )
+    logger.warning(
+        "Checking for instance %r in project %r in remote %r",
+        instance.instance_name,
+        project,
+        remote,
+    )
 
     if instance.exists():
-        # TODO: warn (or auto clean) if ephemeral or map_user_uid is mismatched.
-        if not instance.is_running():
-            instance.start()
-
-        try:
-            base_configuration.warmup(executor=instance)
+        # if the existing instance could not be launched, then continue on so a new
+        # instance can be created (this can occur when `auto_clean` triggers the
+        # instance to be deleted or if the instance is supposed to be ephemeral)
+        if _launch_existing_instance(
+            instance=instance,
+            auto_clean=auto_clean,
+            base_configuration=base_configuration,
+            ephemeral=ephemeral,
+        ):
             return instance
-        except bases.BaseCompatibilityError as error:
-            if auto_clean:
-                logger.debug(
-                    "Cleaning incompatible container %r (reason: %s).",
-                    instance.name,
-                    error.reason,
-                )
-                instance.delete()
-            else:
-                raise
 
-    # Create from snapshot, if available.
-    snapshot_name = _formulate_snapshot_image_name(
+    logger.warning("Instance %r does not exist.", instance.instance_name)
+
+    if not use_base_instance:
+        logger.warning("Using base instances is disabled.")
+        _create_instance(
+            instance=instance,
+            base_instance=None,
+            base_configuration=base_configuration,
+            image_name=image_name,
+            image_remote=image_remote,
+            ephemeral=ephemeral,
+            map_user_uid=map_user_uid,
+            uid=uid,
+            project=project,
+            remote=remote,
+            lxc=lxc,
+        )
+        return instance
+
+    base_instance_name = _formulate_base_instance_name(
         image_name=image_name,
         image_remote=image_remote,
         compatibility_tag=base_configuration.compatibility_tag,
     )
-    if use_snapshots and lxc.has_image(
-        image_name=snapshot_name, project=project, remote=remote
-    ):
-        logger.debug("Using compatible snapshot %r.", snapshot_name)
-        image_name = snapshot_name
-        image_remote = remote
-
-        # Don't re-publish this snapshot later.
-        use_snapshots = False
-
-    instance.launch(
-        image=image_name,
-        image_remote=image_remote,
-        ephemeral=ephemeral,
-        map_user_uid=map_user_uid,
-        uid=uid,
+    base_instance = LXDInstance(
+        name=base_instance_name,
+        project=project,
+        remote=remote,
+        default_command_environment=base_configuration.get_command_environment(),
     )
-    base_configuration.setup(executor=instance)
+    logger.warning(
+        "Checking for base instance %r in project %r in remote %r",
+        base_instance.instance_name,
+        project,
+        remote,
+    )
 
-    # Publish snapshot if enabled and instance is not ephemeral.
-    if use_snapshots:
-        if ephemeral:
-            logger.debug("Refusing to publish snapshot for ephemeral instance.")
-        else:
-            logger.debug("Publishing snapshot from instance %r.", snapshot_name)
-            _publish_snapshot(
-                lxc=lxc,
-                snapshot_name=snapshot_name,
-                instance=instance,
-                base_configuration=base_configuration,
-            )
+    # an application could formulate an instance name that matches the base instance's
+    # name, which would break calls to `lxc.copy()`
+    if instance.instance_name == base_instance.instance_name:
+        raise ProviderError(
+            brief="instance name cannot match the base instance name: "
+            f"{instance.instance_name!r}",
+            resolution="change name of instance",
+        )
 
+    # the base instance does not exist, so create a new instance and base instance
+    if not base_instance.exists():
+        logger.warning("Base instance %r does not exist.", base_instance.instance_name)
+        _create_instance(
+            instance=instance,
+            base_instance=base_instance,
+            base_configuration=base_configuration,
+            image_name=image_name,
+            image_remote=image_remote,
+            ephemeral=ephemeral,
+            map_user_uid=map_user_uid,
+            uid=uid,
+            project=project,
+            remote=remote,
+            lxc=lxc,
+        )
+        return instance
+
+    # the base instance exists but is not valid, so delete it then create a new
+    # instance and base instance
+    if not _is_valid(base_instance):
+        logger.warning(
+            "Base instance %r is expired. Deleting base instance.",
+            base_instance.instance_name,
+        )
+        base_instance.delete()
+        _create_instance(
+            instance=instance,
+            base_instance=base_instance,
+            base_configuration=base_configuration,
+            image_name=image_name,
+            image_remote=image_remote,
+            ephemeral=ephemeral,
+            map_user_uid=map_user_uid,
+            uid=uid,
+            project=project,
+            remote=remote,
+            lxc=lxc,
+        )
+        return instance
+
+    # at this point, there is a valid base instance to be copied to a new instance
+    logger.warning(
+        "Creating instance from base instance %r", base_instance.instance_name
+    )
+
+    # the base instance is not expected to be running but check for safety
+    if base_instance.is_running():
+        logger.warning("Stopping base instance.")
+
+    lxc.copy(
+        source_remote=remote,
+        source_instance_name=base_instance.instance_name,
+        destination_remote=remote,
+        destination_instance_name=instance.instance_name,
+        project=project,
+    )
+
+    # the newly copied instance should not be running, but check anyways
+    if instance.is_running():
+        logger.warning("Instance is already running.")
+    else:
+        logger.warning("Starting instance.")
+        instance.start()
+    base_configuration.warmup(executor=instance)
     return instance

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -87,8 +87,8 @@ def test_launch_and_run(instance_name, alias, image_name):
 
     try:
         assert isinstance(instance, lxd.LXDInstance)
-        assert instance.exists() is True
-        assert instance.is_running() is True
+        assert instance.exists()
+        assert instance.is_running()
 
         proc = instance.execute_run(["echo", "hi"], check=True, stdout=subprocess.PIPE)
 
@@ -124,12 +124,12 @@ def test_launch_use_base_instance(get_base_instance, launch_args, instance_name)
 
     try:
         # the instance and base instance should both exist
-        assert instance.exists() is True
-        assert base_instance.exists() is True
+        assert instance.exists()
+        assert base_instance.exists()
 
         # only the instance should be running
-        assert instance.is_running() is True
-        assert base_instance.is_running() is False
+        assert instance.is_running()
+        assert not base_instance.is_running()
 
         # delete the instance so a new instance is created from the base instance
         instance.delete()
@@ -141,8 +141,8 @@ def test_launch_use_base_instance(get_base_instance, launch_args, instance_name)
             use_base_instance=True,
         )
 
-        assert instance.exists() is True
-        assert instance.is_running() is True
+        assert instance.exists()
+        assert instance.is_running()
 
         # relaunch the existing instance
         instance = lxd.launch(
@@ -153,8 +153,8 @@ def test_launch_use_base_instance(get_base_instance, launch_args, instance_name)
             use_base_instance=True,
         )
 
-        assert instance.exists() is True
-        assert instance.is_running() is True
+        assert instance.exists()
+        assert instance.is_running()
     finally:
         if instance.exists():
             instance.delete()
@@ -206,12 +206,12 @@ def test_launch_with_project_and_use_base_instance(
 
     try:
         # the instance and base instance should both exist
-        assert instance.exists() is True
-        assert base_instance.exists() is True
+        assert instance.exists()
+        assert base_instance.exists()
 
         # only the instance should be running
-        assert instance.is_running() is True
-        assert base_instance.is_running() is False
+        assert instance.is_running()
+        assert not base_instance.is_running()
 
         # delete the instance so a new instance is created from the base instance
         instance.delete()
@@ -225,8 +225,8 @@ def test_launch_with_project_and_use_base_instance(
             remote="local",
         )
 
-        assert instance.exists() is True
-        assert instance.is_running() is True
+        assert instance.exists()
+        assert instance.is_running()
 
         # relaunch the existing instance
         instance = lxd.launch(
@@ -239,8 +239,8 @@ def test_launch_with_project_and_use_base_instance(
             remote="local",
         )
 
-        assert instance.exists() is True
-        assert instance.is_running() is True
+        assert instance.exists()
+        assert instance.is_running()
     finally:
         if instance.exists():
             instance.delete()
@@ -264,7 +264,7 @@ def test_launch_ephemeral(instance_name):
         # lxd will delete the instance when it is stopped
         instance.stop()
 
-        assert instance.exists() is False
+        assert not instance.exists()
     finally:
         if instance.exists():
             instance.delete()
@@ -284,8 +284,8 @@ def test_launch_ephemeral_existing(instance_name):
     )
 
     try:
-        assert instance.exists() is True
-        assert instance.is_running() is True
+        assert instance.exists()
+        assert instance.is_running()
 
         # relaunching as an ephemeral instance will delete the existing instance
         instance = lxd.launch(
@@ -296,12 +296,12 @@ def test_launch_ephemeral_existing(instance_name):
             ephemeral=True,
         )
 
-        assert instance.exists() is True
+        assert instance.exists()
 
         # lxd will delete the instance when it is stopped
         instance.stop()
 
-        assert instance.exists() is False
+        assert not instance.exists()
     finally:
         if instance.exists():
             instance.delete()
@@ -392,8 +392,8 @@ def test_launch_existing_instance(core20_instance):
         image_remote="ubuntu",
     )
 
-    assert instance.exists() is True
-    assert instance.is_running() is True
+    assert instance.exists()
+    assert instance.is_running()
 
     proc = instance.execute_run(["echo", "hi"], check=True, stdout=subprocess.PIPE)
 
@@ -435,8 +435,8 @@ def test_launch_os_incompatible(core20_instance):
         auto_clean=True,
     )
 
-    assert core20_instance.exists() is True
-    assert core20_instance.is_running() is True
+    assert core20_instance.exists()
+    assert core20_instance.is_running()
 
 
 def test_launch_instance_config_incompatible(core20_instance):
@@ -474,5 +474,5 @@ def test_launch_instance_config_incompatible(core20_instance):
         auto_clean=True,
     )
 
-    assert core20_instance.exists() is True
-    assert core20_instance.is_running() is True
+    assert core20_instance.exists()
+    assert core20_instance.is_running()

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -29,6 +29,27 @@ from . import conftest
 
 
 @pytest.fixture()
+def get_base_instance():
+    def _base_instance(
+        image_name: str = "20.04",
+        image_remote: str = "ubuntu",
+        compatibility_tag: str = "buildd-base-v0",
+        project: str = "default",
+    ):
+        """Get the base instance."""
+        # pylint: disable-next=protected-access
+        base_instance_name = lxd.launcher._formulate_base_instance_name(
+            image_name=image_name,
+            image_remote=image_remote,
+            compatibility_tag=compatibility_tag,
+        )
+        instance = lxd.LXDInstance(name=base_instance_name, project=project)
+        return instance
+
+    yield _base_instance
+
+
+@pytest.fixture()
 def core20_instance(instance_name):
     with conftest.tmp_instance(
         name=instance_name,
@@ -54,6 +75,7 @@ def core20_instance(instance_name):
     ],
 )
 def test_launch_and_run(instance_name, alias, image_name):
+    """Launch an instance and run a command in the instance."""
     base_configuration = bases.BuilddBase(alias=alias)
 
     instance = lxd.launch(
@@ -75,40 +97,73 @@ def test_launch_and_run(instance_name, alias, image_name):
         instance.delete()
 
 
-def test_launch_with_snapshots(instance_name):
-    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
-    snapshot_name = "snapshot-ubuntu-20.04-buildd-base-v0"
-    lxc = lxd.LXC()
+@pytest.mark.parametrize(
+    "launch_args", [{"use_base_instance": True}, {"use_snapshots": True}]
+)
+def test_launch_use_base_instance(get_base_instance, launch_args, instance_name):
+    """Launch an instance using base instances.
 
+    First, launch an instance from an image and create a base instance.
+    Then launch an instance from the base instance.
+    Then launch an instance when the instance exists.
+
+    The parameter `use_base_instance` and the deprecated parameter `use_snapshots`
+    should both result in the same behavior.
+    """
+    base_instance = get_base_instance()
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    # launch an instance from an image and create a base instance
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
         image_name="20.04",
         image_remote="ubuntu",
-        use_snapshots=True,
+        **launch_args,
     )
 
     try:
+        # the instance and base instance should both exist
+        assert instance.exists() is True
+        assert base_instance.exists() is True
+
+        # only the instance should be running
+        assert instance.is_running() is True
+        assert base_instance.is_running() is False
+
+        # delete the instance so a new instance is created from the base instance
         instance.delete()
-
-        assert lxc.has_image(snapshot_name) is True
-
         instance = lxd.launch(
             name=instance_name,
             base_configuration=base_configuration,
             image_name="20.04",
             image_remote="ubuntu",
-            use_snapshots=True,
+            use_base_instance=True,
         )
+
+        assert instance.exists() is True
+        assert instance.is_running() is True
+
+        # relaunch the existing instance
+        instance = lxd.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            use_base_instance=True,
+        )
+
+        assert instance.exists() is True
+        assert instance.is_running() is True
     finally:
         if instance.exists():
             instance.delete()
+        if base_instance.exists():
+            base_instance.delete()
 
-        if lxc.has_image(snapshot_name):
-            lxc.image_delete(image=snapshot_name)
 
-
-def test_launch_creating_project(instance_name, project_name):
+def test_launch_create_project(instance_name, project_name):
+    """Create a project if it does not exist and `auto_create_project` is true."""
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
     lxc = lxd.LXC()
 
@@ -131,44 +186,70 @@ def test_launch_creating_project(instance_name, project_name):
         lxd_project.purge(lxc=lxc, project=project_name)
 
 
-def test_launch_with_project_and_snapshots(instance_name, project):
+def test_launch_with_project_and_use_base_instance(
+    get_base_instance, instance_name, project
+):
+    """With a LXD project specified, launch an instance and use base instances."""
+    base_instance = get_base_instance(project=project)
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
-    snapshot_name = "snapshot-ubuntu-20.04-buildd-base-v0"
-    lxc = lxd.LXC()
 
+    # launch an instance from an image and create a base instance
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
         image_name="20.04",
         image_remote="ubuntu",
-        use_snapshots=True,
+        use_base_instance=True,
         project=project,
         remote="local",
     )
 
     try:
+        # the instance and base instance should both exist
+        assert instance.exists() is True
+        assert base_instance.exists() is True
+
+        # only the instance should be running
+        assert instance.is_running() is True
+        assert base_instance.is_running() is False
+
+        # delete the instance so a new instance is created from the base instance
         instance.delete()
-
-        assert lxc.has_image(snapshot_name, project=project, remote="local") is True
-
         instance = lxd.launch(
             name=instance_name,
             base_configuration=base_configuration,
             image_name="20.04",
             image_remote="ubuntu",
-            use_snapshots=True,
+            use_base_instance=True,
             project=project,
             remote="local",
         )
+
+        assert instance.exists() is True
+        assert instance.is_running() is True
+
+        # relaunch the existing instance
+        instance = lxd.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            use_base_instance=True,
+            project=project,
+            remote="local",
+        )
+
+        assert instance.exists() is True
+        assert instance.is_running() is True
     finally:
         if instance.exists():
             instance.delete()
-
-        if lxc.has_image(snapshot_name, project=project, remote="local"):
-            lxc.image_delete(image=snapshot_name, project=project, remote="local")
+        if base_instance.exists():
+            base_instance.delete()
 
 
 def test_launch_ephemeral(instance_name):
+    """Launch an ephemeral instance and verify it is deleted after it is stopped."""
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
 
     instance = lxd.launch(
@@ -180,6 +261,44 @@ def test_launch_ephemeral(instance_name):
     )
 
     try:
+        # lxd will delete the instance when it is stopped
+        instance.stop()
+
+        assert instance.exists() is False
+    finally:
+        if instance.exists():
+            instance.delete()
+
+
+def test_launch_ephemeral_existing(instance_name):
+    """If an ephemeral instance already exists, delete it and create a new instance."""
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    # create a non-ephemeral instance
+    instance = lxd.launch(
+        name=instance_name,
+        base_configuration=base_configuration,
+        image_name="20.04",
+        image_remote="ubuntu",
+        ephemeral=False,
+    )
+
+    try:
+        assert instance.exists() is True
+        assert instance.is_running() is True
+
+        # relaunching as an ephemeral instance will delete the existing instance
+        instance = lxd.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            ephemeral=True,
+        )
+
+        assert instance.exists() is True
+
+        # lxd will delete the instance when it is stopped
         instance.stop()
 
         assert instance.exists() is False
@@ -189,6 +308,7 @@ def test_launch_ephemeral(instance_name):
 
 
 def test_launch_map_user_uid_true(instance_name, tmp_path):
+    """Enable and map the the UID of the test account."""
     tmp_path.chmod(0o755)
 
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
@@ -213,6 +333,7 @@ def test_launch_map_user_uid_true(instance_name, tmp_path):
 
 
 def test_launch_map_user_uid_true_no_uid(instance_name, tmp_path):
+    """Enable UID mapping without specifying a UID."""
     tmp_path.chmod(0o755)
 
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
@@ -236,6 +357,7 @@ def test_launch_map_user_uid_true_no_uid(instance_name, tmp_path):
 
 
 def test_launch_map_user_uid_false(instance_name, tmp_path):
+    """If UID mapping is not enabled, access to a mounted directory will be denied."""
     tmp_path.chmod(0o755)
 
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
@@ -260,6 +382,7 @@ def test_launch_map_user_uid_false(instance_name, tmp_path):
 
 
 def test_launch_existing_instance(core20_instance):
+    """Launch an existing instance and run a command."""
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
 
     instance = lxd.launch(
@@ -277,7 +400,10 @@ def test_launch_existing_instance(core20_instance):
     assert proc.stdout == b"hi\n"
 
 
-def test_launch_os_incompatible_instance(core20_instance):
+def test_launch_os_incompatible(core20_instance):
+    """Raise an error if the instance's OS is Incompatible.
+    If auto_clean is true, delete and recreate the instance.
+    """
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
 
     core20_instance.push_file_io(
@@ -286,7 +412,7 @@ def test_launch_os_incompatible_instance(core20_instance):
         file_mode="0644",
     )
 
-    # Should raise compatibility error with auto_clean=False.
+    # will raise compatibility error when auto_clean is false
     with pytest.raises(bases.BaseCompatibilityError) as exc_info:
         lxd.launch(
             name=core20_instance.name,
@@ -300,7 +426,7 @@ def test_launch_os_incompatible_instance(core20_instance):
         == "Incompatible base detected: Expected OS 'Ubuntu', found 'Fedora'."
     )
 
-    # Retry with auto_clean=True.
+    # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
         name=core20_instance.name,
         base_configuration=base_configuration,
@@ -313,7 +439,10 @@ def test_launch_os_incompatible_instance(core20_instance):
     assert core20_instance.is_running() is True
 
 
-def test_launch_instance_config_incompatible_instance(core20_instance):
+def test_launch_instance_config_incompatible(core20_instance):
+    """Raise an error if the instance configuration file is incompatible.
+    If auto_clean is true, delete and recreate the instance.
+    """
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
 
     core20_instance.push_file_io(
@@ -322,7 +451,7 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
         file_mode="0644",
     )
 
-    # Should raise compatibility error with auto_clean=False.
+    # will raise compatibility error when auto_clean is false
     with pytest.raises(bases.BaseCompatibilityError) as exc_info:
         lxd.launch(
             name=core20_instance.name,
@@ -336,7 +465,7 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
         " Expected image compatibility tag 'buildd-base-v0', found 'invalid'."
     )
 
-    # Retry with auto_clean=True.
+    # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
         name=core20_instance.name,
         base_configuration=base_configuration,

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -19,8 +19,9 @@
 from unittest.mock import MagicMock, Mock, call
 
 import pytest
+from logassert import Exact  # type: ignore
 
-from craft_providers import Base, bases, lxd
+from craft_providers import Base, ProviderError, bases, lxd
 
 
 @pytest.fixture
@@ -54,32 +55,47 @@ def fake_instance():
 
 
 @pytest.fixture
-def mock_lxd_instance(fake_instance, mocker):
-    """Mock LXDInstance and return a fake instance."""
+def fake_base_instance():
+    """Returns a fake base LXD Instance"""
+    base_instance = MagicMock()
+    # the name has an invalid character to ensure the instance_name will be different,
+    # so the two are not conflated in the unit tests
+    base_instance.name = "test-base-instance-$"
+    base_instance.instance_name = "test-base-instance-e14661a426076717fa04"
+    base_instance.project = "test-project"
+    base_instance.remote = "test-remote"
+    base_instance.exists.return_value = False
+    base_instance.is_running.return_value = False
+    return base_instance
+
+
+@pytest.fixture
+def mock_lxd_instance(fake_instance, fake_base_instance, mocker):
+    """Mock LXD instance to return fake_instance then fake_base_instance."""
     yield mocker.patch(
         "craft_providers.lxd.launcher.LXDInstance",
         spec=lxd.LXDInstance,
-        # single element list appears accidental but side_effect must be an iterable.
-        # it will look more normal for CRAFT-1339:
-        # side_effect=[fake_instance, fake_base_instance]
-        side_effect=[fake_instance],
+        side_effect=[fake_instance, fake_base_instance],
     )
 
 
-def test_launch(fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance):
+def test_launch_no_base_instance(
+    fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance
+):
     """Create an instance from an image and do not save a copy as the base instance."""
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
+        use_base_instance=False,
         lxc=mock_lxc,
     )
 
     assert mock_lxc.mock_calls == [call.project_list("local")]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
             project="default",
             remote="local",
             default_command_environment={"foo": "bar"},
@@ -101,18 +117,20 @@ def test_launch(fake_instance, mock_base_configuration, mock_lxc, mock_lxd_insta
     ]
 
 
-def test_launch_making_initial_snapshot(
-    fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance
+def test_launch_use_base_instance(
+    fake_instance,
+    fake_base_instance,
+    mock_base_configuration,
+    mock_lxc,
+    mock_lxd_instance,
 ):
     """Launch an instance from an image and save a copy as the base instance."""
-    mock_lxc.has_image.return_value = False
-
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
-        use_snapshots=True,
+        use_base_instance=True,
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
@@ -120,22 +138,23 @@ def test_launch_making_initial_snapshot(
 
     assert mock_lxc.mock_calls == [
         call.project_list("test-remote"),
-        call.has_image(
-            image_name="snapshot-image-remote-image-name-mock-compat-tag-v100",
+        call.copy(
+            source_remote="test-remote",
+            source_instance_name=fake_instance.instance_name,
+            destination_remote="test-remote",
+            destination_instance_name=fake_base_instance.instance_name,
             project="test-project",
-            remote="test-remote",
-        ),
-        call.publish(
-            alias="snapshot-image-remote-image-name-mock-compat-tag-v100",
-            instance_name="test-instance-fa2d407652a1c51f6019",
-            force=True,
-            project="test-project",
-            remote="test-remote",
         ),
     ]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
+            project="test-project",
+            remote="test-remote",
+            default_command_environment={"foo": "bar"},
+        ),
+        call(
+            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
             project="test-project",
             remote="test-remote",
             default_command_environment={"foo": "bar"},
@@ -153,25 +172,31 @@ def test_launch_making_initial_snapshot(
         call.stop(),
         call.start(),
     ]
+    assert fake_base_instance.mock_calls == [call.exists()]
     assert mock_base_configuration.mock_calls == [
+        call.get_command_environment(),
         call.get_command_environment(),
         call.setup(executor=fake_instance),
         call.wait_until_ready(executor=fake_instance),
     ]
 
 
-def test_launch_using_existing_snapshot(
-    fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance
+def test_launch_use_existing_base_instance(
+    fake_instance,
+    fake_base_instance,
+    mock_base_configuration,
+    mock_lxc,
+    mock_lxd_instance,
 ):
     """Create instance from an existing base instance."""
-    mock_lxc.has_image.return_value = True
+    fake_base_instance.exists.return_value = True
 
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
-        use_snapshots=True,
+        use_base_instance=True,
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
@@ -179,23 +204,102 @@ def test_launch_using_existing_snapshot(
 
     assert mock_lxc.mock_calls == [
         call.project_list("test-remote"),
-        call.has_image(
-            image_name="snapshot-image-remote-image-name-mock-compat-tag-v100",
+        call.copy(
+            source_remote="test-remote",
+            source_instance_name=fake_base_instance.instance_name,
+            destination_remote="test-remote",
+            destination_instance_name=fake_instance.instance_name,
             project="test-project",
-            remote="test-remote",
         ),
     ]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
+            project="test-project",
+            remote="test-remote",
+            default_command_environment={"foo": "bar"},
+        ),
+        call(
+            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
             project="test-project",
             remote="test-remote",
             default_command_environment={"foo": "bar"},
         ),
     ]
+    assert fake_instance.mock_calls == [call.exists(), call.is_running(), call.start()]
+    assert fake_base_instance.mock_calls == [call.exists(), call.is_running()]
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
+        call.get_command_environment(),
+        call.warmup(executor=fake_instance),
+    ]
+
+
+def test_launch_existing_base_instance_invalid(
+    fake_instance,
+    fake_base_instance,
+    mock_base_configuration,
+    mock_lxc,
+    mock_lxd_instance,
+    mocker,
+):
+    """If the existing base instance is invalid, delete it and create a new instance."""
+    fake_base_instance.exists.return_value = True
+    mocker.patch("craft_providers.lxd.launcher._is_valid", return_value=False)
+
+    lxd.launch(
+        name=fake_instance.name,
+        base_configuration=mock_base_configuration,
+        image_name="image-name",
+        image_remote="image-remote",
+        use_base_instance=True,
+        project="test-project",
+        remote="test-remote",
+        lxc=mock_lxc,
+    )
+
+    assert mock_lxc.mock_calls == [
+        call.project_list("test-remote"),
+        call.copy(
+            source_remote="test-remote",
+            source_instance_name=fake_instance.instance_name,
+            destination_remote="test-remote",
+            destination_instance_name=fake_base_instance.instance_name,
+            project="test-project",
+        ),
+    ]
+    assert mock_lxd_instance.mock_calls == [
+        call(
+            name=fake_instance.name,
+            project="test-project",
+            remote="test-remote",
+            default_command_environment={"foo": "bar"},
+        ),
+        call(
+            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
+            project="test-project",
+            remote="test-remote",
+            default_command_environment={"foo": "bar"},
+        ),
+    ]
+    assert fake_instance.mock_calls == [
+        call.exists(),
+        call.launch(
+            image="image-name",
+            image_remote="image-remote",
+            ephemeral=False,
+            map_user_uid=False,
+            uid=None,
+        ),
+        call.stop(),
+        call.start(),
+    ]
+    assert fake_base_instance.mock_calls == [call.exists(), call.delete()]
+    assert mock_base_configuration.mock_calls == [
+        call.get_command_environment(),
+        call.get_command_environment(),
         call.setup(executor=fake_instance),
+        call.wait_until_ready(executor=fake_instance),
     ]
 
 
@@ -204,7 +308,7 @@ def test_launch_all_opts(
 ):
     """Parse all parameters."""
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
@@ -221,7 +325,7 @@ def test_launch_all_opts(
     assert mock_lxc.mock_calls == [call.project_list("test-remote")]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
             project="test-project",
             remote="test-remote",
             default_command_environment={"foo": "bar"},
@@ -249,7 +353,7 @@ def test_launch_missing_project(
     """Raise an error if project does not exist and auto_create_project if false."""
     with pytest.raises(lxd.LXDError) as exc_info:
         lxd.launch(
-            "test-instance",
+            name=fake_instance.name,
             base_configuration=mock_base_configuration,
             image_name="image-name",
             image_remote="image-remote",
@@ -271,7 +375,7 @@ def test_launch_create_project(
 ):
     """Create a project if it does not exist and auto_create_project is true."""
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
@@ -294,7 +398,7 @@ def test_launch_create_project(
     ]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
             project="project-to-create",
             remote="test-remote",
             default_command_environment={"foo": "bar"},
@@ -323,7 +427,7 @@ def test_launch_with_existing_instance_not_running(
     fake_instance.exists.return_value = True
 
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
@@ -333,17 +437,13 @@ def test_launch_with_existing_instance_not_running(
     assert mock_lxc.mock_calls == [call.project_list("local")]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
             project="default",
             remote="local",
             default_command_environment={"foo": "bar"},
         ),
     ]
-    assert fake_instance.mock_calls == [
-        call.exists(),
-        call.is_running(),
-        call.start(),
-    ]
+    assert fake_instance.mock_calls == [call.exists(), call.is_running(), call.start()]
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.warmup(executor=fake_instance),
@@ -353,12 +453,12 @@ def test_launch_with_existing_instance_not_running(
 def test_launch_with_existing_instance_running(
     fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance
 ):
-    """If the existing instance is not running, do not start it."""
+    """If the existing instance is running, do not start it."""
     fake_instance.exists.return_value = True
     fake_instance.is_running.return_value = True
 
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
@@ -368,16 +468,13 @@ def test_launch_with_existing_instance_running(
     assert mock_lxc.mock_calls == [call.project_list("local")]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
             project="default",
             remote="local",
             default_command_environment={"foo": "bar"},
         ),
     ]
-    assert fake_instance.mock_calls == [
-        call.exists(),
-        call.is_running(),
-    ]
+    assert fake_instance.mock_calls == [call.exists(), call.is_running()]
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.warmup(executor=fake_instance),
@@ -397,7 +494,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
     ]
 
     lxd.launch(
-        "test-instance",
+        name=fake_instance.name,
         base_configuration=mock_base_configuration,
         image_name="image-name",
         image_remote="image-remote",
@@ -408,7 +505,7 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
     assert mock_lxc.mock_calls == [call.project_list("local")]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
             project="default",
             remote="local",
             default_command_environment={"foo": "bar"},
@@ -434,19 +531,18 @@ def test_launch_with_existing_instance_incompatible_with_auto_clean(
     ]
 
 
-def test_launch_with_existing_instance_incompatible_without_auto_clean(
+def test_launch_with_existing_instance_incompatible_without_auto_clean_error(
     fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance
 ):
-    """If instance is incompatible and auto_clean is False, use the instance."""
-    # XXX: should this raise the BaseCompatibilityError? (CRAFT-1339)
+    """If instance is incompatible and auto_clean is False, raise an error."""
     fake_instance.exists.return_value = True
     mock_base_configuration.warmup.side_effect = [
         bases.BaseCompatibilityError(reason="foo")
     ]
 
-    with pytest.raises(bases.BaseCompatibilityError):
+    with pytest.raises(bases.BaseCompatibilityError) as raised:
         lxd.launch(
-            "test-instance",
+            name=fake_instance.name,
             base_configuration=mock_base_configuration,
             image_name="image-name",
             image_remote="image-remote",
@@ -454,10 +550,32 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
             lxc=mock_lxc,
         )
 
+    assert raised.value.brief == "Incompatible base detected: foo."
+    assert raised.value.resolution == (
+        "Clean incompatible instance and retry the requested operation."
+    )
+
+
+def test_launch_with_existing_ephemeral_instance(
+    fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance
+):
+    """Delete and recreate existing ephemeral instances."""
+    fake_instance.exists.return_value = True
+
+    lxd.launch(
+        name=fake_instance.name,
+        base_configuration=mock_base_configuration,
+        image_name="image-name",
+        image_remote="image-remote",
+        ephemeral=True,
+        use_base_instance=False,
+        lxc=mock_lxc,
+    )
+
     assert mock_lxc.mock_calls == [call.project_list("local")]
     assert mock_lxd_instance.mock_calls == [
         call(
-            name="test-instance",
+            name=fake_instance.name,
             project="default",
             remote="local",
             default_command_environment={"foo": "bar"},
@@ -465,10 +583,117 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
     ]
     assert fake_instance.mock_calls == [
         call.exists(),
-        call.is_running(),
-        call.start(),
+        call.delete(),
+        call.launch(
+            image="image-name",
+            image_remote="image-remote",
+            ephemeral=True,
+            map_user_uid=False,
+            uid=None,
+        ),
     ]
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
-        call.warmup(executor=fake_instance),
+        call.setup(executor=fake_instance),
+    ]
+
+
+def test_name_matches_base_name(
+    fake_instance,
+    fake_base_instance,
+    mock_base_configuration,
+    mock_lxc,
+    mock_lxd_instance,
+):
+    """Raise an error if the instance name matches the base instance name."""
+    # force the names to be equal
+    fake_instance.instance_name = fake_base_instance.instance_name
+
+    with pytest.raises(ProviderError) as raised:
+        lxd.launch(
+            name=fake_instance.name,
+            base_configuration=mock_base_configuration,
+            image_name="image-name",
+            image_remote="image-remote",
+            use_base_instance=True,
+            lxc=mock_lxc,
+        )
+
+    assert raised.value.brief == (
+        f"instance name cannot match the base instance name: "
+        f"{fake_base_instance.instance_name!r}"
+    )
+    assert raised.value.resolution == "change name of instance"
+
+
+def test_use_snapshots_deprecated(
+    fake_instance,
+    fake_base_instance,
+    logs,
+    mock_base_configuration,
+    mock_lxc,
+    mock_lxd_instance,
+):
+    """Log deprecation warning for `use_snapshots` and continue to launch."""
+    lxd.launch(
+        name=fake_instance.name,
+        base_configuration=mock_base_configuration,
+        image_name="image-name",
+        image_remote="image-remote",
+        use_snapshots=True,
+        project="test-project",
+        remote="test-remote",
+        lxc=mock_lxc,
+    )
+
+    assert (
+        Exact(
+            "Deprecated: Parameter 'use_snapshots' is deprecated. "
+            "Use parameter 'use_base_instance' instead."
+        )
+        in logs.warning
+    )
+
+    assert mock_lxc.mock_calls == [
+        call.project_list("test-remote"),
+        call.copy(
+            source_remote="test-remote",
+            source_instance_name=fake_instance.instance_name,
+            destination_remote="test-remote",
+            destination_instance_name=fake_base_instance.instance_name,
+            project="test-project",
+        ),
+    ]
+    assert mock_lxd_instance.mock_calls == [
+        call(
+            name=fake_instance.name,
+            project="test-project",
+            remote="test-remote",
+            default_command_environment={"foo": "bar"},
+        ),
+        call(
+            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
+            project="test-project",
+            remote="test-remote",
+            default_command_environment={"foo": "bar"},
+        ),
+    ]
+    assert fake_instance.mock_calls == [
+        call.exists(),
+        call.launch(
+            image="image-name",
+            image_remote="image-remote",
+            ephemeral=False,
+            map_user_uid=False,
+            uid=None,
+        ),
+        call.stop(),
+        call.start(),
+    ]
+    assert fake_base_instance.mock_calls == [call.exists()]
+    assert mock_base_configuration.mock_calls == [
+        call.get_command_environment(),
+        call.get_command_environment(),
+        call.setup(executor=fake_instance),
+        call.wait_until_ready(executor=fake_instance),
     ]


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
## Overview

Cache a configured LXD environment as an instance instead of an image.

## Details

On the first run of an application, an instance will be launched from an image (i.e. an image from https://cloud-images.ubuntu.com). The instance is then setup. After setup, a copy of this instance is saved (or cached) as a 'base instance'. 

This is done to reduce setup time on subsequent runs. When the application requests a new instance on a subsequent run, the base instance will be copied to create the new instance. This instance is run through a small subset of the setup, which is referred to as 'warmup'.

## Previous behavior

![image](https://user-images.githubusercontent.com/60674096/205115452-774be7af-ebdc-44ab-b955-3e7f3e8b542b.png)

## New behavior

The flowchart below describes the logic inside the `launch()` call.  The flowchart has become crowded as it's evolved - it's a result of the fixed drawing size in Google Doc's embedded drawings.

![image](https://user-images.githubusercontent.com/60674096/205114903-3c2d7a1b-506b-46bc-b6b0-406090b88b99.png)

## Notes on the PR

- `craft_providers/lxd/launcher.py` was completely refactored, since the underlying mechanism was redone.  It's may be easier to review the new file instead of the diff.
- The unit tests did not need to be changed dramatically (thanks to https://github.com/canonical/craft-providers/pull/178).  However I added more tests.
- The integration tests are mostly unchanged too, aside from swapping `base image` assertions for `base instance` assertions.
- I've added a deprecation warning for the parameter `use_snapshots` in favor of `use_base_instance`.  For now, the old parameter will still work but will log a warning.

## Performance improvement

The scenarios below were measure how long the call to `lxd.launch()` takes when building a simple snap on a typical developer laptop.
| scenario | previous time | new time | speed up |
|-----|------|----------|-----|
|clean environment|01:58.415|01:24:483|34 seconds|
|base instance exists|00:24.721|00:04.886|19 seconds|
|instance exists|00:04:145|00:04.194|no change|

(CRAFT-1339)