### PR TITLE
bases(buildd): track if instance is properly setup

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -51,7 +51,7 @@ class Base(ABC):
         compatibility levels are maintained.
     """
 
-    compatibility_tag: str = "base-v0"
+    compatibility_tag: str = "base-v1"
 
     @abstractmethod
     def get_command_environment(

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -402,7 +402,7 @@ class BuilddBase(Base):
         self._setup_wait_for_system_ready(
             executor=executor, deadline=deadline, retry_wait=retry_wait
         )
-        self._setup_instance_config(executor=executor, deadline=deadline)
+        self._update_compatibility_tag(executor=executor, deadline=deadline)
         self._setup_hostname(executor=executor, deadline=deadline)
         self._setup_resolved(executor=executor, deadline=deadline)
         self._setup_networkd(executor=executor, deadline=deadline)
@@ -687,16 +687,6 @@ class BuilddBase(Base):
                 details=errors.details_from_called_process_error(error),
             ) from error
 
-    def _setup_instance_config(
-        self, *, executor: Executor, deadline: Optional[float]
-    ) -> None:
-        InstanceConfiguration.update(
-            executor=executor,
-            data={"compatibility_tag": self.compatibility_tag},
-            config_path=self.instance_config_path,
-        )
-        _check_deadline(deadline)
-
     def _setup_networkd(self, *, executor: Executor, deadline: Optional[float]) -> None:
         """Configure networkd and start it.
 
@@ -913,6 +903,17 @@ class BuilddBase(Base):
                 deadline, message="Timed out waiting for environment to be ready."
             )
             sleep(retry_wait)
+
+    def _update_compatibility_tag(
+        self, *, executor: Executor, deadline: Optional[float]
+    ) -> None:
+        """Update the compatibility_tag in the instance config."""
+        InstanceConfiguration.update(
+            executor=executor,
+            data={"compatibility_tag": self.compatibility_tag},
+            config_path=self.instance_config_path,
+        )
+        _check_deadline(deadline)
 
     def wait_until_ready(
         self,

--- a/craft_providers/bases/buildd.py
+++ b/craft_providers/bases/buildd.py
@@ -271,7 +271,7 @@ class BuilddBase(Base):
         """Ensure instance configuration is compatible.
 
         As long as the config is not incompatible (via a mismatched compatibility tag),
-        then assume the instance is compatible. This assumption is done is because the
+        then assume the instance is compatible. This assumption is done because the
         config file may not exist or contain a tag while the set up is in progress.
 
         :raises BaseCompatibilityError: if instance is incompatible.
@@ -337,7 +337,7 @@ class BuilddBase(Base):
         if config is None:
             raise BaseCompatibilityError(reason="instance config is empty")
 
-        if not config.setup or config.setup is False:
+        if not config.setup:
             raise BaseCompatibilityError(reason="instance is marked as not setup")
 
         logger.debug("Instance has already been setup.")

--- a/craft_providers/bases/instance_config.py
+++ b/craft_providers/bases/instance_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -54,7 +54,7 @@ class InstanceConfiguration(pydantic.BaseModel, extra=pydantic.Extra.forbid):
     """Instance configuration datastore.
 
     :param compatibility_tag: Compatibility tag for instance.
-
+    :param setup: True if instance was fully setup.
     :param snaps: dictionary of snaps and their revisions, e.g.
       snaps:
         snapcraft:
@@ -64,6 +64,7 @@ class InstanceConfiguration(pydantic.BaseModel, extra=pydantic.Extra.forbid):
     """
 
     compatibility_tag: Optional[str] = None
+    setup: Optional[bool] = None
     snaps: Optional[Dict[str, Dict[str, Any]]] = None
 
     @classmethod

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -52,6 +52,13 @@ def get_base_instance():
 
 @pytest.fixture()
 def core20_instance(instance_name):
+    """Yields a minimally setup core20 instance.
+
+    The yielded instance will be launched, started, and marked as setup, even though
+    most of the setup is skipped to speed up test execution.
+
+    Delete instance on fixture teardown.
+    """
     with conftest.tmp_instance(
         name=instance_name,
         image="20.04",
@@ -59,6 +66,16 @@ def core20_instance(instance_name):
         project="default",
     ):
         instance = lxd.LXDInstance(name=instance_name)
+
+        # mark instance as setup in the config file
+        instance.push_file_io(
+            destination=bases.BuilddBase.instance_config_path,
+            content=io.BytesIO(
+                f"compatibility_tag: {bases.BuilddBase.compatibility_tag}"
+                "\nsetup: true\n".encode()
+            ),
+            file_mode="0644",
+        )
 
         yield instance
 
@@ -550,7 +567,7 @@ def test_launch_instance_config_incompatible_without_auto_clean(core20_instance)
 
     core20_instance.push_file_io(
         destination=base_configuration.instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: invalid\n"),
+        content=io.BytesIO(b"compatibility_tag: invalid\nsetup: true\n"),
         file_mode="0644",
     )
 
@@ -575,7 +592,55 @@ def test_launch_instance_config_incompatible_with_auto_clean(core20_instance):
 
     core20_instance.push_file_io(
         destination=base_configuration.instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: invalid\n"),
+        content=io.BytesIO(b"compatibility_tag: invalid\nsetup: true\n"),
+        file_mode="0644",
+    )
+
+    # when auto_clean is true, the instance will be deleted and recreated
+    lxd.launch(
+        name=core20_instance.name,
+        base_configuration=base_configuration,
+        image_name="20.04",
+        image_remote="ubuntu",
+        auto_clean=True,
+    )
+
+    assert core20_instance.exists()
+    assert core20_instance.is_running()
+
+
+def test_launch_instance_not_setup_without_auto_clean(core20_instance):
+    """Raise an error if an existing instance is not setup and auto_clean is False."""
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    core20_instance.push_file_io(
+        destination=base_configuration.instance_config_path,
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
+        file_mode="0644",
+    )
+
+    # will raise a compatibility error
+    with pytest.raises(bases.BaseCompatibilityError) as exc_info:
+        lxd.launch(
+            name=core20_instance.name,
+            base_configuration=base_configuration,
+            image_name="20.04",
+            image_remote="ubuntu",
+            auto_clean=False,
+        )
+
+    assert exc_info.value == bases.BaseCompatibilityError(
+        "instance is marked as not setup"
+    )
+
+
+def test_launch_instance_not_setup_with_auto_clean(core20_instance):
+    """Clean the instance if it is not setup and auto_clean is True."""
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    core20_instance.push_file_io(
+        destination=base_configuration.instance_config_path,
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
         file_mode="0644",
     )
 

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -35,7 +35,7 @@ def get_base_instance():
     def _base_instance(
         image_name: str = "20.04",
         image_remote: str = "ubuntu",
-        compatibility_tag: str = "buildd-base-v0",
+        compatibility_tag: str = "buildd-base-v1",
         project: str = "default",
     ):
         """Get the base instance."""
@@ -582,7 +582,7 @@ def test_launch_instance_config_incompatible_without_auto_clean(core20_instance)
 
     assert exc_info.value.brief == (
         "Incompatible base detected:"
-        " Expected image compatibility tag 'buildd-base-v0', found 'invalid'."
+        " Expected image compatibility tag 'buildd-base-v1', found 'invalid'."
     )
 
 
@@ -615,7 +615,7 @@ def test_launch_instance_not_setup_without_auto_clean(core20_instance):
 
     core20_instance.push_file_io(
         destination=base_configuration.instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
     )
 
@@ -640,7 +640,7 @@ def test_launch_instance_not_setup_with_auto_clean(core20_instance):
 
     core20_instance.push_file_io(
         destination=base_configuration.instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
     )
 

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -157,7 +157,7 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
 
     assert exc_info.value.brief == (
         "Incompatible base detected:"
-        " Expected image compatibility tag 'buildd-base-v0', found 'invalid'."
+        " Expected image compatibility tag 'buildd-base-v1', found 'invalid'."
     )
 
     # Retry with auto_clean=True.
@@ -178,7 +178,7 @@ def test_launch_instance_not_setup_without_auto_clean(core20_instance):
 
     core20_instance.push_file_io(
         destination=base_configuration.instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
     )
 
@@ -202,7 +202,7 @@ def test_launch_instance_not_setup_with_auto_clean(core20_instance):
 
     core20_instance.push_file_io(
         destination=base_configuration.instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
     )
 

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -28,11 +28,28 @@ from . import conftest
 
 @pytest.fixture()
 def core20_instance(instance_name):
+    """Yields a minimally setup core20 instance.
+
+    The yielded instance will be launched, started, and marked as setup, even though
+    most of the setup is skipped to speed up test execution.
+
+    Delete instance on fixture teardown.
+    """
     with conftest.tmp_instance(
         instance_name=instance_name,
         image_name="snapcraft:core20",
     ) as tmp_instance:
         instance = multipass.MultipassInstance(name=tmp_instance)
+
+        # mark instance as setup in the config file
+        instance.push_file_io(
+            destination=bases.BuilddBase.instance_config_path,
+            content=io.BytesIO(
+                f"compatibility_tag: {bases.BuilddBase.compatibility_tag}"
+                "\nsetup: true\n".encode()
+            ),
+            file_mode="0644",
+        )
 
         yield instance
 
@@ -126,7 +143,7 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
 
     core20_instance.push_file_io(
         destination=base_configuration.instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: invalid\n"),
+        content=io.BytesIO(b"compatibility_tag: invalid\nsetup: true\n"),
         file_mode="0644",
     )
 
@@ -144,6 +161,52 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
     )
 
     # Retry with auto_clean=True.
+    multipass.launch(
+        name=core20_instance.name,
+        base_configuration=base_configuration,
+        image_name="snapcraft:core20",
+        auto_clean=True,
+    )
+
+    assert core20_instance.exists() is True
+    assert core20_instance.is_running() is True
+
+
+def test_launch_instance_not_setup_without_auto_clean(core20_instance):
+    """Raise an error if an existing instance is not setup and auto_clean is False."""
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    core20_instance.push_file_io(
+        destination=base_configuration.instance_config_path,
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
+        file_mode="0644",
+    )
+
+    # will raise a compatibility error
+    with pytest.raises(bases.BaseCompatibilityError) as exc_info:
+        multipass.launch(
+            name=core20_instance.name,
+            base_configuration=base_configuration,
+            image_name="snapcraft:core20",
+            auto_clean=False,
+        )
+
+    assert exc_info.value == bases.BaseCompatibilityError(
+        "instance is marked as not setup"
+    )
+
+
+def test_launch_instance_not_setup_with_auto_clean(core20_instance):
+    """Clean the instance if it is not setup and auto_clean is True."""
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.FOCAL)
+
+    core20_instance.push_file_io(
+        destination=base_configuration.instance_config_path,
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v0\nsetup: false\n"),
+        file_mode="0644",
+    )
+
+    # when auto_clean is true, the instance will be deleted and recreated
     multipass.launch(
         name=core20_instance.name,
         base_configuration=base_configuration,

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -44,7 +44,7 @@ DEFAULT_FAKE_CMD = ["fake-executor"]
 def mock_load(mocker):
     yield mocker.patch(
         "craft_providers.bases.instance_config.InstanceConfiguration.load",
-        return_value=InstanceConfiguration(compatibility_tag="buildd-base-v0"),
+        return_value=InstanceConfiguration(compatibility_tag="buildd-base-v1"),
     )
 
 
@@ -117,7 +117,7 @@ def mock_inject_from_host(mocker):
     ],
 )
 @pytest.mark.parametrize(
-    "tag, expected_tag", [(None, "buildd-base-v0"), ("test-tag", "test-tag")]
+    "tag, expected_tag", [(None, "buildd-base-v1"), ("test-tag", "test-tag")]
 )
 def test_setup(  # pylint: disable=too-many-arguments, too-many-locals
     fake_process,
@@ -555,7 +555,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
         )
 
     assert exc_info.value == errors.BaseCompatibilityError(
-        "Expected image compatibility tag 'buildd-base-v0', found 'invalid-tag'"
+        "Expected image compatibility tag 'buildd-base-v1', found 'invalid-tag'"
     )
 
 
@@ -1023,7 +1023,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
     assert fake_executor.records_of_push_file_io == [
         {
             "content": (
-                "compatibility_tag: buildd-base-v0\n"
+                "compatibility_tag: buildd-base-v1\n"
                 f"setup: {str(status).lower()}\n".encode()
             ),
             "destination": "/etc/craft-instance.conf",
@@ -1137,7 +1137,7 @@ def test_ensure_setup_completed_not_setup(status, fake_executor, mock_load):
 )
 def test_warmup_overall(environment, fake_process, fake_executor, mock_load, mocker):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v0", setup=True
+        compatibility_tag="buildd-base-v1", setup=True
     )
     mock_datetime = mocker.patch("craft_providers.bases.buildd.datetime")
     mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
@@ -1202,7 +1202,7 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
 
 def test_warmup_bad_os(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v0", setup=True
+        compatibility_tag="buildd-base-v1", setup=True
     )
     base_config = buildd.BuilddBase(
         alias=buildd.BuilddBaseAlias.JAMMY,
@@ -1227,7 +1227,7 @@ def test_warmup_bad_os(fake_process, fake_executor, mock_load):
 
 def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v0", setup=True
+        compatibility_tag="buildd-base-v1", setup=True
     )
     alias = buildd.BuilddBaseAlias.JAMMY
     base_config = buildd.BuilddBase(
@@ -1256,7 +1256,7 @@ def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
 def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
     """Raise a BaseConfigurationError if the instance is not setup."""
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v0", setup=setup
+        compatibility_tag="buildd-base-v1", setup=setup
     )
     alias = buildd.BuilddBaseAlias.JAMMY
     base_config = buildd.BuilddBase(
@@ -1284,7 +1284,7 @@ def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
 
 def test_warmup_never_ready(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v0", setup=True
+        compatibility_tag="buildd-base-v1", setup=True
     )
     alias = buildd.BuilddBaseAlias.JAMMY
     base_config = buildd.BuilddBase(
@@ -1315,7 +1315,7 @@ def test_warmup_never_ready(fake_process, fake_executor, mock_load):
 
 def test_warmup_never_network(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v0", setup=True
+        compatibility_tag="buildd-base-v1", setup=True
     )
     alias = buildd.BuilddBaseAlias.JAMMY
     base_config = buildd.BuilddBase(

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -976,6 +976,25 @@ def test_wait_for_system_ready_timeout_in_network(
     )
 
 
+def test_update_compatibility_tag(fake_executor):
+    """`update_compatibility_tag()` should update the instance config."""
+    base_config = buildd.BuilddBase(
+        alias=buildd.BuilddBaseAlias.JAMMY, compatibility_tag="test-tag"
+    )
+
+    base_config._update_compatibility_tag(executor=fake_executor, deadline=None)
+
+    assert fake_executor.records_of_push_file_io == [
+        {
+            "content": b"compatibility_tag: test-tag\n",
+            "destination": "/etc/craft-instance.conf",
+            "file_mode": "0644",
+            "group": "root",
+            "user": "root",
+        }
+    ]
+
+
 def test_ensure_config_compatible_validation_error(fake_executor, mock_load):
     mock_load.side_effect = ValidationError("foo", InstanceConfiguration)
 

--- a/tests/unit/bases/test_buildd.py
+++ b/tests/unit/bases/test_buildd.py
@@ -42,7 +42,7 @@ DEFAULT_FAKE_CMD = ["fake-executor"]
 
 @pytest.fixture()
 def mock_load(mocker):
-    yield mocker.patch(
+    return mocker.patch(
         "craft_providers.bases.instance_config.InstanceConfiguration.load",
         return_value=InstanceConfiguration(compatibility_tag="buildd-base-v1"),
     )

--- a/tests/unit/bases/test_instance_config.py
+++ b/tests/unit/bases/test_instance_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -31,6 +31,7 @@ from craft_providers.bases.instance_config import InstanceConfiguration
 def default_config_data():
     return {
         "compatibility_tag": "tag-foo-v1",
+        "setup": True,
         "snaps": {
             "charmcraft": {"revision": 834},
             "core22": {"revision": 147},
@@ -62,6 +63,15 @@ def config_fixture(mocker, tmpdir):
         return config_file
 
     yield _config_fixture
+
+
+def test_instance_config_defaults():
+    """Verify default values for instance configuration objects."""
+    config = InstanceConfiguration()
+
+    assert config.setup is None
+    assert config.compatibility_tag is None
+    assert config.snaps is None
 
 
 def test_save(mock_executor):
@@ -118,6 +128,7 @@ def test_load_with_valid_config(mock_executor, config_fixture, default_config_da
 
     assert config_instance == {
         "compatibility_tag": "tag-foo-v1",
+        "setup": True,
         "snaps": {"charmcraft": {"revision": 834}, "core22": {"revision": 147}},
     }
 

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -42,7 +42,7 @@ def mock_get_remote_image(mock_remote_image, mocker):
 @pytest.fixture
 def mock_buildd_base_configuration(mocker):
     mock_base_config = mocker.patch("craft_providers.bases.BuilddBase", autospec=True)
-    mock_base_config.compatibility_tag = "buildd-base-v0"
+    mock_base_config.compatibility_tag = "buildd-base-v1"
     yield mock_base_config
 
 

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -25,7 +25,7 @@ from craft_providers.multipass import MultipassError, MultipassProvider
 @pytest.fixture
 def mock_buildd_base_configuration(mocker):
     mock_base_config = mocker.patch("craft_providers.bases.BuilddBase", autospec=True)
-    mock_base_config.compatibility_tag = "buildd-base-v0"
+    mock_base_config.compatibility_tag = "buildd-base-v1"
     yield mock_base_config
 
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

#### Overview
If craft-providers is interrupted while setting up an instance, the instance will be discarded on the next execution.

Broken into 5 discrete commits.

#### Details

The implementation is pretty straightforward, using the instance's instance configuration file:

```python
def setup():
    # set setup=False
    # set up instance...
    # set setup=True

def warmup():
    # check setup == True
    # warm up instance...
```

#### Background

Previously, craft-providers did not track if an instance was fully setup.  If the set up was interrupted, the next execution of craft-providers would assume the instance was setup.  This causes a whole suite of hard-to-troubleshoot failures (e.g. apt packages can't be installed, no internet connectivity, snapd not configured).

This is similar to what is done for snapcraft's [core18|20 build providers](https://github.com/snapcore/snapcraft/blob/5b0d370ed00a689dbc3754291605830f1a270329/snapcraft_legacy/internal/build_providers/_base_provider.py#L304).


#### Source
Resolves https://github.com/canonical/craft-providers/issues/173

(CRAFT-343)