### PR TITLE
lxd: add lxc.copy() method to copy instances

### DIFF
--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -245,6 +245,51 @@ class LXC:  # pylint: disable=too-many-public-methods
                 details=errors.details_from_called_process_error(error),
             ) from error
 
+    def copy(
+        self,
+        *,
+        source_remote: str = "local",
+        source_instance_name: str,
+        destination_remote: str = "local",
+        destination_instance_name: str,
+        project: str = "default",
+    ) -> None:
+        """Copy instances within or in between LXD servers.
+
+        Calls `lxc copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]`
+        A running instance can be copied but the manpages state "This may cause data
+        corruption or data loss depending on the used filesystem and applications.
+        Use with care."
+
+        # TODO: add parameter `snapshot: Optional[str]` to copy from an instance's
+        snapshot (CRAFT-1340)
+
+        :param source_remote: Name of source LXD remote.
+        :param source_instance_name: Name of instance to copy from.
+        :param destination_remote: Name of remote LXD destination.
+        :param destination_instance_name: Name of instance to copy to.
+        :param project: Name of LXD project.
+
+        :raises LXDError: on unexpected error.
+        """
+        source = f"{source_remote}:{source_instance_name}"
+        destination = f"{destination_remote}:{destination_instance_name}"
+
+        command = ["copy", source, destination]
+
+        try:
+            self._run_lxc(
+                command,
+                capture_output=True,
+                check=True,
+                project=project,
+            )
+        except subprocess.CalledProcessError as error:
+            raise LXDError(
+                brief=(f"Failed to copy instance {source!r} to {destination!r}."),
+                details=errors.details_from_called_process_error(error),
+            ) from error
+
     def delete(
         self,
         *,

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -256,10 +256,10 @@ class LXC:  # pylint: disable=too-many-public-methods
     ) -> None:
         """Copy instances within or in between LXD servers.
 
-        Calls `lxc copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]`
-        A running instance can be copied but the manpages state "This may cause data
-        corruption or data loss depending on the used filesystem and applications.
-        Use with care."
+        Calls `lxc copy <source_remote>:<source_instance_name> <destination_remote>:
+        destination_instance_name>`. A running instance can be copied but the manpages
+        state "This may cause data corruption or data loss depending on the used
+        filesystem and applications. Use with care."
 
         # TODO: add parameter `snapshot: Optional[str]` to copy from an instance's
         snapshot (CRAFT-1340)

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -46,7 +46,7 @@ def test_copy(instance, instance_name, lxc, project):
     """Test `copy()` with default arguments."""
     destination_instance_name = instance_name + "-destination"
 
-    # copy the instance to the a new instance
+    # copy the instance to a new instance
     lxc.copy(
         source_instance_name=instance,
         destination_instance_name=destination_instance_name,
@@ -58,20 +58,31 @@ def test_copy(instance, instance_name, lxc, project):
     # verify both instances exist
     assert instances == [instance, destination_instance_name]
 
-    # delete the destination instance (the source instance is created by the pytest
-    # fixture so it will be deleted when context is lost)
-    lxc.delete(instance_name=destination_instance_name, force=False, project=project)
-
 
 def test_copy_error(instance, instance_name, lxc, project):
     """Raise a LXDError when the copy command fails."""
     # the source and destination cannot be same, so LXC will fail to copy
-    with pytest.raises(LXDError):
+    with pytest.raises(LXDError) as raised:
         lxc.copy(
             source_instance_name=instance,
             destination_instance_name=instance,
             project=project,
         )
+
+    assert raised.value == LXDError(
+        brief=(
+            f"Failed to copy instance 'local:{instance_name}' to 'local:"
+            f"{instance_name}'."
+        ),
+        details=(
+            f"* Command that failed: 'lxc --project {project} copy local:"
+            f"{instance_name} local:{instance_name}'\n"
+            "* Command exit code: 1\n"
+            "* Command standard error output: b'Error: Failed creating instance "
+            'record: Add instance info to the database: This "instances" entry '
+            "already exists\\n'"
+        ),
+    )
 
 
 def test_delete(instance, lxc, project):

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -358,6 +358,85 @@ def test_config_set_error(fake_process):
     )
 
 
+def test_copy(fake_process):
+    """Test `copy()` with default arguments."""
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "default",
+            "copy",
+            "local:test-source-instance-name",
+            "local:test-destination-instance-name",
+        ],
+    )
+
+    LXC().copy(
+        source_instance_name="test-source-instance-name",
+        destination_instance_name="test-destination-instance-name",
+    )
+
+    assert len(fake_process.calls) == 1
+
+
+def test_copy_all_opts(fake_process):
+    """Test `copy() with all arguments defined`."""
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "copy",
+            "test-source-remote:test-source-instance-name",
+            "test-destination-remote:test-destination-instance-name",
+        ],
+    )
+
+    LXC().copy(
+        source_remote="test-source-remote",
+        source_instance_name="test-source-instance-name",
+        destination_remote="test-destination-remote",
+        destination_instance_name="test-destination-instance-name",
+        project="test-project",
+    )
+
+    assert len(fake_process.calls) == 1
+
+
+def test_copy_error(fake_process):
+    """A LXDError should be raised when the copy command fails."""
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "copy",
+            "test-source-remote:test-source-instance-name",
+            "test-destination-remote:test-destination-instance-name",
+        ],
+        returncode=1,
+    )
+
+    with pytest.raises(LXDError) as exc_info:
+        LXC().copy(
+            source_remote="test-source-remote",
+            source_instance_name="test-source-instance-name",
+            destination_remote="test-destination-remote",
+            destination_instance_name="test-destination-instance-name",
+            project="test-project",
+        )
+
+    assert exc_info.value == LXDError(
+        brief=(
+            "Failed to copy instance 'test-source-remote:test-source-instance-name' "
+            "to 'test-destination-remote:test-destination-instance-name'."
+        ),
+        details=errors.details_from_called_process_error(
+            exc_info.value.__cause__  # type: ignore
+        ),
+    )
+
+
 def test_delete(fake_process):
     fake_process.register_subprocess(
         [


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add `copy()` to LXC class to make a copy of an instance.

(CRAFT-1479)