### PR TITLE
lxd: check id map when launching an existing instance

### DIFF
--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -523,6 +523,7 @@ def test_launch_os_incompatible(core20_instance):
         == "Incompatible base detected: Expected OS 'Ubuntu', found 'Fedora'."
     )
 
+    # TODO: split this into a separate test
     # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
         name=core20_instance.name,
@@ -562,6 +563,7 @@ def test_launch_instance_config_incompatible(core20_instance):
         " Expected image compatibility tag 'buildd-base-v0', found 'invalid'."
     )
 
+    # TODO: split this into a separate test
     # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
         name=core20_instance.name,
@@ -575,10 +577,8 @@ def test_launch_instance_config_incompatible(core20_instance):
     assert core20_instance.is_running()
 
 
-def test_launch_instance_id_map_incompatible(core20_instance):
-    """Raise an error if the instance's id map is incompatible.
-    If auto_clean is true, delete and recreate the instance.
-    """
+def test_launch_instance_id_map_incompatible_without_auto_clean(core20_instance):
+    """Raise an error if the id map is incompatible and auto_clean is False."""
     base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
 
     lxc = lxd.LXC()
@@ -601,6 +601,18 @@ def test_launch_instance_id_map_incompatible(core20_instance):
     assert exc_info.value.brief == (
         "Incompatible base detected: "
         "the instance's id map ('raw.idmap') is not configured as expected."
+    )
+
+
+def test_launch_instance_id_map_incompatible_with_auto_clean(core20_instance):
+    """Clean the instance if the id map is incompatible and auto_clean is True."""
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    lxc = lxd.LXC()
+    lxc.config_set(
+        instance_name=core20_instance.instance_name,
+        key="raw.idmap",
+        value="",  # equivalent to `lxc config unset`, which is not yet implemented
     )
 
     # when auto_clean is true, the instance will be deleted and recreated

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -560,6 +560,47 @@ def test_launch_instance_config_incompatible(core20_instance):
     assert exc_info.value.brief == (
         "Incompatible base detected:"
         " Expected image compatibility tag 'buildd-base-v0', found 'invalid'."
+    )
+
+    # when auto_clean is true, the instance will be deleted and recreated
+    lxd.launch(
+        name=core20_instance.name,
+        base_configuration=base_configuration,
+        image_name="20.04",
+        image_remote="ubuntu",
+        auto_clean=True,
+    )
+
+    assert core20_instance.exists()
+    assert core20_instance.is_running()
+
+
+def test_launch_instance_id_map_incompatible(core20_instance):
+    """Raise an error if the instance's id map is incompatible.
+    If auto_clean is true, delete and recreate the instance.
+    """
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    lxc = lxd.LXC()
+    lxc.config_set(
+        instance_name=core20_instance.instance_name,
+        key="raw.idmap",
+        value="",  # equivalent to `lxc config unset`, which is not yet implemented
+    )
+
+    # will raise compatibility error when auto_clean is false
+    with pytest.raises(bases.BaseCompatibilityError) as exc_info:
+        lxd.launch(
+            name=core20_instance.name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            map_user_uid=True,
+        )
+
+    assert exc_info.value.brief == (
+        "Incompatible base detected: "
+        "the instance's id map ('raw.idmap') is not configured as expected."
     )
 
     # when auto_clean is true, the instance will be deleted and recreated


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

If an existing instance has a mismatched id map, either the instance will be auto-cleaned or a `BaseCompatibiltyError` will be raised.


(CRAFT-1576)