### PR TITLE
multipass: replace deprecated parameter `--mem` with `--memory`

### DIFF
--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -175,7 +175,7 @@ class Multipass:
         if cpus is not None:
             command.extend(["--cpus", cpus])
         if mem is not None:
-            command.extend(["--mem", mem])
+            command.extend(["--memory", mem])
         if disk is not None:
             command.extend(["--disk", disk])
 

--- a/tests/integration/multipass/conftest.py
+++ b/tests/integration/multipass/conftest.py
@@ -46,7 +46,7 @@ def tmp_instance(
             instance_name,
             "--cpus",
             cpus,
-            "--mem",
+            "--memory",
             mem,
             "--disk",
             disk,

--- a/tests/unit/multipass/test_multipass.py
+++ b/tests/unit/multipass/test_multipass.py
@@ -251,7 +251,7 @@ def test_launch_all_opts(fake_process):
             "test-instance",
             "--cpus",
             "4",
-            "--mem",
+            "--memory",
             "8G",
             "--disk",
             "80G",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----


Resolving the Multipass deprecation notice:
```
warning: "--mem" long option will be deprecated in favour of "--memory" in a future release.Please update any scripts, etc.
```

Waiting on https://github.com/canonical/craft-providers/pull/130