### PR TITLE
lxd: delete and recreate invalid bases instances

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -18,6 +18,7 @@
 """LXD Instance Provider."""
 
 import logging
+from datetime import datetime, timedelta
 from typing import Optional
 
 from craft_providers import Base, ProviderError, bases
@@ -136,13 +137,58 @@ def _formulate_base_instance_name(
     return "-".join(["base-instance", compatibility_tag, image_remote, image_name])
 
 
-# TODO: Implement this stubbed function (CRAFT-1341)
-# pylint: disable-next=unused-argument
-def _is_valid(instance: LXDInstance) -> bool:
-    """Check if a instance is valid (i.e. the base instance is not expired).
+def _is_valid(*, instance_name: str, project: str, remote: str, lxc: LXC) -> bool:
+    """Check if a instance is valid.
 
-    :returns: True if the instance is valid.
+    Instances are valid for 3 months (90 days). After 3 months, they are considered
+    expired and invalid.
+
+    If errors occur during the validity check, the instance is assumed to be invalid.
+
+    :param instance: Name of instance to check the validity of.
+    :param project: LXD project name to create.
+    :param remote: LXD remote to create project on.
+    :param lxc: LXC client.
+
+    :returns: True if the instance is valid. False otherwise.
     """
+    logger.debug("Checking validity of instance %r.", instance_name)
+
+    # capture instance info
+    try:
+        info = lxc.info(instance_name=instance_name, project=project, remote=remote)
+    except LXDError as raised:
+        # if the base instance info can't be retrieved, consider it invalid
+        logger.warning("Could not get instance info with error: %s", raised)
+        return False
+
+    creation_date_raw = info.get("Created")
+
+    # if the base instance does not have a creation date, consider it invalid
+    if not creation_date_raw:
+        logger.warning("Instance does not have a 'Created' date.")
+        return False
+
+    # parse datetime
+    try:
+        creation_date = datetime.strptime(creation_date_raw, "%Y/%m/%d %H:%M %Z")
+    except ValueError as raised:
+        # if the date can't be parsed, consider it invalid
+        logger.warning(
+            "Could not parse instance's 'Created' date with error: %s", raised
+        )
+        return False
+
+    expiration_date = datetime.now() - timedelta(days=90)
+    if creation_date < expiration_date:
+        logger.warning(
+            "Instance is expired (Instance creation date: %s, expiration date: %s).",
+            creation_date,
+            expiration_date,
+        )
+        return False
+
+    logger.debug("Instance is valid.")
     return True
 
 
@@ -222,8 +268,6 @@ def launch(
     a new instance on a subsequent run, the base instance will be copied to create the
     new instance. This instance is run through a small subset of the setup, which is
     referred to as 'warmup'.
-
-    TODO: Implement the expiration mechanism described below (CRAFT-1341).
 
     To keep build environments clean, consistent, and up-to-date, any base instance
     older than 3 months (90 days) is deleted and recreated.
@@ -355,7 +399,12 @@ def launch(
 
     # the base instance exists but is not valid, so delete it then create a new
     # instance and base instance
-    if not _is_valid(base_instance):
+    if not _is_valid(
+        instance_name=base_instance.instance_name,
+        project=project,
+        remote=remote,
+        lxc=lxc,
+    ):
         logger.warning(
             "Base instance %r is not valid. Deleting base instance.",
             base_instance.instance_name,

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -138,7 +138,7 @@ def _formulate_base_instance_name(
 
 
 def _is_valid(*, instance_name: str, project: str, remote: str, lxc: LXC) -> bool:
-    """Check if a instance is valid.
+    """Check if an instance is valid.
 
     Instances are valid for 3 months (90 days). After 3 months, they are considered
     expired and invalid.
@@ -175,7 +175,7 @@ def _is_valid(*, instance_name: str, project: str, remote: str, lxc: LXC) -> boo
     except ValueError as raised:
         # if the date can't be parsed, consider it invalid
         logger.warning(
-            "Could not parse instance's 'Created' date with error: %s", raised
+            "Could not parse instance's 'Created' date with error: %r", raised
         )
         return False
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ test_requires = [
     "black",
     "codespell",
     "flake8",
+    "freezegun",
     "isort",
     "mypy",
     "logassert",

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -19,8 +19,10 @@ import io
 import os
 import pathlib
 import subprocess
+from datetime import datetime, timedelta
 
 import pytest
+from freezegun import freeze_time
 
 from craft_providers import bases, lxd
 from craft_providers.lxd import project as lxd_project
@@ -164,12 +166,83 @@ def test_launch_use_base_instance(get_base_instance, launch_args, instance_name)
             use_base_instance=True,
         )
 
-        assert instance.exists()
-        assert instance.is_running()
-
         # confirm the same instance was launched with both fingerprints
         instance.execute_run(["stat", "/base-instance"], check=True)
         instance.execute_run(["stat", "/instance"], check=True)
+
+        assert instance.exists()
+        assert instance.is_running()
+    finally:
+        if instance.exists():
+            instance.delete()
+        if base_instance.exists():
+            base_instance.delete()
+
+
+@freeze_time(datetime.now() + timedelta(days=91))
+def test_launch_use_base_instance_expired(get_base_instance, instance_name):
+    """Launch an instance using an expired base instance.
+
+    First, launch an instance from an image and create a base instance.
+    Then launch an instance from the expired base instance, which will trigger the
+    creation of a new instance and base instance.
+
+    The LXD instance is created via subprocess, so the creation date the instance is
+    out of freezegun's scope and can't be modified.
+    """
+    base_instance = get_base_instance()
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    instance = lxd.launch(
+        name=instance_name,
+        base_configuration=base_configuration,
+        image_name="20.04",
+        image_remote="ubuntu",
+        use_base_instance=True,
+    )
+
+    try:
+        # the instance and base instance should both exist
+        assert instance.exists()
+        assert base_instance.exists()
+
+        # only the instance should be running
+        assert instance.is_running()
+        assert not base_instance.is_running()
+
+        # fingerprint the expired base instance
+        base_instance.start()
+        base_instance.execute_run(["touch", "/base-instance"])
+        base_instance.stop()
+
+        # delete the instance so a new instance is created from the base instance
+        instance.delete()
+        instance = lxd.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            use_base_instance=True,
+        )
+
+        assert instance.exists()
+        assert instance.is_running()
+
+        # confirm instance does not have the expired base instance's fingerprint
+        proc = instance.execute_run(
+            ["stat", "/base-instance"], capture_output=True, text=True
+        )
+        assert proc.returncode == 1
+        assert "'/base-instance': No such file or directory" in proc.stderr
+
+        # confirm new base instance does not have the expired base instance's
+        # fingerprint
+        base_instance.start()
+        proc = base_instance.execute_run(
+            ["stat", "/base-instance"], capture_output=True, text=True
+        )
+        assert proc.returncode == 1
+        assert "'/base-instance': No such file or directory" in proc.stderr
 
     finally:
         if instance.exists():

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -791,8 +791,8 @@ def test_is_valid_value_error(logs, mocker, mock_lxc):
     assert not is_valid
     assert (
         Exact(
-            "Could not parse instance's 'Created' date with error: "
-            "time data 'bad-datetime-value' does not match format '%Y/%m/%d %H:%M %Z'"
+            "Could not parse instance's 'Created' date with error: ValueError(\"time "
+            "data 'bad-datetime-value' does not match format '%Y/%m/%d %H:%M %Z'\")"
         )
         in logs.warning
     )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

To keep build environments clean, consistent, and up-to-date, any base instance older than 3 months (90 days) is deleted and recreated.

(CRAFT-1342)