### PR TITLE
WIP: tests: update macos from 10.15 to latest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,64 +12,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests:
-    name: Ubuntu 20.04 Tests
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install craft-providers
-        run: |
-            pip install -U .[dev]
-      - name: Run black
-        run: |
-          make test-black
-      - name: Run codespell
-        run: |
-          make test-codespell
-      - name: Run flake8
-        run: |
-          make test-flake8
-      - name: Run isort
-        run: |
-          make test-isort
-      - name: Run mypy
-        run: |
-          make test-mypy
-      - name: Run pydocstyle
-        run: |
-          make test-pydocstyle
-      - name: Run pylint
-        run: |
-          make test-pylint
-      - name: Run pyright
-        run: |
-          sudo snap install --classic node
-          sudo snap install --classic pyright
-          make test-pyright
-      - name: Install LXD
-        run: |
-          sudo groupadd --force --system lxd
-          sudo usermod --append --groups lxd $USER
-          sudo snap refresh lxd
-          sudo snap start lxd
-          sudo lxd waitready --timeout=30
-          sudo lxd init --auto
-      - name: Run integration tests on Linux
-        run: |
-          export CRAFT_PROVIDERS_TESTS_ENABLE_SNAP_INSTALL=1
-          export CRAFT_PROVIDERS_TESTS_ENABLE_LXD_INSTALL=1
-          export CRAFT_PROVIDERS_TESTS_ENABLE_LXD_UNINSTALL=1
-          sg lxd -c "lxc version"
-          sg lxd -c "make test-integrations"
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v1
-
   macos-integration-tests:
     name: MacOS 10.15 Integration Tests
-    runs-on: macos-10.15
+    runs-on: macos-13
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -85,16 +30,19 @@ jobs:
           brew install multipass
           multipass version
           sleep 20
+      #- name: Setup upterm session
+      #  uses: lhotari/action-upterm@v1
       - name: Run integration tests on MacOS
         run: |
           export CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_INSTALL=1
           export CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_UNINSTALL=1
           make test-integrations
+          pytest --log-level=6 tests/integration || cat /Library/Logs/Multipass/*
 
   unit-tests:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-13, windows-2019]
         python-version: ["3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.os }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,6 +27,7 @@ import string
 import subprocess
 import sys
 import tempfile
+from time import sleep
 from typing import Optional
 
 import pytest
@@ -296,3 +297,20 @@ def empty_test_snap(installed_snap, tmp_path):
 
     with installed_snap(snap_name, try_path=tmp_path):
         yield snap_name
+
+
+#@pytest.fixture(autouse=True)
+@pytest.fixture()
+def multipass_delay():
+    if sys.platform == "darwin":
+        print("sleeping...")
+        sleep(5)
+        print("restarting multipass")
+        subprocess.run(
+            ["sudo", "launchctl", "kickstart", "-k", "system/com.canonical.multipassd"],
+            check=True,
+        )
+        print("waiting for restart")
+        sleep(20)
+    else:
+        print("not sleeping...")


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
The GitHub action runner for MacOS 10.15 was deprecated in 2022-Dec. It has not received updates since then and is scheduled to be [removed](https://github.com/actions/runner-images/issues/5583#issuecomment-1426004850) on 2023-Mar-31.

(https://github.com/canonical/craft-providers/issues/218)
(CRAFT-1447)