### PR TITLE
multipass(MultipassProvider): support kinetic, lunar, and devel images

### DIFF
--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -68,8 +68,8 @@ class RemoteImage:
     def is_stable(self) -> bool:
         """Check if the image is stable.
 
-        Images are considered stable if they are from a release remote. Images from
-        daily or devel remotes are not considered.
+        Images are stable if they are from a release remote.
+        Images from daily, devel, and any other remotes are not stable.
 
         :returns: True if the image is stable.
         """

--- a/craft_providers/multipass/__init__.py
+++ b/craft_providers/multipass/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,7 +23,7 @@ from .errors import MultipassError, MultipassInstallationError
 from .installer import install, is_installed
 from .multipass import Multipass
 from .multipass_instance import MultipassInstance
-from .multipass_provider import PROVIDER_BASE_TO_MULTIPASS_BASE, MultipassProvider
+from .multipass_provider import MultipassProvider
 
 __all__ = [
     "Multipass",
@@ -31,7 +31,6 @@ __all__ = [
     "MultipassError",
     "MultipassInstallationError",
     "MultipassProvider",
-    "PROVIDER_BASE_TO_MULTIPASS_BASE",
     "install",
     "is_installed",
     "ensure_multipass_is_ready",

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: support KINETIC and LUNAR
-PROVIDER_BASE_TO_MULTIPASS_BASE = {
+_BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE = {
     bases.BuilddBaseAlias.BIONIC.value: "snapcraft:18.04",
     bases.BuilddBaseAlias.FOCAL.value: "snapcraft:20.04",
     bases.BuilddBaseAlias.JAMMY.value: "snapcraft:22.04",
@@ -109,7 +109,7 @@ class MultipassProvider(Provider):
             instance = launch(
                 name=instance_name,
                 base_configuration=base_configuration,
-                image_name=PROVIDER_BASE_TO_MULTIPASS_BASE[build_base],
+                image_name=_BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE[build_base],
                 cpus=2,
                 disk_gb=64,
                 mem_gb=2,

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -58,20 +58,16 @@ def core20_instance(instance_name):
 
 
 @pytest.mark.parametrize(
-    "alias,image_name",
-    [
-        (bases.BuilddBaseAlias.BIONIC, "snapcraft:core18"),
-        (bases.BuilddBaseAlias.FOCAL, "snapcraft:core20"),
-        (bases.BuilddBaseAlias.JAMMY, "snapcraft:core22"),
-    ],
+    "build_base,remote_image",
+    multipass.multipass_provider._BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE.items(),
 )
-def test_launch(instance_name, alias, image_name):
-    base_configuration = bases.BuilddBase(alias=alias)
+def test_launch(instance_name, build_base, remote_image):
+    base_configuration = bases.BuilddBase(alias=build_base)
 
     instance = multipass.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name=image_name,
+        image_name=remote_image,
     )
 
     try:

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -57,17 +57,14 @@ def core20_instance(instance_name):
             instance.delete()
 
 
-@pytest.mark.parametrize(
-    "build_base,remote_image",
-    multipass.multipass_provider._BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE.items(),
-)
-def test_launch(instance_name, build_base, remote_image):
-    base_configuration = bases.BuilddBase(alias=build_base)
+def test_launch(instance_name):
+    """Launch an instance and run a command inside the instance."""
+    base_configuration = bases.BuilddBase(alias=bases.BuilddBaseAlias.JAMMY)
 
     instance = multipass.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name=remote_image,
+        image_name="snapcraft:core22",
     )
 
     try:

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -16,6 +16,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+import pytest
+
 from craft_providers.bases import BuilddBase, BuilddBaseAlias
 from craft_providers.multipass import MultipassProvider, is_installed
 
@@ -41,19 +43,21 @@ def test_create_environment(installed_multipass, instance_name):
     assert test_instance.exists() is False
 
 
-def test_launched_environment(installed_multipass, instance_name, tmp_path):
+@pytest.mark.parametrize("alias", set(BuilddBaseAlias) - {BuilddBaseAlias.XENIAL})
+def test_launched_environment(alias, installed_multipass, instance_name, tmp_path):
     """Verify `launched_environment()` creates and starts an instance then stops
     the instance when the method loses context."""
     provider = MultipassProvider()
 
-    base_configuration = BuilddBase(alias=BuilddBaseAlias.JAMMY)
+    base_configuration = BuilddBase(alias=alias)
 
     with provider.launched_environment(
-        project_name="test-project",
+        project_name="test-multipass-project",
         project_path=tmp_path,
         base_configuration=base_configuration,
-        build_base=BuilddBaseAlias.JAMMY.value,
+        build_base=alias.value,
         instance_name=instance_name,
+        allow_unstable=True,
     ) as test_instance:
         assert test_instance.exists() is True
         assert test_instance.is_running() is True

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -43,7 +43,12 @@ def test_create_environment(installed_multipass, instance_name):
     assert test_instance.exists() is False
 
 
-@pytest.mark.parametrize("alias", set(BuilddBaseAlias) - {BuilddBaseAlias.XENIAL})
+@pytest.mark.parametrize(
+    "alias",
+    set(BuilddBaseAlias)
+    # skip devel images because they are not available on macos
+    - {BuilddBaseAlias.XENIAL, BuilddBaseAlias.LUNAR, BuilddBaseAlias.DEVEL},
+)
 def test_launched_environment(alias, installed_multipass, instance_name, tmp_path):
     """Verify `launched_environment()` creates and starts an instance then stops
     the instance when the method loses context."""

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -22,6 +22,8 @@ from craft_providers import bases
 from craft_providers.multipass import MultipassError, MultipassProvider
 from craft_providers.multipass.multipass_provider import (
     _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE,
+    Remote,
+    RemoteImage,
 )
 
 
@@ -62,6 +64,17 @@ def mock_launch(mocker):
     yield mocker.patch(
         "craft_providers.multipass.multipass_provider.launch", autospec=True
     )
+
+
+@pytest.fixture
+def mock_remote_image(mocker):
+    """Returns a mock RemoteImage object."""
+    _mock_remote_image = mocker.patch(
+        "craft_providers.multipass.multipass_provider.RemoteImage", autospec=True
+    )
+    _mock_remote_image.name = "test-remote:test-image"
+    _mock_remote_image.is_stable = True
+    return _mock_remote_image
 
 
 def test_ensure_provider_is_available_installed(
@@ -130,13 +143,14 @@ def test_launched_environment(
         base_configuration=mock_buildd_base_configuration,
         build_base=build_base,
         instance_name="test-instance-name",
+        allow_unstable=not remote_image.is_stable,
     ) as instance:
         assert instance is not None
         assert mock_launch.mock_calls == [
             call(
                 name="test-instance-name",
                 base_configuration=mock_buildd_base_configuration,
-                image_name=remote_image,
+                image_name=remote_image.name,
                 cpus=2,
                 disk_gb=64,
                 mem_gb=2,
@@ -149,6 +163,98 @@ def test_launched_environment(
         call().unmount_all(),
         call().stop(),
     ]
+
+
+@pytest.mark.parametrize(
+    "is_stable, allow_unstable",
+    [
+        # unstable images can only be launched when `allow_unstable=True`
+        (False, True),
+        # stable images can be launched regardless of `allow_unstable`
+        (True, False),
+        (True, True),
+    ],
+)
+def test_launched_environment_stable(
+    is_stable,
+    allow_unstable,
+    mock_buildd_base_configuration,
+    mock_launch,
+    mock_remote_image,
+    mocker,
+    tmp_path,
+):
+    """Verify allow_unstable parameter works as expected."""
+    mock_remote_image.is_stable = is_stable
+    mocker.patch(
+        "craft_providers.multipass.multipass_provider._get_remote_image",
+        return_value=mock_remote_image,
+    )
+
+    provider = MultipassProvider()
+    with provider.launched_environment(
+        project_name="test-project",
+        project_path=tmp_path,
+        base_configuration=mock_buildd_base_configuration,
+        build_base=bases.BuilddBaseAlias.JAMMY.value,
+        instance_name="test-instance-name",
+        allow_unstable=allow_unstable,
+    ) as instance:
+        assert instance is not None
+        assert mock_launch.mock_calls == [
+            call(
+                name="test-instance-name",
+                base_configuration=mock_buildd_base_configuration,
+                image_name="test-remote:test-image",
+                cpus=2,
+                disk_gb=64,
+                mem_gb=2,
+                auto_clean=True,
+            ),
+        ]
+        mock_launch.reset_mock()
+
+    assert mock_launch.mock_calls == [
+        call().unmount_all(),
+        call().stop(),
+    ]
+
+
+def test_launched_environment_unstable_image_error(
+    mock_buildd_base_configuration,
+    mock_launch,
+    mock_remote_image,
+    mocker,
+    tmp_path,
+):
+    """Raise an error when `allow_unstable=False` and image is unstable."""
+    mock_remote_image.is_stable = False
+    mocker.patch(
+        "craft_providers.multipass.multipass_provider._get_remote_image",
+        return_value=mock_remote_image,
+    )
+
+    provider = MultipassProvider()
+    with pytest.raises(MultipassError) as raised:
+        with provider.launched_environment(
+            project_name="test-project",
+            project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
+            build_base=bases.BuilddBaseAlias.JAMMY.value,
+            instance_name="test-instance-name",
+        ):
+            pass
+
+    assert raised.value == MultipassError(
+        brief="Cannot launch unstable image 'test-remote:test-image'.",
+        details=(
+            "Devel or daily images are not guaranteed and are intended for "
+            "experimental use only."
+        ),
+        resolution=(
+            "Set parameter `allow_unstable` to True to launch unstable images."
+        ),
+    )
 
 
 def test_launched_environment_launch_base_configuration_error(
@@ -169,3 +275,29 @@ def test_launched_environment_launch_base_configuration_error(
             pass
 
     assert raised.value.__cause__ is error
+
+
+@pytest.mark.parametrize("remote", Remote)
+def test_remote_image_name(remote):
+    """Verify RemoteImage name is formulated properly."""
+    remote_image = RemoteImage(remote=remote, image_name="test-name")
+    assert remote_image.name == f"{remote.value}:test-name"
+
+
+@pytest.mark.parametrize(
+    "remote_image, is_stable",
+    [
+        # 'release' and 'snapcraft' remotes are stable
+        (RemoteImage(remote=Remote.RELEASE, image_name="test-name"), True),
+        (RemoteImage(remote=Remote.SNAPCRAFT, image_name="test-name"), True),
+        # 'daily' remote is not stable
+        (RemoteImage(remote=Remote.DAILY, image_name="test-name"), False),
+        # 'devel' images are not stable, regardless of remote
+        (RemoteImage(remote=Remote.RELEASE, image_name="devel"), False),
+        (RemoteImage(remote=Remote.DAILY, image_name="devel"), False),
+        (RemoteImage(remote=Remote.SNAPCRAFT, image_name="devel"), False),
+    ],
+)
+def test_remote_is_stable(remote_image, is_stable):
+    """RemoteImages should be properly marked as stable or unstable."""
+    assert remote_image.is_stable == is_stable

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -143,7 +143,7 @@ def test_launched_environment(
         base_configuration=mock_buildd_base_configuration,
         build_base=build_base,
         instance_name="test-instance-name",
-        allow_unstable=not remote_image.is_stable,
+        allow_unstable=True,
     ) as instance:
         assert instance is not None
         assert mock_launch.mock_calls == [


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

1. Add support for `kinetic`, `lunar`, and `devel` for Multipass with a new `RemoteImage` class.
2. Check if Multipass image are stable and use the `allow_unstable` parameter.

Split into 4 commits for your reviewing pleasure!

(CRAFT-1637)