### PR TITLE
lxc: add new method `config_get()`

### DIFF
--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -208,6 +208,45 @@ class LXC:  # pylint: disable=too-many-public-methods
 
         return load_yaml(proc.stdout)
 
+    def config_get(
+        self,
+        *,
+        instance_name: str,
+        key: str,
+        project: str = "default",
+        remote: str = "local",
+    ) -> str:
+        """Get the value of an instance's config key.
+
+        This command only returns a single string value. It is different in behavior
+        than most other lxc commands, which can return multiple lines of yaml (like
+        `lxc config show`).
+
+        :param instance_name: Name of instance.
+        :param key: Config key name.
+        :param project: Name of LXD project.
+        :param remote: Name of LXD remote.
+
+        :returns: String containing the key's value. If the key does not exist, then
+        an empty string is returned.
+
+        :raises LXDError: on unexpected error.
+        """
+        command = ["config", "get", f"{remote}:{instance_name}", key]
+
+        try:
+            return self._run_lxc(
+                command, capture_output=True, check=True, text=True, project=project
+            ).stdout.rstrip()
+        except subprocess.CalledProcessError as error:
+            raise LXDError(
+                brief=(
+                    f"Failed to get value for config key {key!r} "
+                    f"for instance {instance_name!r}."
+                ),
+                details=errors.details_from_called_process_error(error),
+            ) from error
+
     def config_set(
         self,
         *,

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -42,6 +42,29 @@ def test_exec(instance, lxc, project):
     assert proc.stdout == b"this is a test\n"
 
 
+def test_config_get_and_set(instance, instance_name, lxc, project):
+    """Set and get config key/value pairs."""
+    lxc.config_set(
+        instance_name=instance,
+        key="user.test-key",  # `user` namespace is for arbitrary config values
+        value="test-value",
+        project=project,
+    )
+
+    value = lxc.config_get(instance_name=instance, key="user.test-key", project=project)
+
+    assert value == "test-value"
+
+
+def test_config_get_non_existent_key(instance, instance_name, lxc, project):
+    """Get a non-existent key and confirm the value is an empty string."""
+    value = lxc.config_get(
+        instance_name=instance, key="non-existant-key", project=project
+    )
+
+    assert value == ""
+
+
 def test_copy(instance, instance_name, lxc, project):
     """Test `copy()` with default arguments."""
     destination_instance_name = instance_name + "-destination"

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -298,6 +298,62 @@ def test_config_device_show_error(fake_process):
     )
 
 
+def test_config_get(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "config",
+            "get",
+            "test-remote:test-instance",
+            "test-key",
+        ],
+    )
+
+    LXC().config_get(
+        instance_name="test-instance",
+        key="test-key",
+        project="test-project",
+        remote="test-remote",
+    )
+
+    assert len(fake_process.calls) == 1
+
+
+def test_config_get_error(fake_process):
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "config",
+            "get",
+            "test-remote:test-instance",
+            "test-key",
+        ],
+        returncode=1,
+    )
+
+    with pytest.raises(LXDError) as exc_info:
+        LXC().config_get(
+            instance_name="test-instance",
+            key="test-key",
+            project="test-project",
+            remote="test-remote",
+        )
+
+    assert exc_info.value == LXDError(
+        brief=(
+            "Failed to get value for config key 'test-key' "
+            "for instance 'test-instance'."
+        ),
+        details=errors.details_from_called_process_error(
+            exc_info.value.__cause__  # type: ignore
+        ),
+    )
+
+
 def test_config_set(fake_process):
     fake_process.register_subprocess(
         [


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This method allows for retrieving the value of a single key in a LXD instance's config key/value store.

It's required to unblock [this TODO](https://github.com/canonical/craft-providers/blob/fd238327501662014bb0df76ed468de4c2e7bee9/craft_providers/lxd/launcher.py#L219) for CRAFT-1576.