### PR TITLE
provider: add `allow_unstable` to Provider base class

### DIFF
--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -112,9 +112,9 @@ class LXDProvider(Provider):
         :param base_configuration: Base configuration to apply to instance.
         :param build_base: Base to build from.
         :param instance_name: Name of the instance to launch.
-        :param allow_unstable: If true, allow unstable images to be launched
+        :param allow_unstable: If true, allow unstable images to be launched.
 
-        :raises LXDError: if instance cannot be configured and launched
+        :raises LXDError: if instance cannot be configured and launched.
         """
         image = get_remote_image(build_base)
         image.add_remote(lxc=self.lxc)

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -103,6 +103,7 @@ class MultipassProvider(Provider):
         :param base_configuration: Base configuration to apply to instance.
         :param build_base: Base to build from.
         :param instance_name: Name of the instance to launch.
+        :param allow_unstable: Unused - unstable images are not yet supported.
         """
         try:
             instance = launch(

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -90,6 +90,7 @@ class MultipassProvider(Provider):
         base_configuration: base.Base,
         build_base: str,
         instance_name: str,
+        allow_unstable: bool = False,
     ) -> Generator[Executor, None, None]:
         """Configure and launch environment for specified base.
 

--- a/craft_providers/provider.py
+++ b/craft_providers/provider.py
@@ -100,4 +100,5 @@ class Provider(ABC):
         :param base_configuration: Base configuration to apply to instance.
         :param build_base: Base to build from.
         :param instance_name: Name of the instance to launch.
+        :param allow_unstable: If true, allow unstable images to be launched.
         """

--- a/craft_providers/provider.py
+++ b/craft_providers/provider.py
@@ -87,6 +87,7 @@ class Provider(ABC):
         base_configuration: Base,
         build_base: str,
         instance_name: str,
+        allow_unstable: bool,
     ) -> Generator[Executor, None, None]:
         """Configure and launch environment for specified base.
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Adding a new parameter from `LXDProvider` to the `Provider` base class and the `Multipass` class.

Multipass is currently not using the parameter, but it will use it in a PR next week!