### PR TITLE
lxd: add default for _run_lxc() parameter `check=True`

### DIFF
--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -130,11 +130,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         ]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to add disk to instance {instance_name!r}.",
@@ -158,20 +154,10 @@ class LXC:  # pylint: disable=too-many-public-methods
 
         :raises LXDError: on unexpected error.
         """
-        command = [
-            "config",
-            "device",
-            "remove",
-            f"{remote}:{instance_name}",
-            device,
-        ]
+        command = ["config", "device", "remove", f"{remote}:{instance_name}", device]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to remove device from instance {instance_name!r}.",
@@ -192,11 +178,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["config", "device", "show", f"{remote}:{instance_name}"]
 
         try:
-            proc = self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            proc = self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to show devices for instance {instance_name!r}.",
@@ -227,11 +209,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["config", "set", f"{remote}:{instance_name}", key, value]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=(
@@ -271,11 +249,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["copy", source, destination]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=(f"Failed to copy instance {source!r} to {destination!r}."),
@@ -305,11 +279,7 @@ class LXC:  # pylint: disable=too-many-public-methods
             command.append("--force")
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to delete instance {instance_name!r}.",
@@ -401,11 +371,7 @@ class LXC:  # pylint: disable=too-many-public-methods
             command.append("--recursive")
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=(
@@ -467,11 +433,7 @@ class LXC:  # pylint: disable=too-many-public-methods
             command.append(f"--uid={uid}")
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=(
@@ -520,11 +482,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["info", remote + ":" + instance_name]
 
         try:
-            proc = self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            proc = self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to get info for remote {remote!r}.",
@@ -565,11 +523,7 @@ class LXC:  # pylint: disable=too-many-public-methods
 
         :raises LXDError: on unexpected error.
         """
-        command = [
-            "launch",
-            f"{image_remote}:{image}",
-            f"{remote}:{instance_name}",
-        ]
+        command = ["launch", f"{image_remote}:{image}", f"{remote}:{instance_name}"]
 
         if ephemeral:
             command.append("--ephemeral")
@@ -610,22 +564,13 @@ class LXC:  # pylint: disable=too-many-public-methods
 
         :raises LXDError: on unexpected error.
         """
-        command = [
-            "image",
-            "copy",
-            f"{image_remote}:{image}",
-            f"{remote}:",
-        ]
+        command = ["image", "copy", f"{image_remote}:{image}", f"{remote}:"]
 
         if alias is not None:
             command.append(f"--alias={alias}")
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to copy image {image!r}.",
@@ -643,18 +588,10 @@ class LXC:  # pylint: disable=too-many-public-methods
 
         :raises LXDError: on unexpected error.
         """
-        command = [
-            "image",
-            "delete",
-            f"{remote}:{image}",
-        ]
+        command = ["image", "delete", f"{remote}:{image}"]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to delete image {image!r}.",
@@ -672,11 +609,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["image", "list", f"{remote}:", "--format=yaml"]
 
         try:
-            proc = self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            proc = self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to list images for project {project!r}.",
@@ -712,11 +645,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["list", f"{remote}:", "--format=yaml"]
 
         try:
-            proc = self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            proc = self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to list instances for project {project!r}.",
@@ -779,10 +708,7 @@ class LXC:  # pylint: disable=too-many-public-methods
 
         try:
             self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-                input=encoded_config,
+                command, capture_output=True, project=project, input=encoded_config
             )
         except subprocess.CalledProcessError as error:
             raise LXDError(
@@ -804,11 +730,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["profile", "show", f"{remote}:{profile}"]
 
         try:
-            proc = self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            proc = self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to show profile {profile!r}.",
@@ -828,11 +750,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["project", "create", f"{remote}:{project}"]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to create project {project!r}.",
@@ -850,11 +768,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["project", "delete", f"{remote}:{project}"]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to delete project {project!r}.",
@@ -873,10 +787,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["project", "list", f"{remote}:", "--format=yaml"]
 
         try:
-            proc = self._run_lxc(
-                command,
-                capture_output=True,
-            )
+            proc = self._run_lxc(command, capture_output=True)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to list projects on remote {remote!r}.",
@@ -916,11 +827,7 @@ class LXC:  # pylint: disable=too-many-public-methods
 
         :raises LXDError: on unexpected error.
         """
-        command = [
-            "publish",
-            f"{remote}:{instance_name}",
-            f"{image_remote}:",
-        ]
+        command = ["publish", f"{remote}:{instance_name}", f"{image_remote}:"]
 
         if alias is not None:
             command.append(f"--alias={alias}")
@@ -929,11 +836,7 @@ class LXC:  # pylint: disable=too-many-public-methods
             command.append("--force")
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to publish image from {instance_name!r}.",
@@ -954,10 +857,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["remote", "add", remote, addr, f"--protocol={protocol}"]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-            )
+            self._run_lxc(command, capture_output=True)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to add remote {remote!r}.",
@@ -972,10 +872,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["remote", "list", "--format=yaml"]
 
         try:
-            proc = self._run_lxc(
-                command,
-                capture_output=True,
-            )
+            proc = self._run_lxc(command, capture_output=True)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief="Failed to list remotes.",
@@ -1007,11 +904,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         command = ["start", f"{remote}:{instance_name}"]
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to start {instance_name!r}.",
@@ -1046,11 +939,7 @@ class LXC:  # pylint: disable=too-many-public-methods
             command.append(f"--timeout={timeout}")
 
         try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+            self._run_lxc(command, capture_output=True, project=project)
         except subprocess.CalledProcessError as error:
             raise LXDError(
                 brief=f"Failed to stop {instance_name!r}.",

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -66,7 +66,7 @@ class LXC:  # pylint: disable=too-many-public-methods
         self,
         command: List[str],
         *,
-        check: bool,
+        check: bool = True,
         project: Optional[str] = None,
         stdin: StdinType = StdinType.INTERACTIVE,
         **kwargs,
@@ -133,7 +133,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -171,7 +170,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -197,7 +195,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             proc = self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -233,7 +230,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -278,7 +274,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -313,7 +308,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -410,7 +404,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -477,7 +470,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -531,7 +523,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             proc = self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -591,7 +582,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 stdin=StdinType.INTERACTIVE,
                 project=project,
             )
@@ -634,7 +624,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -664,7 +653,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -687,7 +675,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             proc = self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -728,7 +715,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             proc = self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -795,7 +781,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
                 input=encoded_config,
             )
@@ -822,7 +807,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             proc = self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -847,7 +831,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -870,7 +853,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -894,7 +876,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             proc = self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
             )
         except subprocess.CalledProcessError as error:
             raise LXDError(
@@ -951,7 +932,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -977,7 +957,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
             )
         except subprocess.CalledProcessError as error:
             raise LXDError(
@@ -996,7 +975,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             proc = self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
             )
         except subprocess.CalledProcessError as error:
             raise LXDError(
@@ -1032,7 +1010,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:
@@ -1072,7 +1049,6 @@ class LXC:  # pylint: disable=too-many-public-methods
             self._run_lxc(
                 command,
                 capture_output=True,
-                check=True,
                 project=project,
             )
         except subprocess.CalledProcessError as error:

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -30,9 +30,7 @@ def test_lxc_run_default(mocker, tmp_path):
     """Test _lxc_run with default arguments."""
     mock_run = mocker.patch("subprocess.run")
 
-    LXC()._run_lxc(
-        command=["test-command"],
-    )
+    LXC()._run_lxc(command=["test-command"])
 
     assert mock_run.mock_calls[:1] == [
         call(
@@ -41,6 +39,7 @@ def test_lxc_run_default(mocker, tmp_path):
             stdin=subprocess.DEVNULL,
         ),
     ]
+
 
 @pytest.mark.parametrize("check", [True, False])
 def test_lxc_run_with_check(check, mocker, tmp_path):
@@ -62,10 +61,7 @@ def test_lxc_run_with_project(mocker, tmp_path):
     """Test _lxc_run with project."""
     mock_run = mocker.patch("subprocess.run")
 
-    LXC()._run_lxc(
-        command=["test-command"],
-        project="test-project",
-    )
+    LXC()._run_lxc(command=["test-command"], project="test-project")
 
     assert mock_run.mock_calls[:1] == [
         call(
@@ -81,9 +77,7 @@ def test_lxc_run_with_stdin(mocker, tmp_path):
     mock_run = mocker.patch("subprocess.run")
 
     LXC()._run_lxc(
-        command=["test-command"],
-        project="test-project",
-        stdin=lxc.StdinType.NULL,
+        command=["test-command"], project="test-project", stdin=lxc.StdinType.NULL
     )
 
     assert mock_run.mock_calls[:1] == [

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -32,13 +32,27 @@ def test_lxc_run_default(mocker, tmp_path):
 
     LXC()._run_lxc(
         command=["test-command"],
-        check=True,
     )
 
     assert mock_run.mock_calls[:1] == [
         call(
             ["lxc", "test-command"],
             check=True,
+            stdin=subprocess.DEVNULL,
+        ),
+    ]
+
+@pytest.mark.parametrize("check", [True, False])
+def test_lxc_run_with_check(check, mocker, tmp_path):
+    """Test check parameter."""
+    mock_run = mocker.patch("subprocess.run")
+
+    LXC()._run_lxc(command=["test-command"], check=check, project="test-project")
+
+    assert mock_run.mock_calls[:1] == [
+        call(
+            ["lxc", "--project", "test-project", "test-command"],
+            check=check,
             stdin=subprocess.DEVNULL,
         ),
     ]
@@ -50,7 +64,6 @@ def test_lxc_run_with_project(mocker, tmp_path):
 
     LXC()._run_lxc(
         command=["test-command"],
-        check=True,
         project="test-project",
     )
 
@@ -69,7 +82,6 @@ def test_lxc_run_with_stdin(mocker, tmp_path):
 
     LXC()._run_lxc(
         command=["test-command"],
-        check=True,
         project="test-project",
         stdin=lxc.StdinType.NULL,
     )
@@ -89,7 +101,6 @@ def test_lxc_run_with_input(mocker, tmp_path):
 
     LXC()._run_lxc(
         command=["test-command"],
-        check=True,
         project="test-project",
         stdin=lxc.StdinType.NULL,
         input="test-input",
@@ -110,7 +121,6 @@ def test_lxc_run_with_input_and_stdin(mocker, tmp_path):
 
     LXC()._run_lxc(
         command=["test-command"],
-        check=True,
         project="test-project",
         stdin=lxc.StdinType.NULL,
         input="test-input",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

No functional changes.

1. Add default for private method `run_lxd()`'s parameter `check=True` .  I did this because all calls to this method were setting `check=True`.
2. Reformat calls to `_run_lxc()` to improve readability
