### PR TITLE
bases: clean up packages cache

### DIFF
--- a/craft_providers/bases/almalinux.py
+++ b/craft_providers/bases/almalinux.py
@@ -210,3 +210,16 @@ class AlmaLinuxBase(Base):
                 brief="Failed to setup snapd.",
                 details=details_from_called_process_error(error),
             ) from error
+
+    def _clean_up(self, executor: Executor) -> None:
+        """Clean up unused packages and cached package files."""
+        self._execute_run(
+            ["dnf", "autoremove", "-y"],
+            executor=executor,
+            timeout=self._timeout_complex,
+        )
+        self._execute_run(
+            ["dnf", "clean", "packages", "-y"],
+            executor=executor,
+            timeout=self._timeout_complex,
+        )

--- a/craft_providers/bases/centos.py
+++ b/craft_providers/bases/centos.py
@@ -228,3 +228,16 @@ class CentOSBase(Base):
                 brief="Failed to setup snapd.",
                 details=details_from_called_process_error(error),
             ) from error
+
+    def _clean_up(self, executor: Executor) -> None:
+        """Clean up unused packages and cached package files."""
+        self._execute_run(
+            ["yum", "autoremove", "-y"],
+            executor=executor,
+            timeout=self._timeout_complex,
+        )
+        self._execute_run(
+            ["yum", "clean", "packages", "-y"],
+            executor=executor,
+            timeout=self._timeout_complex,
+        )

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -340,6 +340,18 @@ class BuilddBase(Base):
                 details=details_from_called_process_error(error),
             ) from error
 
+    def _clean_up(self, executor: Executor) -> None:
+        self._execute_run(
+            ["apt-get", "autoremove", "-y"],
+            executor=executor,
+            timeout=self._timeout_complex,
+        )
+        self._execute_run(
+            ["apt-get", "clean", "-y"],
+            executor=executor,
+            timeout=self._timeout_complex,
+        )
+
 
 # Backward compatible, will be removed in 2.0
 default_command_environment = BuilddBase.default_command_environment


### PR DESCRIPTION
Packages that are cached locally are usually never used again. Clean them up to reduce size and increase speed of copying snapshots

