### PR TITLE
ci: reorganize github CI tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,25 +4,38 @@ on:
   push:
     branches:
       - "main"
+      - "feature/*"
       - "release/*"
       - "hotfix/*"
   pull_request:
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows triggering the workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  tests:
-    name: Ubuntu 20.04 Tests
-    runs-on: ubuntu-20.04
+  linters:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install craft-providers
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Configure environment
         run: |
-            pip install -U .[dev]
+          echo "::group::Begin snap install"
+          echo "Installing snaps in the background while running apt and pip..."
+          sudo snap install --no-wait --classic pyright
+          echo "::endgroup::"
+          echo "::group::pip install"
+          python -m pip install -U .[dev]
+          echo "::endgroup::"
+          echo "::group::Wait for snap to complete"
+          snap watch --last=install
+          echo "::endgroup::"
       - name: Run black
         run: |
           make test-black
@@ -46,17 +59,62 @@ jobs:
           make test-pylint
       - name: Run pyright
         run: |
-          sudo snap install --classic node
-          sudo snap install --classic pyright
           make test-pyright
-      - name: Install LXD
+
+  unit-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        # does not work with python 3.11 (see https://github.com/canonical/craft-providers/issues/272)
+        python-version: ["3.8", "3.10"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python on ${{ matrix.platform }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Configure environment
         run: |
+          echo "::group::pip install"
+          python -m pip install -U .[dev]
+          python -m pip install -U -e .
+          echo "::endgroup::"
+      - name: Run unit tests
+        run: make test-units
+
+  integration-tests-linux:
+    strategy:
+      matrix:
+        # does not work with python 3.11 (see https://github.com/canonical/craft-providers/issues/272)
+        python-version: ["3.8", "3.10"]
+    # does not work ubuntu-22.04 (see https://github.com/canonical/craft-providers/issues/270)
+    # does not work with canonical/setup-lxd github action (see https://github.com/canonical/craft-providers/issues/271)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Configure environment
+        run: |
+          echo "::group::pip install"
+          python -m pip install -U .[dev]
+          echo "::endgroup::"
+          echo "::group::Configure LXD"
           sudo groupadd --force --system lxd
           sudo usermod --append --groups lxd $USER
-          sudo snap refresh lxd
           sudo snap start lxd
           sudo lxd waitready --timeout=30
           sudo lxd init --auto
+          echo "::endgroup::"
       - name: Run integration tests on Linux
         run: |
           export CRAFT_PROVIDERS_TESTS_ENABLE_SNAP_INSTALL=1
@@ -64,52 +122,39 @@ jobs:
           export CRAFT_PROVIDERS_TESTS_ENABLE_LXD_UNINSTALL=1
           sg lxd -c "lxc version"
           sg lxd -c "make test-integrations"
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v1
 
-  macos-integration-tests:
-    name: MacOS 10.15 Integration Tests
-    runs-on: macos-10.15
+  integration-tests-macos:
+    strategy:
+      matrix:
+        # does not work with python 3.11 (see https://github.com/canonical/craft-providers/issues/272)
+        python-version: ["3.8", "3.10"]
+    runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install craft-providers
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Configure environment
         run: |
-          pip3 install -U .[dev]
-          pip3 install -U -e .
-      - name: Install Multipass
-        run: |
+          echo "::group::pip install"
+          python -m pip install -U -e .[dev]
+          echo "::endgroup::"
+          echo "::group::Install Multipass"
           brew update
           brew install multipass
-          multipass version
+          # wait 20 seconds for multipassd to start (see https://github.com/canonical/multipass/issues/1995)
           sleep 20
+          # this can be removed when multipass 1.12 is available on brew, because qemu will be the new default
+          multipass set local.driver=qemu
+          sleep 20
+          multipass version
+          echo "::endgroup::"
       - name: Run integration tests on MacOS
         run: |
           export CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_INSTALL=1
           export CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_UNINSTALL=1
           make test-integrations
-
-  unit-tests:
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
-        python-version: ["3.8", "3.9", "3.10"]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install craft-providers
-        run: |
-          pip install -U .[dev]
-          pip install -U -e .
-      - name: Run unit tests for Python ${{ matrix.python-version }}
-        run: make test-units

--- a/tests/unit/multipass/test_installer.py
+++ b/tests/unit/multipass/test_installer.py
@@ -46,6 +46,7 @@ def test_install_darwin(fake_process, monkeypatch):
     monkeypatch.setattr(sys, "platform", "darwin")
 
     fake_process.register_subprocess(["brew", "install", "multipass"])
+    fake_process.register_subprocess(["multipass", "set", "local.driver=qemu"])
     fake_process.register_subprocess(
         ["multipass", "version"], stdout="multipass 1.4.2\nmultipassd 1.4.2\n"
     )
@@ -54,6 +55,7 @@ def test_install_darwin(fake_process, monkeypatch):
 
     assert list(fake_process.calls) == [
         ["brew", "install", "multipass"],
+        ["multipass", "set", "local.driver=qemu"],
         ["multipass", "version"],
     ]
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

## Overview

Reorganize github CI tests and workaround failing MacOS integration tests.

## Details

1. Separate linters, unit tests, and integration tests
2. Align with starbase's [workflow](https://github.com/canonical/starbase/blob/main/.github/workflows/tests.yaml) (this PR is a first step, not the end result)
3. Add more unit testing across OS's and Python versions 

(CRAFT-1726)