### PR TITLE
MultipassInstance: `push_file_io()` method works regardless of working dir

### DIFF
--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -96,6 +96,13 @@ class Multipass:
     ):
         """Execute command in instance_name with specified runner.
 
+        The working directory the command is executed from inside the instance depends
+        on the host's cwd. From the Multipass documentation:
+        "In case we are executing the alias on the host from a directory which is
+        mounted on the instance, the command will be executed on the instance from
+        there. If the working directory is not mounted on the instance, the command will
+        be executed on the default directory on the instance."
+
         :param command: Command to execute in the instance.
         :param instance_name: Name of instance to execute in.
         :param runner: Execution function to invoke, e.g. subprocess.run or
@@ -280,6 +287,13 @@ class Multipass:
 
     def transfer(self, *, source: str, destination: str) -> None:
         """Transfer to destination path with source IO.
+
+        Multipass transfer uses sftp. By default, only the user `ubuntu` can transfer
+        files. Therefore, the path inside the instance should be accessible by the
+        `ubuntu` user.
+
+        By default, Multipass only has access to the host's home directory. The host's
+        path should be inside the home directory.
 
         :param source: The source path, prefixed with <name:> for a path inside
             the instance.

--- a/craft_providers/multipass/multipass_instance.py
+++ b/craft_providers/multipass/multipass_instance.py
@@ -119,7 +119,7 @@ class MultipassInstance(Executor):
                 source=content, destination=f"{self.name}:{tmp_file_path}"
             )
 
-            # now that the file has been transferred, it's ownership can be set
+            # now that the file has been transferred, its ownership can be set
             self.execute_run(
                 ["chown", f"{user}:{group}", tmp_file_path],
                 capture_output=True,

--- a/tests/unit/multipass/test_multipass_instance.py
+++ b/tests/unit/multipass/test_multipass_instance.py
@@ -123,11 +123,25 @@ def test_push_file_io(mock_multipass, instance):
     assert mock_multipass.mock_calls == [
         mock.call.exec(
             instance_name="test-instance",
-            command=["mktemp"],
+            command=["sudo", "-H", "--", "mktemp"],
             runner=subprocess.run,
             capture_output=True,
             check=True,
             text=True,
+        ),
+        mock.call.exec(
+            instance_name="test-instance",
+            command=[
+                "sudo",
+                "-H",
+                "--",
+                "chown",
+                "ubuntu:ubuntu",
+                "/tmp/mktemp-result",
+            ],
+            runner=subprocess.run,
+            capture_output=True,
+            check=True,
         ),
         mock.call.transfer_source_io(
             source=mock.ANY, destination="test-instance:/tmp/mktemp-result"
@@ -183,7 +197,10 @@ def test_push_file_io_error(mock_multipass, instance):
         )
 
     assert exc_info.value == MultipassError(
-        brief="Failed to create file '/etc/test.conf' in 'test-instance' VM.",
+        brief=(
+            "Failed to create file '/etc/test.conf' in Multipass instance "
+            "'test-instance'."
+        ),
         details=errors.details_from_called_process_error(error),
     )
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The method `push_file_io()` fails when it executes inside a working directory that the `ubuntu` user does not have access to. This scenario can occur after *craft applications mount the host's working directory to /root/project.

This minor defect was a side effect of the release of Multipass v1.10.0.  (see [release notes](https://github.com/canonical/multipass/releases/tag/v1.10.0) and [updated documentation](https://multipass.run/docs/exec-command)).

The change itself is small.  The PR is mostly docstrings and comments.

(CRAFT-1544)