### PR TITLE
tests: make integration tests work with pytest-xdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test-flake8:
 
 .PHONY: test-integrations
 test-integrations: ## Run integration tests.
-	pytest tests/integration
+	pytest -n 8 tests/integration
 
 .PHONY: test-isort
 test-isort:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ test_requires = [
     "pytest",
     "pytest-mock",
     "pytest-subprocess",
+    "pytest-xdist",
     "responses",
     "types-requests",
     "types-setuptools",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,6 +35,10 @@ from craft_providers import lxd, multipass
 from craft_providers.actions.snap_installer import get_host_snap_info
 from craft_providers.bases import ubuntu
 
+# exclude XENIAL because it is not supported for LXD
+LXD_ALIASES = list(ubuntu.BuilddBaseAlias)
+LXD_ALIASES.remove(ubuntu.BuilddBaseAlias.XENIAL)
+
 
 def generate_instance_name():
     """Generate a random instance name."""
@@ -49,6 +53,11 @@ def snap_exists(snap_name: str) -> bool:
 def is_installed_dangerously(snap_name: str) -> bool:
     """Returns true if a snap is installed dangerously."""
     return get_host_snap_info(snap_name)["revision"].startswith("x")
+
+
+@pytest.fixture(params=LXD_ALIASES)
+def lxd_alias(request):
+    yield request.param
 
 
 @pytest.fixture()

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -42,14 +42,10 @@ def test_create_environment(installed_lxd, instance_name):
     assert test_instance.exists() is False
 
 
-@pytest.mark.parametrize(
-    "alias",
-    set(ubuntu.BuilddBaseAlias) - {ubuntu.BuilddBaseAlias.XENIAL},
-)
-def test_launched_environment(alias, installed_lxd, instance_name, tmp_path):
+def test_launched_environment(lxd_alias, installed_lxd, instance_name, tmp_path):
     provider = LXDProvider()
 
-    base_configuration = get_base_from_alias(alias)(alias=alias)
+    base_configuration = get_base_from_alias(lxd_alias)(alias=lxd_alias)
     with provider.launched_environment(
         project_name="test-project",
         project_path=tmp_path,

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -23,13 +23,9 @@ from craft_providers import lxd
 from craft_providers.bases import ubuntu
 
 
-# exclude XENIAL because it is not supported for LXD
-@pytest.mark.parametrize(
-    "alias", set(ubuntu.BuilddBaseAlias) - {ubuntu.BuilddBaseAlias.XENIAL}
-)
-def test_configure_and_launch_remote(instance_name, alias):
+def test_configure_and_launch_remote(instance_name, lxd_alias):
     """Verify remotes are configured and images can be launched."""
-    base_configuration = ubuntu.BuilddBase(alias=alias)
+    base_configuration = ubuntu.BuilddBase(alias=lxd_alias)
     remote_image = lxd.get_remote_image(base_configuration)
     instance = lxd.launch(
         name=instance_name,

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+import sys
 
 import pytest
 
@@ -43,15 +44,19 @@ def test_create_environment(installed_multipass, instance_name):
     assert test_instance.exists() is False
 
 
+LINUX_ONLY_ALIASES = [
+    ubuntu.BuilddBaseAlias.XENIAL,
+    ubuntu.BuilddBaseAlias.LUNAR,
+    ubuntu.BuilddBaseAlias.DEVEL,
+]
+
 @pytest.mark.parametrize(
     "alias",
-    set(ubuntu.BuilddBaseAlias)
-    # skip devel images because they are not available on macos
-    - {
-        ubuntu.BuilddBaseAlias.XENIAL,
-        ubuntu.BuilddBaseAlias.LUNAR,
-        ubuntu.BuilddBaseAlias.DEVEL,
-    },
+    [
+        *(alias for alias in ubuntu.BuilddBaseAlias if alias not in LINUX_ONLY_ALIASES),
+        *(pytest.param(alias, marks=pytest.mark.skipif(sys.platform != "Linux"))
+          for alias in LINUX_ONLY_ALIASES),
+    ]
 )
 def test_launched_environment(alias, installed_multipass, instance_name, tmp_path):
     """Verify `launched_environment()` creates and starts an instance then stops


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Our integration tests can easily run in parallel even on a single core — this uses `pytest-xdist` to do exactly that.