### PR TITLE
lxd: add support for interim Ubuntu releases

### DIFF
--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -144,6 +144,8 @@ class BuilddBaseAlias(enum.Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
+    KINETIC = "22.10"
+    LUNAR = "23.04"
 
 
 class Snap(pydantic.BaseModel, extra=pydantic.Extra.forbid):

--- a/craft_providers/lxd/__init__.py
+++ b/craft_providers/lxd/__init__.py
@@ -29,8 +29,8 @@ from .launcher import launch  # noqa: F401
 from .lxc import LXC  # noqa: F401
 from .lxd import LXD  # noqa: F401
 from .lxd_instance import LXDInstance  # noqa: F401
-from .lxd_provider import PROVIDER_BASE_TO_LXD_BASE, LXDProvider  # noqa: F401
-from .remotes import configure_buildd_image_remote  # noqa: F401
+from .lxd_provider import LXDProvider  # noqa: F401
+from .remotes import configure_buildd_image_remote, get_remote_image  # noqa: F401
 
 __all__ = [
     "LXC",
@@ -39,7 +39,7 @@ __all__ = [
     "LXDError",
     "LXDInstallationError",
     "LXDProvider",
-    "PROVIDER_BASE_TO_LXD_BASE",
+    "get_remote_image",
     "install",
     "is_installed",
     "is_initialized",

--- a/craft_providers/lxd/__init__.py
+++ b/craft_providers/lxd/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,7 +17,7 @@
 
 """LXD environment provider."""
 
-from .errors import LXDError, LXDInstallationError  # noqa: F401
+from .errors import LXDError, LXDInstallationError, LXDUnstableImageError  # noqa: F401
 from .installer import (  # noqa: F401
     ensure_lxd_is_ready,
     install,
@@ -38,6 +38,7 @@ __all__ = [
     "LXDInstance",
     "LXDError",
     "LXDInstallationError",
+    "LXDUnstableImageError",
     "LXDProvider",
     "get_remote_image",
     "install",

--- a/craft_providers/lxd/errors.py
+++ b/craft_providers/lxd/errors.py
@@ -46,3 +46,19 @@ class LXDInstallationError(LXDError):
         brief = f"Failed to install LXD: {reason}."
         resolution = LXD_INSTALL_HELP
         super().__init__(brief=brief, details=details, resolution=resolution)
+
+
+class LXDUnstableImageError(LXDError):
+    """LXD Unstable Image Error.
+
+    :param brief: Brief description of error.
+    """
+
+    def __init__(self, brief: str) -> None:
+        super().__init__(
+            brief=brief,
+            details=(
+                "Devel or daily images are not guaranteed and are intended for "
+                "experimental use only."
+            ),
+        )

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -115,7 +115,7 @@ class LXDProvider(Provider):
         :raises LXDError: if instance cannot be configured and launched
         """
         image = get_remote_image(build_base)
-        image.add_remote()
+        image.add_remote(lxc=self.lxc)
 
         # we can't guarantee daily and devel images, so explicitly warn the user
         if not image.is_stable:

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -19,6 +19,7 @@
 """Manages LXD remotes and provides access to remote images."""
 
 import logging
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 
@@ -171,8 +172,12 @@ def configure_buildd_image_remote(lxc: LXC = LXC()) -> str:
 
     :returns: Name of remote to pass to launcher.
     """
-    logger.warning(
-        "configure_buildd_image_remote() is deprecated. Use configure_image_remote()."
+    warnings.warn(
+        message=(
+            "configure_buildd_image_remote() is deprecated. "
+            "Use configure_image_remote()."
+        ),
+        category=DeprecationWarning,
     )
     # configure the buildd remote for core22
     image = get_remote_image(BuilddBaseAlias.JAMMY.value)

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -32,6 +32,14 @@ logger = logging.getLogger(__name__)
 BUILDD_RELEASES_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd"
 BUILDD_RELEASES_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/releases"
 
+# XXX: lunar and kinetic buildd daily images are not working (LP #2007419)
+BUILDD_DAILY_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd-daily"
+BUILDD_DAILY_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/daily"
+
+# temporarily use the cloud release images until daily buildd images are fixed
+DAILY_REMOTE_NAME = "ubuntu-daily"
+DAILY_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/daily"
+
 
 class ProtocolType(Enum):
     """Enumeration of protocols for LXD remotes."""
@@ -116,6 +124,20 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE = {
         remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
         is_stable=True,
+    ),
+    BuilddBaseAlias.KINETIC.value: RemoteImage(
+        image_name="kinetic",
+        remote_name=DAILY_REMOTE_NAME,
+        remote_address=DAILY_REMOTE_ADDRESS,
+        remote_protocol=ProtocolType.SIMPLESTREAMS,
+        is_stable=False,
+    ),
+    BuilddBaseAlias.LUNAR.value: RemoteImage(
+        image_name="lunar",
+        remote_name=DAILY_REMOTE_NAME,
+        remote_address=DAILY_REMOTE_ADDRESS,
+        remote_protocol=ProtocolType.SIMPLESTREAMS,
+        is_stable=False,
     ),
 }
 

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -1,5 +1,6 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,7 +16,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-"""Remote helper utilities."""
+"""Manages LXD remotes and provides access to remote images."""
 
 import logging
 
@@ -23,26 +24,24 @@ from .lxc import LXC
 
 logger = logging.getLogger(__name__)
 
-BUILDD_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd"
-BUILDD_REMOTE_ADDR = "https://cloud-images.ubuntu.com/buildd/releases"
+BUILDD_RELEASES_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd"
+BUILDD_RELEASES_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/releases"
 
 
 def configure_buildd_image_remote(
     lxc: LXC = LXC(),
 ) -> str:
     """Configure buildd remote, adding remote as required.
-
     :param lxc: LXC client.
-
     :returns: Name of remote to pass to launcher.
     """
-    if BUILDD_REMOTE_NAME in lxc.remote_list():
-        logger.debug("Remote %r already exists.", BUILDD_REMOTE_NAME)
+    if BUILDD_RELEASES_REMOTE_NAME in lxc.remote_list():
+        logger.debug("Remote %r already exists.", BUILDD_RELEASES_REMOTE_NAME)
     else:
         try:
             lxc.remote_add(
-                remote=BUILDD_REMOTE_NAME,
-                addr=BUILDD_REMOTE_ADDR,
+                remote=BUILDD_RELEASES_REMOTE_NAME,
+                addr=BUILDD_RELEASES_REMOTE_ADDRESS,
                 protocol="simplestreams",
             )
         except Exception as exc:  # pylint: disable=broad-except
@@ -50,15 +49,15 @@ def configure_buildd_image_remote(
             # condition on remote creation (it's not idempotent) and now the remote is
             # there, the purpose of this function is done (otherwise we let the
             # original exception fly)
-            if BUILDD_REMOTE_NAME in lxc.remote_list():
+            if BUILDD_RELEASES_REMOTE_NAME in lxc.remote_list():
                 logger.debug(
                     "Remote %r is present on second check, ignoring exception %r.",
-                    BUILDD_REMOTE_NAME,
+                    BUILDD_RELEASES_REMOTE_NAME,
                     exc,
                 )
             else:
                 raise
         else:
-            logger.debug("Remote %r was successfully added.", BUILDD_REMOTE_NAME)
+            logger.debug("Remote %r was successfully added.", BUILDD_RELEASES_REMOTE_NAME)
 
-    return BUILDD_REMOTE_NAME
+    return BUILDD_RELEASES_REMOTE_NAME

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -67,7 +67,7 @@ class RemoteImage:
     remote_protocol: ProtocolType
     is_stable: bool
 
-    def add_remote(self, lxc: LXC = LXC()) -> None:
+    def add_remote(self, lxc: LXC) -> None:
         """Add the LXD remote for an image.
 
         If the remote already exists, it will not be re-added.

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -57,15 +57,26 @@ class RemoteImage:
     :param remote_name: Name of the remote server.
     :param remote_address: Address of the remote (can be an IP, FDQN, URL, or token)
     :param remote_protocol: Remote protocol (options are `lxd` and `simplestreams`)
-    :param is_stable: True if the image is a stable release. Daily and devel images
-    are not stable.
     """
 
     image_name: str
     remote_name: str
     remote_address: str
     remote_protocol: ProtocolType
-    is_stable: bool
+
+    @property
+    def is_stable(self) -> bool:
+        """Check if the image is stable.
+
+        Images are considered stable if they are from a release remote. Images from
+        daily or devel remotes are not considered.
+
+        :returns: True if the image is stable.
+        """
+        return (
+            self.remote_name == BUILDD_RELEASES_REMOTE_NAME
+            and self.remote_address == BUILDD_RELEASES_REMOTE_ADDRESS
+        )
 
     def add_remote(self, lxc: LXC) -> None:
         """Add the LXD remote for an image.
@@ -110,35 +121,30 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE = {
         remote_name=BUILDD_RELEASES_REMOTE_NAME,
         remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
-        is_stable=True,
     ),
     BuilddBaseAlias.FOCAL.value: RemoteImage(
         image_name="core20",
         remote_name=BUILDD_RELEASES_REMOTE_NAME,
         remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
-        is_stable=True,
     ),
     BuilddBaseAlias.JAMMY.value: RemoteImage(
         image_name="core22",
         remote_name=BUILDD_RELEASES_REMOTE_NAME,
         remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
-        is_stable=True,
     ),
     BuilddBaseAlias.KINETIC.value: RemoteImage(
         image_name="kinetic",
         remote_name=DAILY_REMOTE_NAME,
         remote_address=DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
-        is_stable=False,
     ),
     BuilddBaseAlias.LUNAR.value: RemoteImage(
         image_name="lunar",
         remote_name=DAILY_REMOTE_NAME,
         remote_address=DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
-        is_stable=False,
     ),
 }
 

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -19,13 +19,90 @@
 """Manages LXD remotes and provides access to remote images."""
 
 import logging
+from dataclasses import dataclass
+from enum import Enum
 
+from craft_providers.bases import BuilddBaseAlias
+
+from .errors import LXDError
 from .lxc import LXC
 
 logger = logging.getLogger(__name__)
 
 BUILDD_RELEASES_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd"
 BUILDD_RELEASES_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/releases"
+
+
+class ProtocolType(Enum):
+    """Enumeration of protocols for LXD remotes."""
+
+    LXD = "lxd"
+    SIMPLESTREAMS = "simplestreams"
+
+
+@dataclass
+class RemoteImage:
+    """Contains the name, location, and details of a remote LXD image.
+
+    :param image_name: Name of the image on the remote (e.g. `core22` or `lunar`).
+    :param remote_name: Name of the remote server.
+    :param remote_address: Address of the remote (can be an IP, FDQN, URL, or token)
+    :param remote_protocol: Remote protocol (options are `lxd` and `simplestreams`)
+    :param is_stable: True if the image is a stable release. Daily and devel images
+    are not stable.
+    """
+
+    image_name: str
+    remote_name: str
+    remote_address: str
+    remote_protocol: ProtocolType
+    is_stable: bool
+
+
+# XXX: support xenial?
+# mapping from supported bases to actual lxd remote images
+_PROVIDER_BASE_TO_LXD_REMOTE_IMAGE = {
+    BuilddBaseAlias.BIONIC.value: RemoteImage(
+        image_name="core18",
+        remote_name=BUILDD_RELEASES_REMOTE_NAME,
+        remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
+        remote_protocol=ProtocolType.SIMPLESTREAMS,
+        is_stable=True,
+    ),
+    BuilddBaseAlias.FOCAL.value: RemoteImage(
+        image_name="core20",
+        remote_name=BUILDD_RELEASES_REMOTE_NAME,
+        remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
+        remote_protocol=ProtocolType.SIMPLESTREAMS,
+        is_stable=True,
+    ),
+    BuilddBaseAlias.JAMMY.value: RemoteImage(
+        image_name="core22",
+        remote_name=BUILDD_RELEASES_REMOTE_NAME,
+        remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
+        remote_protocol=ProtocolType.SIMPLESTREAMS,
+        is_stable=True,
+    ),
+}
+
+
+def get_remote_image(provider_base: str) -> RemoteImage:
+    """Get a RemoteImage for a particular provider base.
+
+    :param provider_base: string containing the provider base
+
+    :returns: the RemoteImage for the provider base
+    """
+    image = _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE.get(provider_base)
+    if not image:
+        raise LXDError(
+            brief=(
+                "could not find a lxd remote image for the provider base "
+                f"{provider_base!r}"
+            )
+        )
+
+    return image
 
 
 def configure_buildd_image_remote(

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -33,6 +33,7 @@ from .multipass_instance import MultipassInstance
 logger = logging.getLogger(__name__)
 
 
+# TODO: support KINETIC and LUNAR
 PROVIDER_BASE_TO_MULTIPASS_BASE = {
     bases.BuilddBaseAlias.BIONIC.value: "snapcraft:18.04",
     bases.BuilddBaseAlias.FOCAL.value: "snapcraft:20.04",

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -48,6 +48,8 @@ def test_create_environment(installed_lxd, instance_name):
         BuilddBaseAlias.BIONIC,
         BuilddBaseAlias.FOCAL,
         BuilddBaseAlias.JAMMY,
+        BuilddBaseAlias.KINETIC,
+        BuilddBaseAlias.LUNAR,
     ],
 )
 def test_launched_environment(alias, installed_lxd, instance_name, tmp_path):

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -63,6 +63,7 @@ def test_launched_environment(alias, installed_lxd, instance_name, tmp_path):
         base_configuration=base_configuration,
         build_base=alias.value,
         instance_name=instance_name,
+        allow_unstable=True,
     ) as test_instance:
         assert test_instance.exists() is True
         assert test_instance.is_running() is True

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+
+import pytest
 
 from craft_providers.bases import BuilddBase, BuilddBaseAlias
 from craft_providers.lxd import LXDProvider, is_installed
@@ -40,16 +42,24 @@ def test_create_environment(installed_lxd, instance_name):
     assert test_instance.exists() is False
 
 
-def test_launched_environment(installed_lxd, instance_name, tmp_path):
+@pytest.mark.parametrize(
+    "alias",
+    [
+        BuilddBaseAlias.BIONIC,
+        BuilddBaseAlias.FOCAL,
+        BuilddBaseAlias.JAMMY,
+    ],
+)
+def test_launched_environment(alias, installed_lxd, instance_name, tmp_path):
     provider = LXDProvider()
 
-    base_configuration = BuilddBase(alias=BuilddBaseAlias.JAMMY)
+    base_configuration = BuilddBase(alias=alias)
 
     with provider.launched_environment(
         project_name="test-project",
         project_path=tmp_path,
         base_configuration=base_configuration,
-        build_base=BuilddBaseAlias.JAMMY.value,
+        build_base=alias.value,
         instance_name=instance_name,
     ) as test_instance:
         assert test_instance.exists() is True

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -28,6 +28,8 @@ from craft_providers import bases, lxd
         bases.BuilddBaseAlias.BIONIC,
         bases.BuilddBaseAlias.FOCAL,
         bases.BuilddBaseAlias.JAMMY,
+        bases.BuilddBaseAlias.KINETIC,
+        bases.BuilddBaseAlias.LUNAR,
     ],
 )
 def test_configure_and_launch_remote(instance_name, alias):

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,37 @@ from craft_providers import bases, lxd
 
 
 @pytest.mark.parametrize(
+    "alias",
+    [
+        bases.BuilddBaseAlias.BIONIC,
+        bases.BuilddBaseAlias.FOCAL,
+        bases.BuilddBaseAlias.JAMMY,
+    ],
+)
+def test_configure_and_launch_remote(instance_name, alias):
+    """Verify remotes are configured and images can be launched."""
+    remote_image = lxd.get_remote_image(alias.value)
+    base_configuration = bases.BuilddBase(alias=alias)
+    instance = lxd.launch(
+        name=instance_name,
+        base_configuration=base_configuration,
+        image_name=remote_image.image_name,
+        image_remote=remote_image.remote_name,
+    )
+
+    try:
+        assert isinstance(instance, lxd.LXDInstance)
+        assert instance.exists() is True
+        assert instance.is_running() is True
+
+        proc = instance.execute_run(["echo", "hi"], check=True, stdout=subprocess.PIPE)
+
+        assert proc.stdout == b"hi\n"
+    finally:
+        instance.delete()
+
+
+@pytest.mark.parametrize(
     "alias,image_name",
     [
         (bases.BuilddBaseAlias.BIONIC, "18.04"),
@@ -31,6 +62,7 @@ from craft_providers import bases, lxd
     ],
 )
 def test_configure_and_launch_buildd_remotes(instance_name, alias, image_name):
+    """Verify function `configure_buildd_image_remote()` can launch core 18|20|22."""
     image_remote = lxd.configure_buildd_image_remote()
     assert image_remote == "craft-com.ubuntu.cloud-buildd"
 

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -73,6 +73,8 @@ def mock_inject_from_host(mocker):
         (buildd.BuilddBaseAlias.BIONIC, "test-bionic-host"),
         (buildd.BuilddBaseAlias.FOCAL, "test-focal-host"),
         (buildd.BuilddBaseAlias.JAMMY, "test-jammy-host"),
+        (buildd.BuilddBaseAlias.KINETIC, "test-kinetic-host"),
+        (buildd.BuilddBaseAlias.LUNAR, "test-lunar-host"),
     ],
 )
 @pytest.mark.parametrize(
@@ -846,6 +848,8 @@ def test_setup_snapd_failures(fake_process, fake_executor, fail_index):
         buildd.BuilddBaseAlias.BIONIC,
         buildd.BuilddBaseAlias.FOCAL,
         buildd.BuilddBaseAlias.JAMMY,
+        buildd.BuilddBaseAlias.KINETIC,
+        buildd.BuilddBaseAlias.LUNAR,
     ],
 )
 @pytest.mark.parametrize("system_running_ready_stdout", ["degraded", "running"])
@@ -918,6 +922,8 @@ def test_wait_for_system_ready(
         buildd.BuilddBaseAlias.BIONIC,
         buildd.BuilddBaseAlias.FOCAL,
         buildd.BuilddBaseAlias.JAMMY,
+        buildd.BuilddBaseAlias.KINETIC,
+        buildd.BuilddBaseAlias.LUNAR,
     ],
 )
 def test_wait_for_system_ready_timeout(fake_executor, fake_process, alias):
@@ -950,6 +956,8 @@ def test_wait_for_system_ready_timeout(fake_executor, fake_process, alias):
         buildd.BuilddBaseAlias.BIONIC,
         buildd.BuilddBaseAlias.FOCAL,
         buildd.BuilddBaseAlias.JAMMY,
+        buildd.BuilddBaseAlias.KINETIC,
+        buildd.BuilddBaseAlias.LUNAR,
     ],
 )
 def test_wait_for_system_ready_timeout_in_network(

--- a/tests/unit/lxd/test_errors.py
+++ b/tests/unit/lxd/test_errors.py
@@ -58,3 +58,13 @@ def test_lxd_installation_error_with_details():
         "Visit https://linuxcontainers.org/lxd/getting-started-cli/"
         " for instructions on installing and configuring LXD for your operating system."
     )
+
+
+def test_lxd_unstable_image_error():
+    error = errors.LXDUnstableImageError(brief="test error")
+
+    assert str(error) == (
+        "test error\n"
+        "Devel or daily images are not guaranteed and are intended for "
+        "experimental use only."
+    )

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest import mock
+from unittest.mock import call
 
 import pytest
 
@@ -23,18 +23,27 @@ from craft_providers.lxd import LXDError, LXDProvider
 
 
 @pytest.fixture
+def mock_remote_image(mocker):
+    _mock_remote_image = mocker.patch("craft_providers.lxd.remotes.RemoteImage")
+    _mock_remote_image.image_name = "test-image-name"
+    _mock_remote_image.remote_name = "test-remote-name"
+    yield _mock_remote_image
+
+
+@pytest.fixture
+def mock_get_remote_image(mock_remote_image, mocker):
+    _mock_get_remote_image = mocker.patch(
+        "craft_providers.lxd.lxd_provider.get_remote_image",
+        return_value=mock_remote_image,
+    )
+    yield _mock_get_remote_image
+
+
+@pytest.fixture
 def mock_buildd_base_configuration(mocker):
     mock_base_config = mocker.patch("craft_providers.bases.BuilddBase", autospec=True)
     mock_base_config.compatibility_tag = "buildd-base-v0"
     yield mock_base_config
-
-
-@pytest.fixture
-def mock_configure_buildd_image_remote(mocker):
-    yield mocker.patch(
-        "craft_providers.lxd.lxd_provider.configure_buildd_image_remote",
-        return_value="buildd-remote",
-    )
 
 
 @pytest.fixture
@@ -112,19 +121,10 @@ def test_create_environment(mocker):
     )
 
 
-@pytest.mark.parametrize(
-    "build_base, lxd_base",
-    [
-        (bases.BuilddBaseAlias.BIONIC.value, "core18"),
-        (bases.BuilddBaseAlias.FOCAL.value, "core20"),
-        (bases.BuilddBaseAlias.JAMMY.value, "core22"),
-    ],
-)
 def test_launched_environment(
-    build_base,
-    lxd_base,
     mock_buildd_base_configuration,
-    mock_configure_buildd_image_remote,
+    mock_get_remote_image,
+    mock_remote_image,
     mock_launch,
     tmp_path,
 ):
@@ -134,17 +134,18 @@ def test_launched_environment(
         project_name="test-project",
         project_path=tmp_path,
         base_configuration=mock_buildd_base_configuration,
-        build_base=build_base,
+        build_base="test-build-base",
         instance_name="test-instance-name",
     ) as instance:
         assert instance is not None
-        assert mock_configure_buildd_image_remote.mock_calls == [mock.call()]
+        mock_get_remote_image.assert_called_once_with("test-build-base")
+        mock_remote_image.add_remote.assert_called_once()
         assert mock_launch.mock_calls == [
-            mock.call(
+            call(
                 name="test-instance-name",
                 base_configuration=mock_buildd_base_configuration,
-                image_name=lxd_base,
-                image_remote="buildd-remote",
+                image_name="test-image-name",
+                image_remote="test-remote-name",
                 auto_clean=True,
                 auto_create_project=True,
                 map_user_uid=True,
@@ -158,14 +159,15 @@ def test_launched_environment(
         mock_launch.reset_mock()
 
     assert mock_launch.mock_calls == [
-        mock.call().unmount_all(),
-        mock.call().stop(),
+        call().unmount_all(),
+        call().stop(),
     ]
 
 
 def test_launched_environment_launch_base_configuration_error(
     mock_buildd_base_configuration,
-    mock_configure_buildd_image_remote,
+    mock_get_remote_image,
+    mock_remote_image,
     mock_launch,
     tmp_path,
 ):
@@ -184,3 +186,31 @@ def test_launched_environment_launch_base_configuration_error(
             pass
 
     assert raised.value.__cause__ is error
+
+
+def test_launched_environment_unsupported_image_warning(
+    mock_buildd_base_configuration,
+    mock_get_remote_image,
+    mock_remote_image,
+    mock_launch,
+    tmp_path,
+):
+    """Raise a warning when an unstable remote image is used."""
+    mock_remote_image.is_stable = False
+    provider = LXDProvider()
+
+    with pytest.warns(UserWarning) as warning:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert str(warning[0].message) == (
+        "You are using an daily or devel image 'test-image-name' from remote "
+        "'test-remote-name'. Devel or daily images are not guaranteed and are "
+        "intended for experimental use only."
+    )

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -126,9 +126,10 @@ def test_launched_environment(
     mock_get_remote_image,
     mock_remote_image,
     mock_launch,
+    mock_lxc,
     tmp_path,
 ):
-    provider = LXDProvider()
+    provider = LXDProvider(lxc=mock_lxc)
 
     with provider.launched_environment(
         project_name="test-project",
@@ -139,7 +140,7 @@ def test_launched_environment(
     ) as instance:
         assert instance is not None
         mock_get_remote_image.assert_called_once_with("test-build-base")
-        mock_remote_image.add_remote.assert_called_once()
+        mock_remote_image.add_remote.assert_called_once_with(lxc=mock_lxc)
         assert mock_launch.mock_calls == [
             call(
                 name="test-instance-name",

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -1,5 +1,6 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -20,7 +21,10 @@ from unittest import mock
 import pytest
 
 from craft_providers import lxd
-from craft_providers.lxd.remotes import BUILDD_REMOTE_ADDR, BUILDD_REMOTE_NAME
+from craft_providers.lxd.remotes import (
+    BUILDD_RELEASES_REMOTE_ADDRESS,
+    BUILDD_RELEASES_REMOTE_NAME,
+)
 
 
 @pytest.fixture
@@ -35,29 +39,29 @@ def mock_lxc():
 def test_configure_buildd_image_remote_fresh(mock_lxc, logs):
     name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
 
-    assert name == BUILDD_REMOTE_NAME
+    assert name == BUILDD_RELEASES_REMOTE_NAME
     assert mock_lxc.mock_calls == [
         mock.call.remote_list(),
-        mock.call.remote_list().__contains__(BUILDD_REMOTE_NAME),
+        mock.call.remote_list().__contains__(BUILDD_RELEASES_REMOTE_NAME),
         mock.call.remote_add(
-            remote=BUILDD_REMOTE_NAME,
-            addr=BUILDD_REMOTE_ADDR,
+            remote=BUILDD_RELEASES_REMOTE_NAME,
+            addr=BUILDD_RELEASES_REMOTE_ADDRESS,
             protocol="simplestreams",
         ),
     ]
-    assert f"Remote '{BUILDD_REMOTE_NAME}' was successfully added." in logs.debug
+    assert f"Remote '{BUILDD_RELEASES_REMOTE_NAME}' was successfully added." in logs.debug
 
 
 def test_configure_buildd_image_remote_already_exists(mock_lxc, logs):
-    mock_lxc.remote_list.return_value = {BUILDD_REMOTE_NAME: {}}
+    mock_lxc.remote_list.return_value = {BUILDD_RELEASES_REMOTE_NAME: {}}
 
     name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
 
-    assert name == BUILDD_REMOTE_NAME
+    assert name == BUILDD_RELEASES_REMOTE_NAME
     assert mock_lxc.mock_calls == [
         mock.call.remote_list(),
     ]
-    assert f"Remote '{BUILDD_REMOTE_NAME}' already exists." in logs.debug
+    assert f"Remote '{BUILDD_RELEASES_REMOTE_NAME}' already exists." in logs.debug
 
 
 def test_configure_buildd_image_remote_racecondition_created(mock_lxc, logs):
@@ -65,24 +69,24 @@ def test_configure_buildd_image_remote_racecondition_created(mock_lxc, logs):
     # the first time the list will not show the remote, then `remote_add` will fail
     # because it was just created from other process, and exactly because of that
     # it will show in the list the second time is asked
-    test_remote_name = BUILDD_REMOTE_NAME
+    test_remote_name = BUILDD_RELEASES_REMOTE_NAME
     mock_lxc.remote_list.side_effect = [{}, {test_remote_name: {}}]
     mock_lxc.remote_add.side_effect = ValueError()
 
     name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
 
-    assert name == BUILDD_REMOTE_NAME
+    assert name == BUILDD_RELEASES_REMOTE_NAME
     assert mock_lxc.mock_calls == [
         mock.call.remote_list(),
         mock.call.remote_add(
-            remote=BUILDD_REMOTE_NAME,
-            addr=BUILDD_REMOTE_ADDR,
+            remote=BUILDD_RELEASES_REMOTE_NAME,
+            addr=BUILDD_RELEASES_REMOTE_ADDRESS,
             protocol="simplestreams",
         ),
         mock.call.remote_list(),
     ]
     assert (
-        f"Remote '{BUILDD_REMOTE_NAME}' is present on second check, "
+        f"Remote '{BUILDD_RELEASES_REMOTE_NAME}' is present on second check, "
         "ignoring exception ValueError()." in logs.debug
     )
 

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -19,7 +19,6 @@
 from unittest.mock import call
 
 import pytest
-from logassert import Exact  # type: ignore
 
 from craft_providers import lxd
 from craft_providers.bases import BuilddBaseAlias
@@ -163,14 +162,13 @@ def test_configure_buildd_image_remote(
     mock_lxc, logs, mock_get_remote_image, mock_remote_image
 ):
     """Verify deprecated `configure_buildd_image_remote()` call."""
-    name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
 
-    assert (
-        Exact(
-            "configure_buildd_image_remote() is deprecated. "
-            "Use configure_image_remote()."
-        )
-        in logs.warning
+    with pytest.warns(DeprecationWarning) as warning:
+        name = lxd.remotes.configure_buildd_image_remote(lxc=mock_lxc)
+
+    assert str(warning[0].message) == (
+        "configure_buildd_image_remote() is deprecated. "
+        "Use configure_image_remote()."
     )
     mock_get_remote_image.assert_called_once_with(BuilddBaseAlias.JAMMY.value)
     mock_remote_image.add_remote.assert_called_once_with(mock_lxc)

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -124,6 +124,8 @@ def test_add_remote_race_condition_error(fake_remote_image, mock_lxc, logs):
         (BuilddBaseAlias.BIONIC.value, "core18"),
         (BuilddBaseAlias.FOCAL.value, "core20"),
         (BuilddBaseAlias.JAMMY.value, "core22"),
+        (BuilddBaseAlias.KINETIC.value, "kinetic"),
+        (BuilddBaseAlias.LUNAR.value, "lunar"),
     ],
 )
 def test_get_image_remote(provider_base, image_name):

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -16,7 +16,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-from unittest import mock
+from unittest.mock import call
 
 import pytest
 
@@ -28,12 +28,8 @@ from craft_providers.lxd.remotes import (
 
 
 @pytest.fixture
-def mock_lxc():
-    with mock.patch(
-        "craft_providers.lxd.launcher.LXC",
-        spec=lxd.LXC,
-    ) as mock_lxc:
-        yield mock_lxc.return_value
+def mock_lxc(mocker):
+    yield mocker.patch("craft_providers.lxd.launcher.LXC", spec=lxd.LXC)
 
 
 def test_configure_buildd_image_remote_fresh(mock_lxc, logs):
@@ -41,9 +37,9 @@ def test_configure_buildd_image_remote_fresh(mock_lxc, logs):
 
     assert name == BUILDD_RELEASES_REMOTE_NAME
     assert mock_lxc.mock_calls == [
-        mock.call.remote_list(),
-        mock.call.remote_list().__contains__(BUILDD_RELEASES_REMOTE_NAME),
-        mock.call.remote_add(
+        call.remote_list(),
+        call.remote_list().__contains__(BUILDD_RELEASES_REMOTE_NAME),
+        call.remote_add(
             remote=BUILDD_RELEASES_REMOTE_NAME,
             addr=BUILDD_RELEASES_REMOTE_ADDRESS,
             protocol="simplestreams",
@@ -59,7 +55,7 @@ def test_configure_buildd_image_remote_already_exists(mock_lxc, logs):
 
     assert name == BUILDD_RELEASES_REMOTE_NAME
     assert mock_lxc.mock_calls == [
-        mock.call.remote_list(),
+        call.remote_list(),
     ]
     assert f"Remote '{BUILDD_RELEASES_REMOTE_NAME}' already exists." in logs.debug
 
@@ -77,13 +73,13 @@ def test_configure_buildd_image_remote_racecondition_created(mock_lxc, logs):
 
     assert name == BUILDD_RELEASES_REMOTE_NAME
     assert mock_lxc.mock_calls == [
-        mock.call.remote_list(),
-        mock.call.remote_add(
+        call.remote_list(),
+        call.remote_add(
             remote=BUILDD_RELEASES_REMOTE_NAME,
             addr=BUILDD_RELEASES_REMOTE_ADDRESS,
             protocol="simplestreams",
         ),
-        mock.call.remote_list(),
+        call.remote_list(),
     ]
     assert (
         f"Remote '{BUILDD_RELEASES_REMOTE_NAME}' is present on second check, "


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
#### Overview
This PR adds support for interim and devel Ubuntu releases with LXD.

Broken into 6 separate commits to speed up review time.

#### Details

Previously, craft-providers maintained a list of valid LXD images with a simple enum.  Now, the `remotes.py` module has a new dataclass called `RemoteImage` and a dictionary of valid `RemoteImages` to track what images are supported.

It is designed in such a way that users can add custom remotes and we'll be able to add support for other bases (like a centos base) without breaking changes.

#### Usage

For applications using the `LxdProvider` class (snapcraft, charmcraft, and rockcraft), there are no changes in behavior or usage.  You can simply pass in the new release names:
```python
class BuilddBaseAlias(enum.Enum):
    XENIAL = "16.04"
    BIONIC = "18.04"
    FOCAL = "20.04"
    JAMMY = "22.04"
    KINETIC = "22.10"
    LUNAR = "23.04"
```

For other applications (lpcraft :eyes:), you'll need to use the replace the old `configure_buildd_image_remote()` function with the new `get_remote_image()` function.

Note - the old function `configure_build_image_remote()` still exists and its behavior is unchanged, except for a deprecation notice.

#### Example usage

```python
remote_image = lxd.get_remote_image(BuilddBaseAlias.KINETIC.value)

base_configuration = bases.BuilddBase(alias=BuildBaseAlias.KINETIC)

instance = lxd.launch(
    name="my-instance",
    base_configuration=base_configuration,
    image_name=remote_image.image_name,
    image_remote=remote_image.remote_name,
)
```

#### TODO
- [x] break into smaller commits

#### Sources

- [Provide build base support for interim releases #190](https://github.com/canonical/craft-providers/issues/190)
- [Support new series of ubuntu including interim releases ](https://bugs.launchpad.net/lpcraft/+bug/1999694)

(CRAFT-1601)