### PR TITLE
tests: improve lxd launcher tests for base instances

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -357,7 +357,7 @@ def launch(
     # instance and base instance
     if not _is_valid(base_instance):
         logger.warning(
-            "Base instance %r is expired. Deleting base instance.",
+            "Base instance %r is not valid. Deleting base instance.",
             base_instance.instance_name,
         )
         base_instance.delete()

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -211,3 +211,10 @@ def test_disk_add_remove(instance, lxc, tmp_path, project):
             instance_name=instance,
             check=True,
         )
+
+
+def test_info(instance, lxc, project):
+    """Test `info()` method works as expected."""
+    data = lxc.info(instance_name=instance, project=project)
+
+    assert data["Name"] == instance

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -79,6 +79,11 @@ def mock_lxd_instance(fake_instance, fake_base_instance, mocker):
     )
 
 
+@pytest.fixture
+def mock_is_valid(mocker):
+    yield mocker.patch("craft_providers.lxd.launcher._is_valid", return_value=True)
+
+
 def test_launch_no_base_instance(
     fake_instance, mock_base_configuration, mock_lxc, mock_lxd_instance
 ):
@@ -121,6 +126,7 @@ def test_launch_use_base_instance(
     fake_instance,
     fake_base_instance,
     mock_base_configuration,
+    mock_is_valid,
     mock_lxc,
     mock_lxd_instance,
 ):
@@ -185,6 +191,7 @@ def test_launch_use_existing_base_instance(
     fake_instance,
     fake_base_instance,
     mock_base_configuration,
+    mock_is_valid,
     mock_lxc,
     mock_lxd_instance,
 ):
@@ -239,13 +246,13 @@ def test_launch_existing_base_instance_invalid(
     fake_instance,
     fake_base_instance,
     mock_base_configuration,
+    mock_is_valid,
     mock_lxc,
     mock_lxd_instance,
-    mocker,
 ):
     """If the existing base instance is invalid, delete it and create a new instance."""
     fake_base_instance.exists.return_value = True
-    mocker.patch("craft_providers.lxd.launcher._is_valid", return_value=False)
+    mock_is_valid.return_value = False
 
     lxd.launch(
         name=fake_instance.name,
@@ -630,6 +637,7 @@ def test_use_snapshots_deprecated(
     fake_instance,
     fake_base_instance,
     logs,
+    mock_is_valid,
     mock_base_configuration,
     mock_lxc,
     mock_lxd_instance,


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Minor cleanup prior to adding support for expiring base instance.

- Add more assertions for lxd launcher to ensure the base instance mechanism is working.
- Mock `is_valid()` function
- Add an integration test for `lxc.info()`
- Clarify an error message