### PR TITLE
lxd: set instance id map after launching or copying an instance

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -267,7 +267,9 @@ def _set_id_map(
     :param remote: LXD remote to create instance on.
     :param uid: The uid to be mapped. If not supplied, the current user's uid is used.
     """
-    uid = uid if uid else os.getuid()
+    if uid is None:
+        uid = os.getuid()
+
     lxc.config_set(
         instance_name=instance.instance_name,
         key="raw.idmap",

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -387,8 +387,8 @@ class LXDInstance(Executor):
 
         :param image: Image name to launch.
         :param image_remote: Image remote name.
-        :param map_user_id: Whether id mapping should be used.
-        :param uid: If ``map_user_id`` is True,
+        :param map_user_uid: Whether id mapping should be used.
+        :param uid: If ``map_user_uid`` is True,
                     the host user ID to map to instance root.
         :param ephemeral: Flag to enable ephemeral instance.
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
The id map for LXD instances needs to be set after an instance is launched from an image or after copying from a base instance.

(CRAFT-1577)