### PR TITLE
snap installer: capture error details when snap removal fails

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -150,8 +150,8 @@ def _get_snap_revision_ensuring_source(
         executor.execute_run(cmd, check=True, capture_output=True)
     except subprocess.CalledProcessError as error:
         raise SnapInstallationError(
-            brief=f"Failed to inject snap {snap_name!r}.",
-            details="unable to remove previously installed snap",
+            brief=f"Failed to remove snap {snap_name!r}.",
+            details=details_from_called_process_error(error),
         ) from error
     return None
 

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -961,7 +961,9 @@ def test_get_snap_revision_ensuring_source_different_source_error(
             "test-name", snap_installer.SNAP_SRC_STORE, fake_executor
         )
     assert exc_info.value == snap_installer.SnapInstallationError(
-        brief="Failed to inject snap 'test-name'.",
-        details="unable to remove previously installed snap",
+        brief="Failed to remove snap 'test-name'.",
+        details=details_from_called_process_error(
+            exc_info.value.__cause__  # type: ignore
+        ),
     )
     assert exc_info.value.__cause__ is not None


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

When the command `snap remove <snap>` fails, capture details from the subprocess call.

Note - this PR is blocked by failing linters.  I will merge in the linter fixes from `hotfix/1.7` in the near future.