### PR TITLE
Bump version: 1.8.0 → 1.8.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.0
+current_version = 1.8.1
 commit = True
 tag = True
 

--- a/craft_providers/__init__.py
+++ b/craft_providers/__init__.py
@@ -17,7 +17,7 @@
 
 """Craft Providers base package."""
 
-__version__ = "1.8.0"  # noqa: F401
+__version__ = "1.8.1"  # noqa: F401
 
 from .base import Base  # noqa: F401
 from .errors import ProviderError  # noqa: F401

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,12 @@
 Changelog
 *********
 
+1.8.1 (2023-03-10)
+------------------
+- Add new base alias `BuilddBaseAlias.DEVEL`
+- Expire unstable base instances every 14 days
+- Refactor tests such that all base aliases are tested by default
+
 1.8.0 (2023-03-01)
 ------------------
 - Track if instances are properly setup when launching. If the instance did not fully

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ copyright = "2021, Canonical Ltd."
 author = "Canonical Ltd."
 
 # The full version, including alpha/beta/rc tags
-release = "1.8.0"
+release = "1.8.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ extras_requires = {
 
 setup(
     name="craft-providers",
-    version="1.8.0",
+    version="1.8.1",
     description="Craft provider tooling",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

`v1.8.1` will allow for snapcraft to use `devel` images.