### PR TITLE
bases: pre-installation of common packages

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -106,6 +106,7 @@ class Base(ABC):
         hostname: str = "craft-instance",
         snaps: Optional[List] = None,
         packages: Optional[List[str]] = None,
+        use_default_packages: bool = True,
     ):
         pass
 

--- a/craft_providers/bases/almalinux.py
+++ b/craft_providers/bases/almalinux.py
@@ -62,6 +62,7 @@ class AlmaLinuxBase(Base):
     :param hostname: Hostname to configure.
     :param snaps: Optional list of snaps to install on the base image.
     :param packages: Optional list of system packages to install on the base image.
+    :param use_default_packages: Optional bool to enable/disable default packages.
     """
 
     compatibility_tag: str = f"almalinux-{Base.compatibility_tag}"
@@ -75,6 +76,7 @@ class AlmaLinuxBase(Base):
         hostname: str = "craft-almalinux-instance",
         snaps: Optional[List[Snap]] = None,
         packages: Optional[List[str]] = None,
+        use_default_packages: bool = True,
     ) -> None:
         self.alias: AlmaLinuxBaseAlias = alias
 
@@ -87,11 +89,30 @@ class AlmaLinuxBase(Base):
             self.compatibility_tag = compatibility_tag
 
         self._set_hostname(hostname)
-        self._snaps = snaps
-        self._packages = []
+
+        self._packages: List[str] = []
+        if use_default_packages:
+            self._packages.extend(
+                [
+                    "autoconf",
+                    "automake",
+                    "gcc",
+                    "gcc-c++",
+                    "git",
+                    "make",
+                    "patch",
+                    "python3",
+                    "python3-devel",
+                    "python3-pip",
+                    "python3-pip-wheel",
+                    "python3-setuptools",
+                ]
+            )
 
         if packages:
             self._packages.extend(packages)
+
+        self._snaps = snaps
 
     def _ensure_os_compatible(self, executor: Executor) -> None:
         """Ensure OS is compatible with Base.

--- a/craft_providers/bases/centos.py
+++ b/craft_providers/bases/centos.py
@@ -64,6 +64,7 @@ class CentOSBase(Base):
     :param hostname: Hostname to configure.
     :param snaps: Optional list of snaps to install on the base image.
     :param packages: Optional list of system packages to install on the base image.
+    :param use_default_packages: Optional bool to enable/disable default packages.
     """
 
     compatibility_tag: str = f"centos-{Base.compatibility_tag}"
@@ -77,6 +78,7 @@ class CentOSBase(Base):
         hostname: str = "craft-centos-instance",
         snaps: Optional[List[Snap]] = None,
         packages: Optional[List[str]] = None,
+        use_default_packages: bool = True,
     ):
         self.alias: CentOSBaseAlias = alias
 
@@ -90,7 +92,25 @@ class CentOSBase(Base):
 
         self._set_hostname(hostname)
 
-        self._packages = []
+        self._packages: List[str] = []
+        if use_default_packages:
+            self._packages.extend(
+                [
+                    "autoconf",
+                    "automake",
+                    "gcc",
+                    "gcc-c++",
+                    "git",
+                    "make",
+                    "patch",
+                    "rh-python38-python",
+                    "rh-python38-python-devel",
+                    "rh-python38-python-pip",
+                    "rh-python38-python-pip-wheel",
+                    "rh-python38-python-setuptools",
+                ]
+            )
+
         if packages:
             self._packages.extend(packages)
 
@@ -109,7 +129,7 @@ class CentOSBase(Base):
         return {
             "PATH": "/usr/local/sbin:/usr/local/bin:"
             "/opt/rh/rh-python38/root/usr/bin:"
-            "/sbin:/bin:/usr/sbin:/usr/bin:/var/lib/snapd/bin:/snap/bin",
+            "/sbin:/bin:/usr/sbin:/usr/bin:/snap/bin"
         }
 
     def _ensure_os_compatible(self, executor: Executor) -> None:

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -71,6 +71,7 @@ class BuilddBase(Base):
     :param hostname: Hostname to configure.
     :param snaps: Optional list of snaps to install on the base image.
     :param packages: Optional list of system packages to install on the base image.
+    :param use_default_packages: Optional bool to enable/disable default packages.
     """
 
     compatibility_tag: str = f"buildd-{Base.compatibility_tag}"
@@ -84,6 +85,7 @@ class BuilddBase(Base):
         hostname: str = "craft-buildd-instance",
         snaps: Optional[List[Snap]] = None,
         packages: Optional[List[str]] = None,
+        use_default_packages: bool = True,
     ):
         self.alias: BuilddBaseAlias = alias
 
@@ -97,7 +99,23 @@ class BuilddBase(Base):
 
         self._set_hostname(hostname)
 
-        self._packages = ["apt-utils", "curl", "fuse", "udev"]
+        self._packages: List[str] = []
+        if use_default_packages:
+            self._packages.extend(
+                [
+                    "apt-utils",
+                    "build-essential",
+                    "curl",
+                    "fuse",
+                    "udev",
+                    "python3",
+                    "python3-dev",
+                    "python3-pip",
+                    "python3-wheel",
+                    "python3-setuptools",
+                ]
+            )
+
         if packages:
             self._packages.extend(packages)
 

--- a/tests/unit/bases/test_almalinux.py
+++ b/tests/unit/bases/test_almalinux.py
@@ -118,11 +118,39 @@ def mock_get_os_release(mocker):
     [
         (
             None,
-            [],
+            [
+                "autoconf",
+                "automake",
+                "gcc",
+                "gcc-c++",
+                "git",
+                "make",
+                "patch",
+                "python3",
+                "python3-devel",
+                "python3-pip",
+                "python3-pip-wheel",
+                "python3-setuptools",
+            ],
         ),
         (
             ["clang", "go"],
-            ["clang", "go"],
+            [
+                "autoconf",
+                "automake",
+                "gcc",
+                "gcc-c++",
+                "git",
+                "make",
+                "patch",
+                "python3",
+                "python3-devel",
+                "python3-pip",
+                "python3-pip-wheel",
+                "python3-setuptools",
+                "clang",
+                "go",
+            ],
         ),
     ],
 )
@@ -243,6 +271,18 @@ def test_setup(
             "dnf",
             "install",
             "-y",
+            "autoconf",
+            "automake",
+            "gcc",
+            "gcc-c++",
+            "git",
+            "make",
+            "patch",
+            "python3",
+            "python3-devel",
+            "python3-pip",
+            "python3-pip-wheel",
+            "python3-setuptools",
         ]
     )
     fake_process.register_subprocess(
@@ -251,6 +291,18 @@ def test_setup(
             "dnf",
             "install",
             "-y",
+            "autoconf",
+            "automake",
+            "gcc",
+            "gcc-c++",
+            "git",
+            "make",
+            "patch",
+            "python3",
+            "python3-devel",
+            "python3-pip",
+            "python3-pip-wheel",
+            "python3-setuptools",
             "clang",
             "go",
         ]
@@ -520,6 +572,18 @@ def test_setup_dnf(fake_executor, fake_process):
             "dnf",
             "install",
             "-y",
+            "autoconf",
+            "automake",
+            "gcc",
+            "gcc-c++",
+            "git",
+            "make",
+            "patch",
+            "python3",
+            "python3-devel",
+            "python3-pip",
+            "python3-pip-wheel",
+            "python3-setuptools",
             "clang",
             "go",
         ]
@@ -550,6 +614,27 @@ def test_setup_dnf_install_default(fake_executor, fake_process):
             "python3-pip",
             "python3-pip-wheel",
             "python3-setuptools",
+        ]
+    )
+
+    base._setup_packages(executor=fake_executor)
+
+
+def test_setup_dnf_install_override_system(fake_executor, fake_process):
+    """Verify override default packages."""
+    base = almalinux.AlmaLinuxBase(
+        alias=almalinux.AlmaLinuxBaseAlias.NINE,
+        packages=["clang"],
+        use_default_packages=False,
+    )
+    fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "dnf", "update", "-y"])
+    fake_process.register_subprocess(
+        [
+            *DEFAULT_FAKE_CMD,
+            "dnf",
+            "install",
+            "-y",
+            "clang",
         ]
     )
 

--- a/tests/unit/bases/test_centos_7.py
+++ b/tests/unit/bases/test_centos_7.py
@@ -88,7 +88,7 @@ def mock_get_os_release(mocker):
             (
                 "PATH=/usr/local/sbin:/usr/local/bin:"
                 "/opt/rh/rh-python38/root/usr/bin:"
-                "/sbin:/bin:/usr/sbin:/usr/bin:/var/lib/snapd/bin:/snap/bin\n"
+                "/sbin:/bin:/usr/sbin:/usr/bin:/snap/bin\n"
             ).encode(),
         ),
         (
@@ -120,11 +120,39 @@ def mock_get_os_release(mocker):
     [
         (
             None,
-            [],
+            [
+                "autoconf",
+                "automake",
+                "gcc",
+                "gcc-c++",
+                "git",
+                "make",
+                "patch",
+                "rh-python38-python",
+                "rh-python38-python-devel",
+                "rh-python38-python-pip",
+                "rh-python38-python-pip-wheel",
+                "rh-python38-python-setuptools",
+            ],
         ),
         (
             ["go", "clang"],
-            ["go", "clang"],
+            [
+                "autoconf",
+                "automake",
+                "gcc",
+                "gcc-c++",
+                "git",
+                "make",
+                "patch",
+                "rh-python38-python",
+                "rh-python38-python-devel",
+                "rh-python38-python-pip",
+                "rh-python38-python-pip-wheel",
+                "rh-python38-python-setuptools",
+                "go",
+                "clang",
+            ],
         ),
     ],
 )
@@ -495,6 +523,18 @@ def test_setup_packages(fake_executor, fake_process):
             "yum",
             "install",
             "-y",
+            "autoconf",
+            "automake",
+            "gcc",
+            "gcc-c++",
+            "git",
+            "make",
+            "patch",
+            "rh-python38-python",
+            "rh-python38-python-devel",
+            "rh-python38-python-pip",
+            "rh-python38-python-pip-wheel",
+            "rh-python38-python-setuptools",
             "grep",
             "git",
         ]
@@ -513,6 +553,39 @@ def test_setup_yum_install_default(fake_executor, fake_process):
             "yum",
             "install",
             "-y",
+            "autoconf",
+            "automake",
+            "gcc",
+            "gcc-c++",
+            "git",
+            "make",
+            "patch",
+            "rh-python38-python",
+            "rh-python38-python-devel",
+            "rh-python38-python-pip",
+            "rh-python38-python-pip-wheel",
+            "rh-python38-python-setuptools",
+        ]
+    )
+
+    base._setup_packages(executor=fake_executor)
+
+
+def test_setup_yum_install_override_system(fake_executor, fake_process):
+    """Verify override default packages."""
+    base = centos.CentOSBase(
+        alias=centos.CentOSBaseAlias.SEVEN,
+        packages=["clang"],
+        use_default_packages=False,
+    )
+    fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "yum", "update", "-y"])
+    fake_process.register_subprocess(
+        [
+            *DEFAULT_FAKE_CMD,
+            "yum",
+            "install",
+            "-y",
+            "clang",
         ]
     )
 

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -117,10 +117,37 @@ def mock_get_os_release(mocker):
 @pytest.mark.parametrize(
     "packages, expected_packages",
     [
-        (None, ["apt-utils", "curl", "fuse", "udev"]),
+        (
+            None,
+            [
+                "apt-utils",
+                "build-essential",
+                "curl",
+                "fuse",
+                "udev",
+                "python3",
+                "python3-dev",
+                "python3-pip",
+                "python3-wheel",
+                "python3-setuptools",
+            ],
+        ),
         (
             ["grep", "git"],
-            ["apt-utils", "curl", "fuse", "udev", "grep", "git"],
+            [
+                "apt-utils",
+                "build-essential",
+                "curl",
+                "fuse",
+                "udev",
+                "python3",
+                "python3-dev",
+                "python3-pip",
+                "python3-wheel",
+                "python3-setuptools",
+                "grep",
+                "git",
+            ],
         ),
     ],
 )
@@ -531,9 +558,15 @@ def test_setup_apt(fake_executor, fake_process):
             "install",
             "-y",
             "apt-utils",
+            "build-essential",
             "curl",
             "fuse",
             "udev",
+            "python3",
+            "python3-dev",
+            "python3-pip",
+            "python3-wheel",
+            "python3-setuptools",
             "grep",
             "git",
         ]
@@ -553,9 +586,36 @@ def test_setup_apt_install_default(fake_executor, fake_process):
             "install",
             "-y",
             "apt-utils",
+            "build-essential",
             "curl",
             "fuse",
             "udev",
+            "python3",
+            "python3-dev",
+            "python3-pip",
+            "python3-wheel",
+            "python3-setuptools",
+        ]
+    )
+
+    base._setup_packages(executor=fake_executor)
+
+
+def test_setup_apt_install_override_system(fake_executor, fake_process):
+    """Verify override default packages."""
+    base = ubuntu.BuilddBase(
+        alias=ubuntu.BuilddBaseAlias.JAMMY,
+        packages=["clang"],
+        use_default_packages=False,
+    )
+    fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "apt-get", "update"])
+    fake_process.register_subprocess(
+        [
+            *DEFAULT_FAKE_CMD,
+            "apt-get",
+            "install",
+            "-y",
+            "clang",
         ]
     )
 
@@ -613,6 +673,12 @@ def test_pre_setup_packages_devel(fake_executor, fake_process, mocker):
             "install",
             "-y",
             "apt-utils",
+            "build-essential",
+            "python3",
+            "python3-dev",
+            "python3-pip",
+            "python3-wheel",
+            "python3-setuptools",
             "curl",
             "fuse",
             "udev",


### PR DESCRIPTION
All images will be pre-installed with `build-essential` (or equivalent), `git`, and `python3` (with `devel`, `pip`, `venv`, `setuptools`, `wheel`)

