### PR TITLE
lint: add ruff, remove autoflake, flake8, isort, pydocstyle, pylint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,24 +39,15 @@ jobs:
       - name: Run black
         run: |
           make test-black
+      - name: Run ruff
+        run: |
+          make test-ruff
       - name: Run codespell
         run: |
           make test-codespell
-      - name: Run flake8
-        run: |
-          make test-flake8
-      - name: Run isort
-        run: |
-          make test-isort
       - name: Run mypy
         run: |
           make test-mypy
-      - name: Run pydocstyle
-        run: |
-          make test-pydocstyle
-      - name: Run pylint
-        run: |
-          make test-pylint
       - name: Run pyright
         run: |
           make test-pyright

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ help: ## Show this help.
 
 .PHONY: autoformat
 autoformat: ## Run automatic code formatters.
-	isort $(SOURCES)
-	autoflake --remove-all-unused-imports --ignore-init-module-imports -ri $(SOURCES)
+	ruff --fix --respect-gitignore .
 	black $(SOURCES)
 
 .PHONY: clean
@@ -59,7 +58,7 @@ install: clean ## Install python package.
 	python setup.py install
 
 .PHONY: lint
-lint: test-black test-codespell test-flake8 test-isort test-mypy test-pydocstyle test-pylint test-pyright ## Run all linting tests.
+lint: test-black test-ruff test-codespell test-mypy test-pyright ## Run all linting tests.
 
 .PHONY: release
 release: dist ## Release with twine.
@@ -73,34 +72,21 @@ test-black:
 test-codespell:
 	codespell $(SOURCES)
 
-.PHONY: test-flake8
-test-flake8:
-	flake8 $(SOURCES)
-
 .PHONY: test-integrations
 test-integrations: ## Run integration tests.
 	pytest tests/integration
-
-.PHONY: test-isort
-test-isort:
-	isort --check $(SOURCES)
 
 .PHONY: test-mypy
 test-mypy:
 	mypy $(SOURCES)
 
-.PHONY: test-pydocstyle
-test-pydocstyle:
-	pydocstyle craft_providers
-
-.PHONY: test-pylint
-test-pylint:
-	pylint craft_providers
-	pylint tests --disable=missing-module-docstring,missing-function-docstring,redefined-outer-name,protected-access,too-many-arguments,unnecessary-dunder-call
-
 .PHONY: test-pyright
 test-pyright:
 	pyright $(SOURCES)
+
+.PHONY: test-ruff
+test-ruff:
+	ruff check --respect-gitignore .
 
 .PHONY: test-units
 test-units: ## Run unit tests.

--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -67,7 +67,6 @@ class Snap(pydantic.BaseModel, extra=pydantic.Extra.forbid):
     channel: Optional[str] = "stable"
     classic: bool = False
 
-    # pylint: disable=no-self-argument
     @pydantic.validator("channel")
     def validate_channel(cls, channel):
         """Validate that channel is not an empty string.
@@ -80,8 +79,6 @@ class Snap(pydantic.BaseModel, extra=pydantic.Extra.forbid):
                 resolution="set channel to a non-empty string or `None`",
             )
         return channel
-
-    # pylint: enable=no-self-argument
 
 
 def _download_host_snap(

--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -17,7 +17,6 @@
 
 """Base configuration module."""
 
-# pylint: disable=too-many-lines
 
 import enum
 import io
@@ -694,7 +693,6 @@ class Base(ABC):
 
         This step usually does not need to be overridden.
         """
-        # pylint: disable=unused-argument
         return
 
     def _image_check(self, executor: Executor) -> None:
@@ -710,7 +708,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _pre_setup_os(self, executor: Executor) -> None:
@@ -722,7 +719,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _setup_os(self, executor: Executor) -> None:
@@ -740,7 +736,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _pre_setup_network(self, executor: Executor) -> None:
@@ -751,7 +746,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _setup_network(self, executor: Executor) -> None:
@@ -775,7 +769,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _pre_setup_packages(self, executor: Executor) -> None:
@@ -786,7 +779,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     @abstractmethod
@@ -801,7 +793,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _pre_setup_snapd(self, executor: Executor) -> None:
@@ -840,7 +831,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _setup_snaps(self, executor: Executor) -> None:
@@ -858,7 +848,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _pre_clean_up(self, executor: Executor) -> None:
@@ -869,7 +858,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _clean_up(self, executor: Executor) -> None:
@@ -881,7 +869,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _post_clean_up(self, executor: Executor) -> None:
@@ -893,7 +880,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     def _pre_finish(self, executor: Executor) -> None:
@@ -904,7 +890,6 @@ class Base(ABC):
 
         This step should be overridden when needed.
         """
-        # pylint: disable=unused-argument
         return
 
     @final

--- a/craft_providers/bases/centos.py
+++ b/craft_providers/bases/centos.py
@@ -32,8 +32,6 @@ from craft_providers.executor import Executor
 
 logger = logging.getLogger(__name__)
 
-# pylint: disable=duplicate-code
-
 
 class CentOSBaseAlias(enum.Enum):
     """Mappings for supported CentOS images."""

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -389,7 +389,6 @@ def _set_id_map(
     )
 
 
-# pylint: disable-next=too-many-locals
 def launch(
     name: str,
     *,

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -49,7 +49,7 @@ def load_yaml(data):
     return yaml.load(data, Loader=yaml.BaseLoader)
 
 
-class LXC:  # pylint: disable=too-many-public-methods
+class LXC:
     """Wrapper for lxc command-line interface."""
 
     def __init__(
@@ -371,11 +371,9 @@ class LXC:  # pylint: disable=too-many-public-methods
         logger.debug("Executing in container: %s", shlex.join(final_cmd))
 
         if runner is subprocess.run:
-            return runner(  # pylint: disable=subprocess-run-check
-                final_cmd, timeout=timeout, **kwargs
-            )
+            return runner(final_cmd, timeout=timeout, **kwargs)
 
-        return runner(final_cmd, **kwargs)  # pylint: disable=subprocess-run-check
+        return runner(final_cmd, **kwargs)
 
     def file_pull(
         self,

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -106,7 +106,7 @@ class RemoteImage:
                     protocol=self.remote_protocol.value,
                 )
 
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception as exc:
                 # the remote adding failed, no matter really how: if it was because a
                 # race condition on remote creation (it's not idempotent) and now the
                 # remote is there, the purpose of this function is done (otherwise we

--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -122,11 +122,9 @@ class Multipass:
 
         # Only subprocess.run supports timeout
         if runner is subprocess.run:
-            return runner(  # pylint: disable=subprocess-run-check
-                final_cmd, timeout=timeout, **kwargs
-            )
+            return runner(final_cmd, timeout=timeout, **kwargs)
 
-        return runner(final_cmd, **kwargs)  # pylint: disable=subprocess-run-check
+        return runner(final_cmd, **kwargs)
 
     def info(self, *, instance_name: str) -> Dict[str, Any]:
         """Get information/state for instance.

--- a/craft_providers/util/os_release.py
+++ b/craft_providers/util/os_release.py
@@ -20,7 +20,6 @@ from typing import Dict
 
 
 def parse_os_release(content: str) -> Dict[str, str]:
-    # pylint: disable=line-too-long
     """Parser for /etc/os-release.
 
     Format documentation at:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 88
 target-version = "py38"
-src = ["starcraft", "tests"]
+src = ["craft_providers", "tests"]
 extend-exclude = [
     "docs",
     "__pycache__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,148 @@
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 88
-
-[tool.pylint.messages_control]
-enable="useless-suppression"
-disable = "too-many-ancestors,too-few-public-methods,fixme,unspecified-encoding,use-implicit-booleaness-not-comparison,unnecessary-lambda-assignment"
-
-[tool.pylint.similarities]
-min-similarity-lines=12
-
-[tool.pylint.format]
-max-line-length = "88"
-max-locals = 16
-
-[tool.pylint.MASTER]
-extension-pkg-whitelist = [
-    "pydantic"
+[tool.ruff]
+line-length = 88
+target-version = "py38"
+src = ["starcraft", "tests"]
+extend-exclude = [
+    "docs",
+    "__pycache__",
 ]
-load-plugins = "pylint_fixme_info,pylint_pytest"
+# Follow ST063 - Maintaining and updating linting specifications for updating these.
+select = [  # Base linting rule selections.
+    # See the internal document for discussion:
+    # https://docs.google.com/document/d/1i1n8pDmFmWi4wTDpk-JfnWCVUThPJiggyPi2DYwBBu4/edit
+    # All sections here are stable in ruff and shouldn't randomly introduce
+    # failures with ruff updates.
+    "F",  # The rules built into Flake8
+    "E", "W",  # pycodestyle errors and warnings
+    "I",  # isort checking
+    "N",  # PEP8 naming
+    "D",  # Implement pydocstyle checking as well.
+    "UP",  # Pyupgrade - note that some of are excluded below due to Python versions
+    "YTT",  # flake8-2020: Misuse of `sys.version` and `sys.version_info`
+    "ANN",  # Type annotations.
+    "BLE",  # Do not catch blind exceptions
+    "FBT",  # Disallow boolean positional arguments (make them keyword-only)
+    "B0",  # Common mistakes and typos.
+    "A",  # Shadowing built-ins.
+    "C4", # Encourage comprehensions, which tend to be faster than alternatives.
+    "T10",  # Don't call the debugger in production code
+    "ISC",  # Implicit string concatenation that can cause subtle issues
+    "ICN",  # Only use common conventions for import aliases.
+    "INP",  # Implicit namespace packages
+    "PYI",  # Linting for type stubs.
+    "PT",  # Pytest
+    "Q",  # Consistent quotations
+    "RSE",  # Errors on pytest raises.
+    "RET",  # Simpler logic after return, raise, continue or break
+    "SIM",  # Code simplification
+    "TCH",  # Guard imports only used for type checking behind a type-checkning block.
+    "ARG",  # Unused arguments
+    "PTH",  # Migrate to pathlib
+    "ERA",  # Don't check in commented out code
+    "PGH",  # Pygrep hooks
+    "PL",  # Pylint
+    "TRY",  # Cleaner try/except,
+]
+extend-select = [
+    # Pyupgrade: https://github.com/charliermarsh/ruff#pyupgrade-up
+    "UP00", "UP01", "UP02", "UP030", "UP032", "UP033",
+    # "UP034",  # Very new, not yet enabled in ruff 0.0.227
+    # Annotations: https://github.com/charliermarsh/ruff#flake8-annotations-ann
+    "ANN0",  # Type annotations for arguments other than `self` and `cls`
+    "ANN2",  # Return type annotations
+    "B026",  # Keyword arguments must come after starred arguments
+    # flake8-bandit: security testing. https://github.com/charliermarsh/ruff#flake8-bandit-s
+    # https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
+    "S101", "S102",  # assert or exec
+    "S103", "S108",  # File permissions and tempfiles - use #noqa to silence when appropriate.
+    "S104",  # Network binds
+    "S105", "S106", "S107",  # Hardcoded passwords
+    "S110",  # try-except-pass (use contextlib.suppress instead)
+    "S113",  # Requests calls without timeouts
+    "S3",  # Serialising, deserialising, hashing, crypto, etc.
+    "S506",  # Unsafe YAML load
+    "S508", "S509",  # Insecure SNMP
+    "S701",  # jinja2 templates without autoescape
+    "RUF001", "RUF002", "RUF003",  # Ambiguous unicode characters
+    "RUF005",  # Encourages unpacking rather than concatenation
+    "RUF008",  # Do not use mutable default values for dataclass attributes
+    "RUF100",  # #noqa directive that doesn't flag anything
+]
+ignore = [
+    "ANN10",  # Type annotations for `self` and `cls`
+    #"E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
+    "E501",  # Line too long (reason: black will automatically fix this for us)
+    "D105",  # Missing docstring in magic method (reason: magic methods already have definitions)
+    "D107",  # Missing docstring in __init__ (reason: documented in class docstring)
+    "D203",  # 1 blank line required before class docstring (reason: pep257 default)
+    "D213",  # Multi-line docstring summary should start at the second line (reason: pep257 default)
+    "D215",  # Section underline is over-indented (reason: pep257 default)
+    "A003",  # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
+
+    # Ignored due to common usage in current code
+    "TRY003",  # Avoid specifying long messages outside the exception class
+
+    # Ignored while syncing craft-providers with starbase (see https://github.com/canonical/craft-providers/issues/287)
+    "ANN001", # Missing type annotation for function argument
+    "ANN003", # Missing type annotation for `**kwargs`
+    "ANN201", # Missing return type annotation for public function
+    "ANN204", # Missing return type annotation for special method
+    "ARG001", # Unused function argument
+    "ARG002", # Unused method argument
+    "ARG005", # Unused lambda argument
+    "B008", # Do not perform function call in argument defaults
+    "B028", # No explicit `stacklevel` keyword argument found
+    "BLE001", # Do not catch blind exception
+    "ERA001", # Found commented-out code
+    "FBT001", # Boolean positional arg in function definition
+    "FBT002", # Boolean default value in function definition
+    "FBT003", # Boolean positional value in function call
+    "I001", # Import block is un-sorted or un-formatted
+    "N805", # First argument of a method should be named `self`
+    "PGH003", # Use specific rule codes when ignoring type issues
+    "PLC1901", # channel == ""` can be simplified to `not channel` as an empty string is falsey
+    "PLR0913", # Too many arguments to function call
+    "PLR0915", # Too many statements
+    "PLR2004", # Magic value used in comparison
+    "PLW2901", # `for` loop variable `line` overwritten by assignment target
+    "PT001", # Use `@pytest.fixture()` over `@pytest.fixture`
+    "PT004", # Fixture does not return anything, add leading underscore
+    "PT006", # Wrong name(s) type in `@pytest.mark.parametrize`
+    "PT011", # `pytest.raises(ValueError)` is too broad, set the `match` parameter or usea more specific exception
+    "PT012", # `pytest.raises()` block should contain a single simple statement
+    "PT022", # No teardown in fixture
+    "PTH110", # `os.path.exists()` should be replaced by `Path.exists()`
+    "PTH116", # `os.stat()` should be replaced by `Path.stat()`, `Path.owner()`, or `Path.group()`
+    "PTH123", # `open()` should be replaced by `Path.open()`
+    "RET504", # Unnecessary variable assignment before `return` statement
+    "RSE102", # Unnecessary parentheses on raised exception
+    "RUF005", # Consider unpacking instead of concatenation
+    "S101", # Use of `assert` detected
+    "S108", # Probable insecure usage of temporary file or directory
+    "S311", # Standard pseudo-random generators are not suitable for cryptographic purposes
+    "S324", # Probable use of insecure hash functions in `hashlib`
+    "S506", # Probable use of unsafe loader `BaseLoader` with `yaml.load`. Allows instantiation of arbitrary "object"s. Consider `yaml.safe_load`.
+    "SIM102", # Use a single `if` statement instead of nested `if` statements
+    "SIM108", # Use ternary operator instead of `if`-`else`-block
+    "SIM112", # Use capitalized environment variable `HTTPS_PROXY` instead of `https_proxy`
+    "SIM114", # Combine `if` branches using logical `or` operator
+    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
+    "SIM201", # Use {left} != {right} instead of not {left} == {right}
+    "SIM300", # Yoda conditions are discouraged,
+    "TRY002", # Create your own exception
+    "TRY300", # Consider moving this statement to an `else` block
+    "UP012", # Unnecessary call to `encode` as UTF-8
+    "UP027", # Replace unpacked list comprehension with a generator expression
+]
+
+[tool.ruff.per-file-ignores]
+"tests/**.py" = [  # Some things we want for the moin project are unnecessary in tests.
+    "D",  # Ignore docstring rules in tests
+    "ANN", # Ignore type annotations in tests
+    "S101",  # Allow assertions in tests
+    "S103", # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
+    "S108", # Allow Probable insecure usage of temporary file or directory
+    "PLR0913",  # Allow many arguments for test functions
+]
+# isort leaves init files alone by default, this makes ruff ignore them too.
+"__init__.py" = ["I001"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,12 +6,6 @@ quiet-level = 3
 skip = .direnv,.git,.mypy_cache,.pytest_cache,.venv,__pycache__,venv
 ignore-words-list = buildd,warmup
 
-[flake8]
-exclude = .direnv .git .mypy_cache .pytest_cache .venv __pycache__ venv
-max-line-length = 88
-# E501 line too long
-extend-ignore = E501
-
 [mypy]
 python_version = 3.8
 plugins = pydantic.mypy
@@ -21,14 +15,6 @@ init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True
 warn_untyped_fields = True
-
-[pydocstyle]
-# D105 Missing docstring in magic method (reason: magic methods already have definitions)
-# D107 Missing docstring in __init__ (reason: documented in class docstring)
-# D203 1 blank line required before class docstring (reason: pep257 default)
-# D213 Multi-line docstring summary should start at the second line (reason: pep257 default)
-# D215 Section underline is over-indented (reason: pep257 default)
-ignore = D105, D107, D203, D213, D215
 
 [aliases]
 test = pytest

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ install_requires = [
 ]
 
 dev_requires = [
-    "autoflake",
     "twine",
 ]
 
@@ -49,20 +48,15 @@ test_requires = [
     "coverage",
     "black",
     "codespell",
-    "flake8",
     "freezegun",
-    "isort",
     "mypy",
     "logassert",
-    "pydocstyle",
     "pyfakefs",
-    "pylint",
-    "pylint-fixme-info",
-    "pylint-pytest",
     "pytest",
     "pytest-mock",
     "pytest-subprocess",
     "responses",
+    "ruff==0.0.270",
     "types-requests",
     "types-setuptools",
     "types-pyyaml",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -258,7 +258,6 @@ def dangerously_installed_snap(tmpdir):
             # collect the file name
             match = re.search(f"{snap_name}_\\d+.snap", str(output))
             if not match:
-                # pylint: disable-next=broad-exception-raised
                 raise Exception(
                     "could not parse snap file name from output of "
                     f"'snap download {snap_name}' (output = {output!r})"

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -35,8 +35,6 @@ from craft_providers.errors import (
 )
 from craft_providers.instance_config import InstanceConfiguration
 
-# pylint: disable=too-many-lines
-
 
 @pytest.fixture()
 def mock_requests():
@@ -169,7 +167,7 @@ def test_inject_from_host_classic(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "2",
         "source": snap_installer.SNAP_SRC_HOST,
     }
@@ -224,7 +222,7 @@ def test_inject_from_host_strict(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "2",
         "source": snap_installer.SNAP_SRC_HOST,
     }
@@ -274,7 +272,7 @@ def test_inject_from_host_snap_name(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "2",
         "source": snap_installer.SNAP_SRC_HOST,
     }
@@ -320,7 +318,7 @@ def test_inject_from_host_dangerous(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "x3",
         "source": snap_installer.SNAP_SRC_HOST,
     }
@@ -406,7 +404,7 @@ def test_inject_from_host_not_dangerous(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "2",
         "source": snap_installer.SNAP_SRC_HOST,
     }
@@ -642,7 +640,7 @@ def test_install_from_store_strict(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "4",
         "source": snap_installer.SNAP_SRC_STORE,
     }
@@ -732,7 +730,7 @@ def test_refresh_from_store(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "4",
         "source": snap_installer.SNAP_SRC_STORE,
     }
@@ -818,7 +816,7 @@ def test_install_from_store_trim_suffix(
     ]
     config = InstanceConfiguration(**yaml.safe_load(saved_config_record["content"]))
     assert config.snaps is not None
-    assert config.snaps["test-name"] == {  # pylint: disable=unsubscriptable-object
+    assert config.snaps["test-name"] == {
         "revision": "4",
         "source": snap_installer.SNAP_SRC_STORE,
     }

--- a/tests/unit/bases/test_almalinux.py
+++ b/tests/unit/bases/test_almalinux.py
@@ -15,8 +15,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-# pylint: disable=duplicate-code
-# pylint: disable=too-many-lines
 
 import subprocess
 from datetime import datetime
@@ -49,9 +47,8 @@ def mock_load(mocker):
     )
 
 
-# The variable name "fs" causes a pylint warning.  Provide a longer name.
 @pytest.fixture
-def fake_filesystem(fs):  # pylint: disable=invalid-name
+def fake_filesystem(fs):
     yield fs
 
 
@@ -157,7 +154,6 @@ def mock_get_os_release(mocker):
 @pytest.mark.parametrize(
     "tag, expected_tag", [(None, "almalinux-base-v1"), ("test-tag", "test-tag")]
 )
-# pylint: disable-next=too-many-arguments, too-many-locals, too-many-statements
 def test_setup(
     fake_process,
     fake_executor,

--- a/tests/unit/bases/test_centos_7.py
+++ b/tests/unit/bases/test_centos_7.py
@@ -15,7 +15,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-# pylint: disable=duplicate-code
 
 import subprocess
 from datetime import datetime
@@ -37,7 +36,6 @@ from craft_providers.errors import (
 )
 from craft_providers.instance_config import InstanceConfiguration
 
-# pylint: disable=too-many-lines
 
 DEFAULT_FAKE_CMD = ["fake-executor"]
 
@@ -50,9 +48,8 @@ def mock_load(mocker):
     )
 
 
-# The variable name "fs" causes a pylint warning.  Provide a longer name.
 @pytest.fixture
-def fake_filesystem(fs):  # pylint: disable=invalid-name
+def fake_filesystem(fs):
     yield fs
 
 
@@ -159,7 +156,6 @@ def mock_get_os_release(mocker):
 @pytest.mark.parametrize(
     "tag, expected_tag", [(None, "centos-base-v1"), ("test-tag", "test-tag")]
 )
-# pylint: disable-next=too-many-arguments, too-many-locals
 def test_setup(
     fake_process,
     fake_executor,

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -15,7 +15,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-# pylint: disable=duplicate-code
 
 import subprocess
 from datetime import datetime
@@ -37,7 +36,6 @@ from craft_providers.errors import (
 )
 from craft_providers.instance_config import InstanceConfiguration
 
-# pylint: disable=too-many-lines
 
 DEFAULT_FAKE_CMD = ["fake-executor"]
 
@@ -50,9 +48,8 @@ def mock_load(mocker):
     )
 
 
-# The variable name "fs" causes a pylint warning.  Provide a longer name.
 @pytest.fixture
-def fake_filesystem(fs):  # pylint: disable=invalid-name
+def fake_filesystem(fs):
     yield fs
 
 
@@ -154,7 +151,6 @@ def mock_get_os_release(mocker):
 @pytest.mark.parametrize(
     "tag, expected_tag", [(None, "buildd-base-v1"), ("test-tag", "test-tag")]
 )
-# pylint: disable-next=too-many-arguments, too-many-locals, too-many-statements
 def test_setup(
     fake_process,
     fake_executor,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,7 +97,6 @@ class FakeExecutor(Executor):
 
         final_cmd = ["fake-executor"] + env_args + command
 
-        # pylint: disable-next=subprocess-run-check
         return subprocess.run(final_cmd, timeout=timeout, **kwargs)
 
     def pull_file(self, *, source: pathlib.PurePath, destination: pathlib.Path) -> None:

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -16,7 +16,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-# pylint: disable=too-many-lines
 
 import sys
 from datetime import timedelta

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -22,8 +22,6 @@ import pytest
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, lxc
 
-# pylint: disable=too-many-lines
-
 
 def test_lxc_run_default(mocker, tmp_path):
     """Test _lxc_run with default arguments."""

--- a/tests/unit/util/test_os_release.py
+++ b/tests/unit/util/test_os_release.py
@@ -26,7 +26,6 @@ from craft_providers.util.os_release import parse_os_release
     "config,expected_dict",
     [
         (
-            # pylint: disable=line-too-long
             textwrap.dedent(
                 """\
                 NAME="Ubuntu"
@@ -58,7 +57,6 @@ from craft_providers.util.os_release import parse_os_release
             },
         ),
         (
-            # pylint: disable=line-too-long
             textwrap.dedent(
                 """\
                 NAME=Fedora


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

To separate code changes from tooling changes, I ignored many `ruff` rules.  These will be addressed in subsequent PRs.  See https://github.com/canonical/craft-providers/issues/287

(CRAFT-1726)