### PR TITLE
lint: fixes for black and pylint

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -60,9 +60,9 @@ def default_command_environment() -> Dict[str, Optional[str]]:
 
     :returns: Dictionary of environment key/values.
     """
-    return dict(
-        PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
-    )
+    return {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+    }
 
 
 def _check_deadline(

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -136,7 +136,7 @@ class LXDProvider(Provider):
                 project=self.lxd_project,
                 remote=self.lxd_remote,
             )
-        except (BaseConfigurationError) as error:
+        except BaseConfigurationError as error:
             raise LXDError(str(error)) from error
 
         try:

--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -334,7 +334,6 @@ class Multipass:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ) as proc:
-
             # Should never happen, but mypy/pyright makes noise.
             assert proc.stdout is not None
             assert proc.stderr is not None

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -111,7 +111,7 @@ class MultipassProvider(Provider):
                 mem_gb=2,
                 auto_clean=True,
             )
-        except (bases.BaseConfigurationError) as error:
+        except bases.BaseConfigurationError as error:
             raise MultipassError(str(error)) from error
 
         try:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -257,6 +257,7 @@ def dangerously_installed_snap(tmpdir):
             # collect the file name
             match = re.search(f"{snap_name}_\\d+.snap", str(output))
             if not match:
+                # pylint: disable-next=broad-exception-raised
                 raise Exception(
                     "could not parse snap file name from output of "
                     f"'snap download {snap_name}' (output = {output!r})"

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -86,11 +86,11 @@ def mock_inject_from_host(mocker):
             ).encode(),
         ),
         (
-            dict(
-                https_proxy="http://foo.bar:8081",
-                PATH="/snap",
-                http_proxy="http://foo.bar:8080",
-            ),
+            {
+                "https_proxy": "http://foo.bar:8081",
+                "PATH": "/snap",
+                "http_proxy": "http://foo.bar:8080",
+            },
             (
                 "https_proxy=http://foo.bar:8081\n"
                 "PATH=/snap\nhttp_proxy=http://foo.bar:8080\n"
@@ -276,42 +276,42 @@ def test_setup(  # pylint: disable=too-many-arguments, too-many-locals
     base_config.setup(executor=fake_executor)
 
     expected_push_file_io = [
-        dict(
-            destination="/etc/apt/apt.conf.d/20auto-upgrades",
-            content=dedent(
+        {
+            "destination": "/etc/apt/apt.conf.d/20auto-upgrades",
+            "content": dedent(
                 """\
                 APT::Periodic::Update-Package-Lists "10000";
                 APT::Periodic::Unattended-Upgrade "0";
                 """
             ).encode(),
-            file_mode="0644",
-            group="root",
-            user="root",
-        ),
-        dict(
-            destination="/etc/environment",
-            content=etc_environment_content,
-            file_mode="0644",
-            group="root",
-            user="root",
-        ),
-        dict(
-            destination="/etc/craft-instance.conf",
-            content=(f"compatibility_tag: {expected_tag}\n").encode(),
-            file_mode="0644",
-            group="root",
-            user="root",
-        ),
-        dict(
-            destination="/etc/hostname",
-            content=f"{hostname}\n".encode(),
-            file_mode="0644",
-            group="root",
-            user="root",
-        ),
-        dict(
-            destination="/etc/systemd/network/10-eth0.network",
-            content=dedent(
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        },
+        {
+            "destination": "/etc/environment",
+            "content": etc_environment_content,
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        },
+        {
+            "destination": "/etc/craft-instance.conf",
+            "content": (f"compatibility_tag: {expected_tag}\n").encode(),
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        },
+        {
+            "destination": "/etc/hostname",
+            "content": f"{hostname}\n".encode(),
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        },
+        {
+            "destination": "/etc/systemd/network/10-eth0.network",
+            "content": dedent(
                 """\
                 [Match]
                 Name=eth0
@@ -325,32 +325,32 @@ def test_setup(  # pylint: disable=too-many-arguments, too-many-locals
                 UseMTU=true
                 """
             ).encode(),
-            file_mode="0644",
-            group="root",
-            user="root",
-        ),
-        dict(
-            destination="/etc/apt/apt.conf.d/00no-recommends",
-            content=b'APT::Install-Recommends "false";\n',
-            file_mode="0644",
-            group="root",
-            user="root",
-        ),
-        dict(
-            destination="/etc/apt/apt.conf.d/00update-errors",
-            content=b'APT::Update::Error-Mode "any";\n',
-            file_mode="0644",
-            group="root",
-            user="root",
-        ),
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        },
+        {
+            "destination": "/etc/apt/apt.conf.d/00no-recommends",
+            "content": b'APT::Install-Recommends "false";\n',
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        },
+        {
+            "destination": "/etc/apt/apt.conf.d/00update-errors",
+            "content": b'APT::Update::Error-Mode "any";\n',
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        },
     ]
     expected_push_file = []
     if no_cdn:
         expected_push_file.append(
-            dict(
-                source=Path("/etc/systemd/system/snapd.service.d/no-cdn.conf"),
-                destination=Path("/etc/systemd/system/snapd.service.d/no-cdn.conf"),
-            )
+            {
+                "source": Path("/etc/systemd/system/snapd.service.d/no-cdn.conf"),
+                "destination": Path("/etc/systemd/system/snapd.service.d/no-cdn.conf"),
+            }
         )
 
     assert fake_executor.records_of_push_file_io == expected_push_file_io
@@ -792,10 +792,10 @@ def test_setup_resolved_restart_failure(
 
 def test_setup_snapd_proxy(fake_executor, fake_process):
     """Verify snapd proxy is set or unset."""
-    environment = dict(
-        http_proxy="http://foo.bar:8080",
-        https_proxy="http://foo.bar:8081",
-    )
+    environment = {
+        "http_proxy": "http://foo.bar:8080",
+        "https_proxy": "http://foo.bar:8081",
+    }
     base_config = buildd.BuilddBase(
         alias=buildd.BuilddBaseAlias.FOCAL,
         environment=environment,  # type: ignore
@@ -1086,10 +1086,10 @@ def test_ensure_config_compatible_empty_config_returns_none(fake_executor):
     "environment",
     [
         None,
-        dict(
-            https_proxy="http://foo.bar:8081",
-            http_proxy="http://foo.bar:8080",
-        ),
+        {
+            "https_proxy": "http://foo.bar:8081",
+            "http_proxy": "http://foo.bar:8080",
+        },
     ],
 )
 def test_warmup_overall(environment, fake_process, fake_executor, mock_load, mocker):
@@ -1484,7 +1484,6 @@ def test_disable_and_wait_for_snap_refresh_hold_error(fake_process, fake_executo
     )
 
     with pytest.raises(errors.BaseConfigurationError) as exc_info:
-        # pylint: disable-next=protected-access
         base_config._disable_and_wait_for_snap_refresh(
             executor=fake_executor,
             deadline=None,
@@ -1510,7 +1509,6 @@ def test_disable_and_wait_for_snap_refresh_wait_error(fake_process, fake_executo
     )
 
     with pytest.raises(errors.BaseConfigurationError) as exc_info:
-        # pylint: disable-next=protected-access
         base_config._disable_and_wait_for_snap_refresh(
             executor=fake_executor,
             deadline=None,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,13 +56,13 @@ class FakeExecutor(Executor):
         user: str = "root",
     ) -> None:
         self.records_of_push_file_io.append(
-            dict(
-                destination=destination.as_posix(),
-                content=content.read(),
-                file_mode=file_mode,
-                group=group,
-                user=user,
-            )
+            {
+                "destination": destination.as_posix(),
+                "content": content.read(),
+                "file_mode": file_mode,
+                "group": group,
+                "user": user,
+            }
         )
 
     def execute_popen(
@@ -103,18 +103,18 @@ class FakeExecutor(Executor):
 
     def pull_file(self, *, source: pathlib.PurePath, destination: pathlib.Path) -> None:
         self.records_of_pull_file.append(
-            dict(
-                source=source,
-                destination=destination,
-            )
+            {
+                "source": source,
+                "destination": destination,
+            }
         )
 
     def push_file(self, *, source: pathlib.Path, destination: pathlib.PurePath) -> None:
         self.records_of_push_file.append(
-            dict(
-                source=source,
-                destination=destination,
-            )
+            {
+                "source": source,
+                "destination": destination,
+            }
         )
 
     def delete(self) -> None:
@@ -125,7 +125,7 @@ class FakeExecutor(Executor):
         return True
 
     def mount(self, *, host_source: pathlib.Path, target: pathlib.Path) -> None:
-        self.records_of_mount.append(dict(host_source=host_source, target=target))
+        self.records_of_mount.append({"host_source": host_source, "target": target})
 
     def is_running(self) -> bool:
         self.records_of_is_running.append({})

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -235,7 +235,7 @@ def test_execute_popen_with_cwd(mock_lxc, instance):
 
 
 def test_execute_popen_with_env(mock_lxc, instance):
-    instance.execute_popen(command=["test-command", "flags"], env=dict(foo="bar"))
+    instance.execute_popen(command=["test-command", "flags"], env={"foo": "bar"})
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
@@ -290,7 +290,7 @@ def test_execute_run_with_default_command_env(mock_lxc):
         lxc=mock_lxc,
     )
 
-    instance.execute_run(command=["test-command", "flags"], env=dict(foo="bar"))
+    instance.execute_run(command=["test-command", "flags"], env={"foo": "bar"})
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
@@ -328,7 +328,7 @@ def test_execute_run_with_default_command_env_unset(mock_lxc):
 
 
 def test_execute_run_with_env(mock_lxc, instance):
-    instance.execute_run(command=["test-command", "flags"], env=dict(foo="bar"))
+    instance.execute_run(command=["test-command", "flags"], env={"foo": "bar"})
 
     assert mock_lxc.mock_calls == [
         mock.call.exec(
@@ -344,7 +344,7 @@ def test_execute_run_with_env(mock_lxc, instance):
 
 def test_execute_run_with_env_unset(mock_lxc, instance):
     instance.execute_run(
-        command=["test-command", "flags"], env=dict(foo="bar", TERM=None)
+        command=["test-command", "flags"], env={"foo": "bar", "TERM": None}
     )
 
     assert mock_lxc.mock_calls == [

--- a/tests/unit/multipass/test_multipass_instance.py
+++ b/tests/unit/multipass/test_multipass_instance.py
@@ -250,7 +250,7 @@ def test_execute_popen_with_cwd(mock_multipass, instance):
 
 
 def test_execute_popen_with_env(mock_multipass, instance):
-    instance.execute_popen(command=["test-command", "flags"], env=dict(foo="bar"))
+    instance.execute_popen(command=["test-command", "flags"], env={"foo": "bar"})
 
     assert mock_multipass.mock_calls == [
         mock.call.exec(
@@ -295,7 +295,7 @@ def test_execute_run_with_cwd(mock_multipass, instance, tmp_path):
 
 
 def test_execute_run_with_env(mock_multipass, instance):
-    instance.execute_run(command=["test-command", "flags"], env=dict(foo="bar"))
+    instance.execute_run(command=["test-command", "flags"], env={"foo": "bar"})
 
     assert mock_multipass.mock_calls == [
         mock.call.exec(
@@ -308,7 +308,7 @@ def test_execute_run_with_env(mock_multipass, instance):
 
 def test_execute_run_with_env_unset(mock_multipass, instance):
     instance.execute_run(
-        command=["test-command", "flags"], env=dict(foo="bar", TERM=None)
+        command=["test-command", "flags"], env={"foo": "bar", "TERM": None}
     )
 
     assert mock_multipass.mock_calls == [

--- a/tests/unit/util/test_env_cmd.py
+++ b/tests/unit/util/test_env_cmd.py
@@ -26,13 +26,13 @@ from craft_providers.util import env_cmd
     "env,expected",
     [
         ({}, ["env"]),
-        (dict(foo="bar"), ["env", "foo=bar"]),
-        (dict(foo="bar", foo2="bar2"), ["env", "foo=bar", "foo2=bar2"]),
+        ({"foo": "bar"}, ["env", "foo=bar"]),
+        ({"foo": "bar", "foo2": "bar2"}, ["env", "foo=bar", "foo2=bar2"]),
         (
-            dict(foo="bar", foo2=None, foo3="baz"),
+            {"foo": "bar", "foo2": None, "foo3": "baz"},
             ["env", "foo=bar", "-u", "foo2", "foo3=baz"],
         ),
-        (dict(foo=None), ["env", "-u", "foo"]),
+        ({"foo": None}, ["env", "-u", "foo"]),
     ],
 )
 def test_formulate_command(env, expected):
@@ -43,13 +43,13 @@ def test_formulate_command(env, expected):
     "env,expected",
     [
         ({}, ["env", "-i"]),
-        (dict(foo="bar"), ["env", "-i", "foo=bar"]),
-        (dict(foo="bar", foo2="bar2"), ["env", "-i", "foo=bar", "foo2=bar2"]),
+        ({"foo": "bar"}, ["env", "-i", "foo=bar"]),
+        ({"foo": "bar", "foo2": "bar2"}, ["env", "-i", "foo=bar", "foo2=bar2"]),
         (
-            dict(foo="bar", foo2=None, foo3="baz"),
+            {"foo": "bar", "foo2": None, "foo3": "baz"},
             ["env", "-i", "foo=bar", "-u", "foo2", "foo3=baz"],
         ),
-        (dict(foo=None), ["env", "-i", "-u", "foo"]),
+        ({"foo": None}, ["env", "-i", "-u", "foo"]),
     ],
 )
 def test_formulate_command_ignore(env, expected):


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

It's been a busy 12 hours for the world of Python linting!

2 commits, 1 for the [latest `black` release](https://github.com/psf/black/releases/tag/23.1.0) and 1 for the [latest `pylint` release](https://github.com/PyCQA/pylint/releases/tag/v2.16.0).

Targeting `hotfix/1.7` so I can prep a craft-providers release.  I will have to post another PR targeting `main` to allow development on the `main` branch to continue.