### PR TITLE
tests: bump MacOS runner from 10.15 to 11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,8 +66,8 @@ jobs:
         uses: codecov/codecov-action@v1
 
   macos-integration-tests:
-    name: MacOS 10.15 Integration Tests
-    runs-on: macos-10.15
+    name: MacOS Integration Tests
+    runs-on: macos-11
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -82,6 +82,7 @@ jobs:
           brew install multipass
           multipass version
           sleep 20
+          multipass set local.driver=qemu
       - name: Run integration tests on MacOS
         run: |
           export CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_INSTALL=1

--- a/tests/integration/multipass/conftest.py
+++ b/tests/integration/multipass/conftest.py
@@ -17,6 +17,7 @@
 
 """Fixtures for Multipass integration tests."""
 import subprocess
+import sys
 import time
 from contextlib import contextmanager
 
@@ -83,3 +84,16 @@ def tmp_instance(
         capture_output=True,
         check=False,
     )
+
+
+@pytest.fixture(autouse=True)
+def slow_down_tests():
+    """Workaround for MacOS 11 and 12.
+
+    When repeatedly launching, using, and deleting the same instance, the network
+    may be ready immediately. Because there is no API call to check if the network is
+    ready, a time delay is used.
+    """
+    yield
+    if sys.platform == "darwin":
+        time.sleep(30)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The macos-10.15 action runner is [being deprecated on 2022-Dec-01](https://github.com/actions/runner-images/issues/5583).

(CRAFT-1447)