### PR TITLE
ci: run workflow on all pull requests and oneflow branches

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,9 +2,11 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - "main"
+      - "release/*"
+      - "hotfix/*"
   pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
## Overview
Minor CI change to support the OneFlow workflow and align with [other craft workflows](https://github.com/snapcore/snapcraft/blob/31a3990c8f42eb27c326e42b7a79619996ab456d/.github/workflows/tests.yaml#L2).

## Details
The GitHub CI workflow runs on all pull requests.
Additionally, it runs when pushing to any OneFlow branch beginning with `release/` or `hotfix/`.