### PR TITLE
provider: deprecate build_base

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -22,6 +22,7 @@ import os
 import subprocess
 import time
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Dict, List, Optional
 
 from craft_providers.errors import BaseConfigurationError, NetworkError
@@ -57,6 +58,7 @@ class Base(ABC):
     """
 
     compatibility_tag: str = "base-v1"
+    alias: Enum
 
     @abstractmethod
     def get_command_environment(

--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -19,9 +19,13 @@
 
 # Backward compatible, will be removed in 2.0
 import sys
+from enum import Enum
+from typing import Dict, Tuple, Type
 
 from craft_providers.errors import BaseCompatibilityError, BaseConfigurationError
 
+from ..base import Base
+from . import ubuntu
 from . import ubuntu as buildd
 from .ubuntu import BuilddBase, BuilddBaseAlias
 
@@ -33,3 +37,33 @@ __all__ = [
     "BaseCompatibilityError",
     "BaseConfigurationError",
 ]
+
+BASE_NAME_TO_BASE_ALIAS: Dict[Tuple[str, str], Enum] = {
+    ("ubuntu", "16.04"): ubuntu.BuilddBaseAlias.XENIAL,
+    ("ubuntu", "18.04"): ubuntu.BuilddBaseAlias.BIONIC,
+    ("ubuntu", "20.04"): ubuntu.BuilddBaseAlias.FOCAL,
+    ("ubuntu", "22.04"): ubuntu.BuilddBaseAlias.JAMMY,
+    ("ubuntu", "22.10"): ubuntu.BuilddBaseAlias.KINETIC,
+    ("ubuntu", "23.04"): ubuntu.BuilddBaseAlias.LUNAR,
+    ("ubuntu", "devel"): ubuntu.BuilddBaseAlias.DEVEL,
+}
+
+
+def get_base_alias(
+    base_name: Tuple[str, str],
+) -> Enum:
+    """Return a Base alias from a base (name, version) tuple."""
+    if base_name in BASE_NAME_TO_BASE_ALIAS:
+        return BASE_NAME_TO_BASE_ALIAS[base_name]
+
+    raise BaseConfigurationError(f"Base alias not found for {base_name}")
+
+
+def get_base_from_alias(
+    alias: Enum,
+) -> Type[Base]:
+    """Return a Base class from a known base alias."""
+    if isinstance(alias, ubuntu.BuilddBaseAlias):
+        return ubuntu.BuilddBase
+
+    raise BaseConfigurationError(f"Base not found for alias {alias}")

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -20,7 +20,7 @@ import contextlib
 import logging
 import pathlib
 from datetime import timedelta
-from typing import Generator
+from typing import Generator, Optional
 
 from craft_providers import Executor, Provider
 from craft_providers.base import Base
@@ -97,7 +97,7 @@ class LXDProvider(Provider):
         project_name: str,
         project_path: pathlib.Path,
         base_configuration: Base,
-        build_base: str,
+        build_base: Optional[str] = None,
         instance_name: str,
         allow_unstable: bool = False,
     ) -> Generator[Executor, None, None]:
@@ -110,13 +110,20 @@ class LXDProvider(Provider):
         :param project_name: Name of project.
         :param project_path: Path to project.
         :param base_configuration: Base configuration to apply to instance.
-        :param build_base: Base to build from.
+        :param build_base: Base to build from. (Deprecated)
         :param instance_name: Name of the instance to launch.
         :param allow_unstable: If true, allow unstable images to be launched.
 
         :raises LXDError: if instance cannot be configured and launched.
         """
-        image = get_remote_image(build_base)
+        if build_base:
+            logger.warning(
+                "Deprecated: Parameter 'build_base' is deprecated and should "
+                "not be used. The build base now comes from the "
+                "base_configuration's alias."
+            )
+
+        image = get_remote_image(base_configuration)
         image.add_remote(lxc=self.lxc)
 
         # only allow launching unstable images when opted-in with `allow_unstable`

--- a/craft_providers/provider.py
+++ b/craft_providers/provider.py
@@ -25,7 +25,7 @@ import contextlib
 import logging
 import pathlib
 from abc import ABC, abstractmethod
-from typing import Generator
+from typing import Generator, Optional
 
 from .base import Base
 from .executor import Executor
@@ -85,7 +85,7 @@ class Provider(ABC):
         project_name: str,
         project_path: pathlib.Path,
         base_configuration: Base,
-        build_base: str,
+        build_base: Optional[str] = None,
         instance_name: str,
         allow_unstable: bool,
     ) -> Generator[Executor, None, None]:
@@ -98,7 +98,7 @@ class Provider(ABC):
         :param project_name: Name of project.
         :param project_path: Path to project.
         :param base_configuration: Base configuration to apply to instance.
-        :param build_base: Base to build from.
+        :param build_base: Base to build from. (Deprecated)
         :param instance_name: Name of the instance to launch.
         :param allow_unstable: If true, allow unstable images to be launched.
         """

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -54,7 +54,6 @@ def test_launched_environment(alias, installed_lxd, instance_name, tmp_path):
         project_name="test-project",
         project_path=tmp_path,
         base_configuration=base_configuration,
-        build_base=alias.value,
         instance_name=instance_name,
         allow_unstable=True,
     ) as test_instance:

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -29,8 +29,8 @@ from craft_providers.bases import ubuntu
 )
 def test_configure_and_launch_remote(instance_name, alias):
     """Verify remotes are configured and images can be launched."""
-    remote_image = lxd.get_remote_image(alias.value)
     base_configuration = ubuntu.BuilddBase(alias=alias)
+    remote_image = lxd.get_remote_image(base_configuration)
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -64,7 +64,6 @@ def test_launched_environment(alias, installed_multipass, instance_name, tmp_pat
         project_name="test-multipass-project",
         project_path=tmp_path,
         base_configuration=base_configuration,
-        build_base=alias.value,
         instance_name=instance_name,
         allow_unstable=True,
     ) as test_instance:

--- a/tests/unit/bases/test_get_base.py
+++ b/tests/unit/bases/test_get_base.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+import pytest
+
+from craft_providers.bases import get_base_alias, get_base_from_alias, ubuntu
+from craft_providers.errors import BaseConfigurationError
+
+
+def test_get_base_alias():
+    assert get_base_alias(("ubuntu", "22.04")) == ubuntu.BuilddBaseAlias.JAMMY
+
+
+def test_get_base_alias_does_not_exist():
+    with pytest.raises(BaseConfigurationError) as exc_info:
+        get_base_alias(("ubuntu", "8.04"))
+
+    assert exc_info.value == BaseConfigurationError(
+        brief="Base alias not found for ('ubuntu', '8.04')"
+    )
+
+
+def test_get_base_from_alias():
+    assert get_base_from_alias(ubuntu.BuilddBaseAlias.JAMMY) == ubuntu.BuilddBase
+
+
+def test_get_base_from_alias_does_not_exist():
+    with pytest.raises(BaseConfigurationError) as exc_info:
+        get_base_from_alias("ubuntu 8")  # type: ignore
+
+    assert exc_info.value == BaseConfigurationError(
+        brief="Base not found for alias ubuntu 8"
+    )

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -46,6 +46,7 @@ def mock_buildd_base_configuration(mocker):
     mock_base_config = mocker.patch(
         "craft_providers.bases.ubuntu.BuilddBase", autospec=True
     )
+    mock_base_config.alias = ubuntu.BuilddBaseAlias.JAMMY
     mock_base_config.compatibility_tag = "buildd-base-v1"
     yield mock_base_config
 
@@ -157,12 +158,11 @@ def test_launched_environment(
         project_name="test-project",
         project_path=tmp_path,
         base_configuration=mock_buildd_base_configuration,
-        build_base="test-build-base",
         instance_name="test-instance-name",
         allow_unstable=allow_unstable,
     ) as instance:
         assert instance is not None
-        mock_get_remote_image.assert_called_once_with("test-build-base")
+        mock_get_remote_image.assert_called_once_with(mock_buildd_base_configuration)
         mock_remote_image.add_remote.assert_called_once_with(lxc=mock_lxc)
         assert mock_launch.mock_calls == [
             call(
@@ -205,7 +205,6 @@ def test_launched_environment_launch_base_configuration_error(
             project_name="test-project",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base=ubuntu.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass
@@ -229,7 +228,6 @@ def test_launched_environment_unstable_error(
             project_name="test-project",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base=ubuntu.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass


### PR DESCRIPTION
We are now use `base_configuration` which included alias to decide which os / version to use, instead of use `build_base`. The `build_base` now has no effect.

Added 2 new functions in craft_providers.bases:

`get_base_alias()` accept a tuple `(system, version)` and return a `BaseAlias`.

`get_base_from_alias` accept a `BaseAlias` and return the `Base` of it.

-----
