### PR TITLE
lxd(LXDProvider): expire unstable base instances every 14 days

### DIFF
--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -19,6 +19,7 @@
 import contextlib
 import logging
 import pathlib
+from datetime import timedelta
 from typing import Generator
 
 from craft_providers import Executor, Provider
@@ -127,6 +128,12 @@ class LXDProvider(Provider):
                 ),
             )
 
+        if image.is_stable:
+            expiration = timedelta(days=90)
+        else:
+            # unstable images should be refreshed more often
+            expiration = timedelta(days=14)
+
         try:
             instance = launch(
                 name=instance_name,
@@ -140,6 +147,7 @@ class LXDProvider(Provider):
                 use_base_instance=True,
                 project=self.lxd_project,
                 remote=self.lxd_remote,
+                expiration=expiration,
             )
         except BaseConfigurationError as error:
             raise LXDError(str(error)) from error

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -249,6 +249,7 @@ def test_launch_use_base_instance_expired(
         image_name="20.04",
         image_remote="ubuntu",
         use_base_instance=True,
+        expiration=timedelta(days=90),
     )
 
     assert instance.exists()

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -17,6 +17,7 @@
 #
 
 import sys
+from datetime import timedelta
 from unittest.mock import MagicMock, Mock, call
 
 import pytest
@@ -802,7 +803,7 @@ def test_use_snapshots_deprecated(
     ],
 )
 def test_is_valid(creation_date, mocker, mock_lxc):
-    """Instances created within the last 90 days (inclusive) are valid."""
+    """Instances younger than the expiration date (inclusive) are valid."""
     mock_lxc.info.return_value = {"Created": creation_date}
 
     is_valid = lxd.launcher._is_valid(
@@ -810,6 +811,7 @@ def test_is_valid(creation_date, mocker, mock_lxc):
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
+        expiration=timedelta(days=90),
     )
 
     assert is_valid
@@ -817,7 +819,7 @@ def test_is_valid(creation_date, mocker, mock_lxc):
 
 @freeze_time("2022/12/07 11:05:00 UTC")
 def test_is_valid_expired(mocker, mock_lxc):
-    """Instances created more than 90 days ago are not valid."""
+    """Instances older than the expiration date are not valid."""
     # 91 days old
     mock_lxc.info.return_value = {"Created": "2022/09/07 11:05 UTC"}
 
@@ -826,6 +828,7 @@ def test_is_valid_expired(mocker, mock_lxc):
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
+        expiration=timedelta(days=90),
     )
 
     assert not is_valid
@@ -840,6 +843,7 @@ def test_is_valid_lxd_error(logs, mocker, mock_lxc):
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
+        expiration=timedelta(days=1),
     )
 
     assert not is_valid
@@ -855,6 +859,7 @@ def test_is_valid_key_error(logs, mocker, mock_lxc):
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
+        expiration=timedelta(days=1),
     )
 
     assert not is_valid
@@ -870,6 +875,7 @@ def test_is_valid_value_error(logs, mocker, mock_lxc):
         project="test-project",
         remote="test-remote",
         lxc=mock_lxc,
+        expiration=timedelta(days=1),
     )
 
     assert not is_valid

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from datetime import timedelta
 from unittest.mock import call
 
 import pytest
@@ -143,6 +144,12 @@ def test_launched_environment(
     mock_remote_image.is_stable = is_stable
     provider = LXDProvider(lxc=mock_lxc)
 
+    # set the expected expiration time
+    if is_stable:
+        expiration = timedelta(days=90)
+    else:
+        expiration = timedelta(days=14)
+
     with provider.launched_environment(
         project_name="test-project",
         project_path=tmp_path,
@@ -167,6 +174,7 @@ def test_launched_environment(
                 use_base_instance=True,
                 project="default",
                 remote="local",
+                expiration=expiration,
             ),
         ]
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

### Overview

A fairly innocuous PR to expire unstable base instances every 14 days.

### Details

1. `launch()` takes a new parameter `expiration` to set a base instance's expiration date.
    - Previously, it was hardcoded to 90 days.
2. The `LXDProvider` class sets a 90 day expiration for stable images and a 14 day expiration for unstable images.

This is preparatory work for adding `BuilddBaseAlias.DEVEL` (CRAFT-1636).