### PR TITLE
bases(buildd): add new BuilddBaseAlias.DEVEL

### DIFF
--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -146,6 +146,12 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE = {
         remote_address=DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
+    BuilddBaseAlias.DEVEL.value: RemoteImage(
+        image_name="devel",
+        remote_name=DAILY_REMOTE_NAME,
+        remote_address=DAILY_REMOTE_ADDRESS,
+        remote_protocol=ProtocolType.SIMPLESTREAMS,
+    ),
 }
 
 

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -38,6 +38,7 @@ PROVIDER_BASE_TO_MULTIPASS_BASE = {
     bases.BuilddBaseAlias.BIONIC.value: "snapcraft:18.04",
     bases.BuilddBaseAlias.FOCAL.value: "snapcraft:20.04",
     bases.BuilddBaseAlias.JAMMY.value: "snapcraft:22.04",
+    bases.BuilddBaseAlias.DEVEL.value: "snapcraft:devel",
 }
 
 

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -116,18 +116,14 @@ def get_instance_and_base_instance(get_base_instance, instance_name):
             base_instance.delete()
 
 
-# exclude 23.04 (lunar) because it is a daily, not a supported release
-@pytest.mark.parametrize(
-    "alias", set(bases.BuilddBaseAlias) - {bases.BuilddBaseAlias.LUNAR}
-)
-def test_launch_and_run(instance_name, alias):
+def test_launch_and_run(instance_name):
     """Launch an instance from the `ubuntu` remote and run a command in the instance."""
-    base_configuration = bases.BuilddBase(alias=alias)
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name=alias.value,
+        image_name=bases.BuilddBaseAlias.JAMMY.value,
         image_remote="ubuntu",
     )
 

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -147,6 +147,7 @@ def test_add_remote_race_condition_error(fake_remote_image, mock_lxc, logs):
         (BuilddBaseAlias.JAMMY.value, "core22"),
         (BuilddBaseAlias.KINETIC.value, "kinetic"),
         (BuilddBaseAlias.LUNAR.value, "lunar"),
+        (BuilddBaseAlias.DEVEL.value, "devel"),
     ],
 )
 def test_get_image_remote(provider_base, image_name):

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -115,6 +115,7 @@ def test_create_environment(mocker):
         (bases.BuilddBaseAlias.BIONIC.value, "snapcraft:18.04"),
         (bases.BuilddBaseAlias.FOCAL.value, "snapcraft:20.04"),
         (bases.BuilddBaseAlias.JAMMY.value, "snapcraft:22.04"),
+        (bases.BuilddBaseAlias.DEVEL.value, "snapcraft:devel"),
     ],
 )
 def test_launched_environment(


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

- Add support for `BuilddBaseAlias.DEVEL`.
- Update `/etc/apt/sources.list` and `/etc/apt/sources.list.d/*.list` to point to the `devel` archives

(CRAFT-1636)
