### PR TITLE
lxd: use new `use_base_instance` parameter

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -292,7 +292,7 @@ def launch(
     map_user_uid: bool = False,
     uid: Optional[int] = None,
     use_snapshots: Optional[bool] = None,
-    use_base_instance: Optional[bool] = False,
+    use_base_instance: bool = False,
     project: str = "default",
     remote: str = "local",
     lxc: LXC = LXC(),

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -132,7 +132,7 @@ class LXDProvider(Provider):
                 auto_create_project=True,
                 map_user_uid=True,
                 uid=project_path.stat().st_uid,
-                use_snapshots=True,
+                use_base_instance=True,
                 project=self.lxd_project,
                 remote=self.lxd_remote,
             )

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -149,7 +149,7 @@ def test_launched_environment(
                 auto_create_project=True,
                 map_user_uid=True,
                 uid=tmp_path.stat().st_uid,
-                use_snapshots=True,
+                use_base_instance=True,
                 project="default",
                 remote="local",
             ),


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Minor PR to use the new `use_base_instance` parameter when launching LXD instances.