### PR TITLE
tests: test with core22 by default, remove core16 tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -87,9 +87,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.10", "3.11", "3.12-dev"]
-    # does not work ubuntu-22.04 (see https://github.com/canonical/craft-providers/issues/270)
     # does not work with canonical/setup-lxd github action (see https://github.com/canonical/craft-providers/issues/271)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -107,9 +106,13 @@ jobs:
           echo "::group::Configure LXD"
           sudo groupadd --force --system lxd
           sudo usermod --append --groups lxd $USER
+          sudo snap refresh lxd --channel=latest/stable
           sudo snap start lxd
           sudo lxd waitready --timeout=30
           sudo lxd init --auto
+          # iptables calls from https://github.com/canonical/setup-lxd/blob/main/action.yml
+          sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
+          sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
           echo "::endgroup::"
       - name: Run integration tests on Linux
         run: |

--- a/craft_providers/multipass/_launch.py
+++ b/craft_providers/multipass/_launch.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -42,7 +42,7 @@ def launch(
 
     :param name: Name of instance.
     :param base_configuration: Base configuration to apply to instance.
-    :param image_name: Multipass image to use, e.g. snapcraft:core20.
+    :param image_name: Multipass image to use, e.g. snapcraft:core22.
     :param cpus: Number of CPUs.
     :param disk_gb: Disk allocation in gigabytes.
     :param mem_gb: Memory allocation in gigabytes.

--- a/craft_providers/util/os_release.py
+++ b/craft_providers/util/os_release.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -29,17 +29,17 @@ def parse_os_release(content: str) -> Dict[str, str]:
     Example os-release contents::
 
         NAME="Ubuntu"
-        VERSION="20.10 (Groovy Gorilla)"
+        VERSION="22.04 (Jammy Jellyfish)"
         ID=ubuntu
         ID_LIKE=debian
-        PRETTY_NAME="Ubuntu 20.10"
-        VERSION_ID="20.10"
+        PRETTY_NAME="Ubuntu 22.04"
+        VERSION_ID="22.04"
         HOME_URL="https://www.ubuntu.com/"
         SUPPORT_URL="https://help.ubuntu.com/"
         BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
         PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-        VERSION_CODENAME=groovy
-        UBUNTU_CODENAME=groovy
+        VERSION_CODENAME=jammy
+        UBUNTU_CODENAME=jammy
 
     :param content: String contents of os-release file.
 

--- a/tests/integration/actions/test_snap_installer.py
+++ b/tests/integration/actions/test_snap_installer.py
@@ -23,20 +23,20 @@ from textwrap import dedent
 from craft_providers.actions import snap_installer
 
 
-def test_inject_from_host(core20_lxd_instance, installed_snap, caplog):
+def test_inject_from_host(core22_lxd_instance, installed_snap, caplog):
     """Verify a snap can be injected from the host."""
-    core20_lxd_instance.execute_run(
+    core22_lxd_instance.execute_run(
         ["test", "!", "-d", "/snap/hello-world"], check=True
     )
 
     with installed_snap("hello-world"):
         snap_installer.inject_from_host(
-            executor=core20_lxd_instance, snap_name="hello-world", classic=False
+            executor=core22_lxd_instance, snap_name="hello-world", classic=False
         )
 
-    core20_lxd_instance.execute_run(["test", "-d", "/snap/hello-world"], check=True)
+    core22_lxd_instance.execute_run(["test", "-d", "/snap/hello-world"], check=True)
 
-    config = core20_lxd_instance.execute_run(
+    config = core22_lxd_instance.execute_run(
         ["cat", "/etc/craft-instance.conf"], check=True, capture_output=True
     ).stdout.decode()
 
@@ -63,21 +63,21 @@ def test_inject_from_host(core20_lxd_instance, installed_snap, caplog):
 
 
 def test_inject_from_host_dangerous(
-    core20_lxd_instance, dangerously_installed_snap, caplog
+    core22_lxd_instance, dangerously_installed_snap, caplog
 ):
     """Verify a dangerously installed snap can be injected from the host."""
-    core20_lxd_instance.execute_run(
+    core22_lxd_instance.execute_run(
         ["test", "!", "-d", "/snap/hello-world"], check=True
     )
 
     with dangerously_installed_snap("hello-world"):
         snap_installer.inject_from_host(
-            executor=core20_lxd_instance, snap_name="hello-world", classic=False
+            executor=core22_lxd_instance, snap_name="hello-world", classic=False
         )
 
-    core20_lxd_instance.execute_run(["test", "-d", "/snap/hello-world"], check=True)
+    core22_lxd_instance.execute_run(["test", "-d", "/snap/hello-world"], check=True)
 
-    config = core20_lxd_instance.execute_run(
+    config = core22_lxd_instance.execute_run(
         ["cat", "/etc/craft-instance.conf"], check=True, capture_output=True
     ).stdout.decode()
 
@@ -104,16 +104,16 @@ def test_inject_from_host_dangerous(
 
 
 def test_inject_from_host_using_pack_fallback(
-    core20_lxd_instance, empty_test_snap, caplog
+    core22_lxd_instance, empty_test_snap, caplog
 ):
     """Verify a snap is packed if the local download fails."""
     snap_installer.inject_from_host(
-        executor=core20_lxd_instance,
+        executor=core22_lxd_instance,
         snap_name=empty_test_snap,
         classic=False,
     )
 
-    core20_lxd_instance.execute_run(
+    core22_lxd_instance.execute_run(
         ["test", "-d", f"/snap/{empty_test_snap}"], check=True
     )
 
@@ -123,22 +123,22 @@ def test_inject_from_host_using_pack_fallback(
     ]
 
 
-def test_install_from_store_strict(core20_lxd_instance, installed_snap, caplog):
+def test_install_from_store_strict(core22_lxd_instance, installed_snap, caplog):
     """Verify a strictly confined snap from the store can be installed."""
-    core20_lxd_instance.execute_run(
+    core22_lxd_instance.execute_run(
         ["test", "!", "-d", "/snap/hello-world"], check=True
     )
 
     snap_installer.install_from_store(
-        executor=core20_lxd_instance,
+        executor=core22_lxd_instance,
         snap_name="hello-world",
         channel="latest/stable",
         classic=False,
     )
 
-    core20_lxd_instance.execute_run(["test", "-f", "/snap/bin/hello-world"], check=True)
+    core22_lxd_instance.execute_run(["test", "-f", "/snap/bin/hello-world"], check=True)
 
-    config = core20_lxd_instance.execute_run(
+    config = core22_lxd_instance.execute_run(
         ["cat", "/etc/craft-instance.conf"], check=True, capture_output=True
     ).stdout.decode()
 
@@ -164,20 +164,20 @@ def test_install_from_store_strict(core20_lxd_instance, installed_snap, caplog):
     assert caplog.records == []
 
 
-def test_install_from_store_classic(core20_lxd_instance, installed_snap, caplog):
+def test_install_from_store_classic(core22_lxd_instance, installed_snap, caplog):
     """Verify a classicly confined snap from the store can be installed."""
-    core20_lxd_instance.execute_run(["test", "!", "-d", "/snap/charmcraft"], check=True)
+    core22_lxd_instance.execute_run(["test", "!", "-d", "/snap/charmcraft"], check=True)
 
     snap_installer.install_from_store(
-        executor=core20_lxd_instance,
+        executor=core22_lxd_instance,
         snap_name="charmcraft",
         channel="latest/stable",
         classic=True,
     )
 
-    core20_lxd_instance.execute_run(["test", "-f", "/snap/bin/charmcraft"], check=True)
+    core22_lxd_instance.execute_run(["test", "-f", "/snap/bin/charmcraft"], check=True)
 
-    config = core20_lxd_instance.execute_run(
+    config = core22_lxd_instance.execute_run(
         ["cat", "/etc/craft-instance.conf"], check=True, capture_output=True
     ).stdout.decode()
 
@@ -203,24 +203,24 @@ def test_install_from_store_classic(core20_lxd_instance, installed_snap, caplog)
     assert caplog.records == []
 
 
-def test_install_from_store_channel(core20_lxd_instance, installed_snap, caplog):
+def test_install_from_store_channel(core22_lxd_instance, installed_snap, caplog):
     """Verify a channel can be specified when installing from the store"""
-    core20_lxd_instance.execute_run(["test", "!", "-d", "/snap/go"], check=True)
+    core22_lxd_instance.execute_run(["test", "!", "-d", "/snap/go"], check=True)
 
     snap_installer.install_from_store(
-        executor=core20_lxd_instance,
+        executor=core22_lxd_instance,
         snap_name="go",
         channel="1.15/stable",
         classic=True,
     )
 
-    proc = core20_lxd_instance.execute_run(
+    proc = core22_lxd_instance.execute_run(
         ["/snap/bin/go", "version"], capture_output=True, check=True, text=True
     )
 
     assert "go1.15" in proc.stdout
 
-    config = core20_lxd_instance.execute_run(
+    config = core22_lxd_instance.execute_run(
         ["cat", "/etc/craft-instance.conf"], check=True, capture_output=True
     ).stdout.decode()
 
@@ -247,23 +247,23 @@ def test_install_from_store_channel(core20_lxd_instance, installed_snap, caplog)
 
 
 def test_install_from_store_snap_name_suffix(
-    core20_lxd_instance, installed_snap, caplog
+    core22_lxd_instance, installed_snap, caplog
 ):
     """Verify a snap can be installed from the store when the snap name has a suffix."""
-    core20_lxd_instance.execute_run(
+    core22_lxd_instance.execute_run(
         ["test", "!", "-d", "/snap/hello-world"], check=True
     )
 
     snap_installer.install_from_store(
-        executor=core20_lxd_instance,
+        executor=core22_lxd_instance,
         snap_name="hello-world_suffix",
         channel="latest/stable",
         classic=False,
     )
 
-    core20_lxd_instance.execute_run(["test", "-f", "/snap/bin/hello-world"], check=True)
+    core22_lxd_instance.execute_run(["test", "-f", "/snap/bin/hello-world"], check=True)
 
-    config = core20_lxd_instance.execute_run(
+    config = core22_lxd_instance.execute_run(
         ["cat", "/etc/craft-instance.conf"], check=True, capture_output=True
     ).stdout.decode()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -170,14 +170,14 @@ def uninstalled_multipass():
 
 
 @pytest.fixture()
-def core20_lxd_instance(installed_lxd, instance_name):
-    """Fully configured buildd-based core20 LXD instance."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+def core22_lxd_instance(installed_lxd, instance_name):
+    """Fully configured buildd-based core22 LXD instance."""
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         ephemeral=True,
     )

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -58,7 +58,7 @@ def tmp_instance(
     name: str,
     config_keys: Optional[Dict[str, Any]] = None,
     ephemeral: bool = True,
-    image: str = "16.04",
+    image: str = "22.04",
     image_remote: str = "ubuntu",
     project: str,
     remote: str = "local",

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -35,7 +35,7 @@ from . import conftest
 @pytest.fixture()
 def get_base_instance():
     def _base_instance(
-        image_name: str = "20.04",
+        image_name: str = "22.04",
         image_remote: str = "ubuntu",
         compatibility_tag: str = "buildd-base-v1",
         project: str = "default",
@@ -53,8 +53,8 @@ def get_base_instance():
 
 
 @pytest.fixture()
-def core20_instance(instance_name):
-    """Yields a minimally setup core20 instance.
+def core22_instance(instance_name):
+    """Yields a minimally setup core22 instance.
 
     The yielded instance will be launched, started, and marked as setup, even though
     most of the setup is skipped to speed up test execution.
@@ -63,7 +63,7 @@ def core20_instance(instance_name):
     """
     with conftest.tmp_instance(
         name=instance_name,
-        image="20.04",
+        image="22.04",
         image_remote="ubuntu",
         project="default",
     ):
@@ -92,13 +92,13 @@ def get_instance_and_base_instance(get_base_instance, instance_name):
     Delete instances on fixture teardown.
     """
     base_instance = get_base_instance()
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     # launch an instance from an image and create a base instance
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         use_base_instance=True,
     )
@@ -144,12 +144,12 @@ def test_launch_and_run(instance_name):
 def test_launch_use_snapshots_deprecated(get_base_instance, instance_name):
     """Launch an instance with the deprecated parameter `use_snapshots`."""
     base_instance = get_base_instance()
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         use_snapshots=True,
     )
@@ -174,7 +174,7 @@ def test_launch_use_base_instance(get_instance_and_base_instance, instance_name)
     The parameter `use_base_instance` and the deprecated parameter `use_snapshots`
     should both result in the same behavior.
     """
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     instance, base_instance = get_instance_and_base_instance
 
     # fingerprint the base instance
@@ -187,7 +187,7 @@ def test_launch_use_base_instance(get_instance_and_base_instance, instance_name)
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         use_base_instance=True,
     )
@@ -205,7 +205,7 @@ def test_launch_use_base_instance(get_instance_and_base_instance, instance_name)
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         use_base_instance=True,
     )
@@ -223,13 +223,13 @@ def test_launch_create_base_instance_with_correct_image_description(
 ):
     """Create a base instance and check the image description"""
     base_instance = get_base_instance()
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     # launch an instance from an image and create a base instance
     lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         use_base_instance=True,
     )
@@ -250,7 +250,7 @@ def test_launch_create_base_instance_with_correct_image_description(
 
     assert (
         lxc_result[0]["expanded_config"]["image.description"]
-        == "base-instance-buildd-base-v1-ubuntu-20.04"
+        == "base-instance-buildd-base-v1-ubuntu-22.04"
     )
 
 
@@ -267,7 +267,7 @@ def test_launch_use_base_instance_expired(
     The LXD instance is created via subprocess, so the creation date the instance is
     out of freezegun's scope and can't be modified.
     """
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     instance, base_instance = get_instance_and_base_instance
 
     # fingerprint the expired base instance
@@ -280,7 +280,7 @@ def test_launch_use_base_instance_expired(
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         use_base_instance=True,
         expiration=timedelta(days=90),
@@ -307,7 +307,7 @@ def test_launch_use_base_instance_expired(
 
 def test_launch_create_project(instance_name, project_name):
     """Create a project if it does not exist and `auto_create_project` is true."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     lxc = lxd.LXC()
 
     assert project_name not in lxc.project_list()
@@ -316,7 +316,7 @@ def test_launch_create_project(instance_name, project_name):
         instance = lxd.launch(
             name=instance_name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
             auto_create_project=True,
             project=project_name,
@@ -334,13 +334,13 @@ def test_launch_with_project_and_use_base_instance(
 ):
     """With a LXD project specified, launch an instance and use base instances."""
     base_instance = get_base_instance(project=project)
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     # launch an instance from an image and create a base instance
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         use_base_instance=True,
         project=project,
@@ -361,7 +361,7 @@ def test_launch_with_project_and_use_base_instance(
         instance = lxd.launch(
             name=instance_name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
             use_base_instance=True,
             project=project,
@@ -375,7 +375,7 @@ def test_launch_with_project_and_use_base_instance(
         instance = lxd.launch(
             name=instance_name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
             use_base_instance=True,
             project=project,
@@ -393,12 +393,12 @@ def test_launch_with_project_and_use_base_instance(
 
 def test_launch_ephemeral(instance_name):
     """Launch an ephemeral instance and verify it is deleted after it is stopped."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         ephemeral=True,
     )
@@ -415,13 +415,13 @@ def test_launch_ephemeral(instance_name):
 
 def test_launch_ephemeral_existing(instance_name):
     """If an ephemeral instance already exists, delete it and create a new instance."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     # create a non-ephemeral instance
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         ephemeral=False,
     )
@@ -434,7 +434,7 @@ def test_launch_ephemeral_existing(instance_name):
         instance = lxd.launch(
             name=instance_name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
             ephemeral=True,
         )
@@ -454,12 +454,12 @@ def test_launch_map_user_uid_true(instance_name, tmp_path):
     """Enable and map the the UID of the test account."""
     tmp_path.chmod(0o755)
 
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         map_user_uid=True,
         uid=os.stat(tmp_path).st_uid,
@@ -479,12 +479,12 @@ def test_launch_map_user_uid_true_no_uid(instance_name, tmp_path):
     """Enable UID mapping without specifying a UID."""
     tmp_path.chmod(0o755)
 
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         map_user_uid=True,
     )
@@ -503,12 +503,12 @@ def test_launch_map_user_uid_false(instance_name, tmp_path):
     """If UID mapping is not enabled, access to a mounted directory will be denied."""
     tmp_path.chmod(0o755)
 
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
         name=instance_name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         map_user_uid=False,
     )
@@ -524,14 +524,14 @@ def test_launch_map_user_uid_false(instance_name, tmp_path):
             instance.delete()
 
 
-def test_launch_existing_instance(core20_instance):
+def test_launch_existing_instance(core22_instance):
     """Launch an existing instance and run a command."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = lxd.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
     )
 
@@ -543,11 +543,11 @@ def test_launch_existing_instance(core20_instance):
     assert proc.stdout == b"hi\n"
 
 
-def test_launch_os_incompatible_without_auto_clean(core20_instance):
+def test_launch_os_incompatible_without_auto_clean(core22_instance):
     """Raise an error if the OS is incompatible and auto_clean is False."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=pathlib.Path("/etc/os-release"),
         content=io.BytesIO(b"NAME=Fedora\nVERSION_ID=32\n"),
         file_mode="0644",
@@ -556,9 +556,9 @@ def test_launch_os_incompatible_without_auto_clean(core20_instance):
     # will raise compatibility error when auto_clean is false
     with pytest.raises(BaseCompatibilityError) as exc_info:
         lxd.launch(
-            name=core20_instance.name,
+            name=core22_instance.name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
         )
 
@@ -568,11 +568,11 @@ def test_launch_os_incompatible_without_auto_clean(core20_instance):
     )
 
 
-def test_launch_os_incompatible_with_auto_clean(core20_instance):
+def test_launch_os_incompatible_with_auto_clean(core22_instance):
     """Clean the instance if the OS is incompatible and auto_clean is True."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=pathlib.Path("/etc/os-release"),
         content=io.BytesIO(b"NAME=Fedora\nVERSION_ID=32\n"),
         file_mode="0644",
@@ -580,22 +580,22 @@ def test_launch_os_incompatible_with_auto_clean(core20_instance):
 
     # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         auto_clean=True,
     )
 
-    assert core20_instance.exists()
-    assert core20_instance.is_running()
+    assert core22_instance.exists()
+    assert core22_instance.is_running()
 
 
-def test_launch_instance_config_incompatible_without_auto_clean(core20_instance):
+def test_launch_instance_config_incompatible_without_auto_clean(core22_instance):
     """Raise an error if the config file is incompatible and auto_clean is False."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
         content=io.BytesIO(b"compatibility_tag: invalid\nsetup: true\n"),
         file_mode="0644",
@@ -604,9 +604,9 @@ def test_launch_instance_config_incompatible_without_auto_clean(core20_instance)
     # will raise compatibility error when auto_clean is false
     with pytest.raises(BaseCompatibilityError) as exc_info:
         lxd.launch(
-            name=core20_instance.name,
+            name=core22_instance.name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
         )
 
@@ -616,11 +616,11 @@ def test_launch_instance_config_incompatible_without_auto_clean(core20_instance)
     )
 
 
-def test_launch_instance_config_incompatible_with_auto_clean(core20_instance):
+def test_launch_instance_config_incompatible_with_auto_clean(core22_instance):
     """Clean the instance if the config is incompatible and auto_clean is True."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
         content=io.BytesIO(b"compatibility_tag: invalid\nsetup: true\n"),
         file_mode="0644",
@@ -628,22 +628,22 @@ def test_launch_instance_config_incompatible_with_auto_clean(core20_instance):
 
     # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         auto_clean=True,
     )
 
-    assert core20_instance.exists()
-    assert core20_instance.is_running()
+    assert core22_instance.exists()
+    assert core22_instance.is_running()
 
 
-def test_launch_instance_not_setup_without_auto_clean(core20_instance):
+def test_launch_instance_not_setup_without_auto_clean(core22_instance):
     """Raise an error if an existing instance is not setup and auto_clean is False."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
         content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
@@ -652,9 +652,9 @@ def test_launch_instance_not_setup_without_auto_clean(core20_instance):
     # will raise a compatibility error
     with pytest.raises(BaseCompatibilityError) as exc_info:
         lxd.launch(
-            name=core20_instance.name,
+            name=core22_instance.name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
             auto_clean=False,
         )
@@ -662,11 +662,11 @@ def test_launch_instance_not_setup_without_auto_clean(core20_instance):
     assert exc_info.value == BaseCompatibilityError("instance is marked as not setup")
 
 
-def test_launch_instance_not_setup_with_auto_clean(core20_instance):
+def test_launch_instance_not_setup_with_auto_clean(core22_instance):
     """Clean the instance if it is not setup and auto_clean is True."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
         content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
@@ -674,24 +674,24 @@ def test_launch_instance_not_setup_with_auto_clean(core20_instance):
 
     # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         auto_clean=True,
     )
 
-    assert core20_instance.exists()
-    assert core20_instance.is_running()
+    assert core22_instance.exists()
+    assert core22_instance.is_running()
 
 
-def test_launch_instance_id_map_incompatible_without_auto_clean(core20_instance):
+def test_launch_instance_id_map_incompatible_without_auto_clean(core22_instance):
     """Raise an error if the id map is incompatible and auto_clean is False."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     lxc = lxd.LXC()
     lxc.config_set(
-        instance_name=core20_instance.instance_name,
+        instance_name=core22_instance.instance_name,
         key="raw.idmap",
         value="",  # equivalent to `lxc config unset`, which is not yet implemented
     )
@@ -699,9 +699,9 @@ def test_launch_instance_id_map_incompatible_without_auto_clean(core20_instance)
     # will raise compatibility error when auto_clean is false
     with pytest.raises(BaseCompatibilityError) as exc_info:
         lxd.launch(
-            name=core20_instance.name,
+            name=core22_instance.name,
             base_configuration=base_configuration,
-            image_name="20.04",
+            image_name="22.04",
             image_remote="ubuntu",
             map_user_uid=True,
         )
@@ -712,25 +712,25 @@ def test_launch_instance_id_map_incompatible_without_auto_clean(core20_instance)
     )
 
 
-def test_launch_instance_id_map_incompatible_with_auto_clean(core20_instance):
+def test_launch_instance_id_map_incompatible_with_auto_clean(core22_instance):
     """Clean the instance if the id map is incompatible and auto_clean is True."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     lxc = lxd.LXC()
     lxc.config_set(
-        instance_name=core20_instance.instance_name,
+        instance_name=core22_instance.instance_name,
         key="raw.idmap",
         value="",  # equivalent to `lxc config unset`, which is not yet implemented
     )
 
     # when auto_clean is true, the instance will be deleted and recreated
     lxd.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="20.04",
+        image_name="22.04",
         image_remote="ubuntu",
         auto_clean=True,
     )
 
-    assert core20_instance.exists()
-    assert core20_instance.is_running()
+    assert core22_instance.exists()
+    assert core22_instance.is_running()

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -124,9 +124,9 @@ def test_delete_force(instance, lxc, project):
 
 def test_image_copy(lxc, project):
     lxc.image_copy(
-        image="16.04",
+        image="22.04",
         image_remote="ubuntu",
-        alias="test-1604",
+        alias="test-2204",
         project=project,
     )
 
@@ -136,13 +136,13 @@ def test_image_copy(lxc, project):
 
 def test_image_delete(lxc, project):
     lxc.image_copy(
-        image="16.04",
+        image="22.04",
         image_remote="ubuntu",
-        alias="test-1604",
+        alias="test-2204",
         project=project,
     )
 
-    lxc.image_delete(image="test-1604", project=project)
+    lxc.image_delete(image="test-2204", project=project)
 
     images = lxc.image_list(project=project)
     assert images == []

--- a/tests/integration/multipass/conftest.py
+++ b/tests/integration/multipass/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -32,7 +32,7 @@ def installed_multipass_required(installed_multipass):
 def tmp_instance(
     *,
     instance_name: str,
-    image_name: str = "20.04",
+    image_name: str = "22.04",
     cpus: str = "2",
     disk: str = "64G",
     mem: str = "1G",

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -28,8 +28,8 @@ from . import conftest
 
 
 @pytest.fixture()
-def core20_instance(instance_name):
-    """Yields a minimally setup core20 instance.
+def core22_instance(instance_name):
+    """Yields a minimally setup core22 instance.
 
     The yielded instance will be launched, started, and marked as setup, even though
     most of the setup is skipped to speed up test execution.
@@ -38,7 +38,7 @@ def core20_instance(instance_name):
     """
     with conftest.tmp_instance(
         instance_name=instance_name,
-        image_name="snapcraft:core20",
+        image_name="snapcraft:core22",
     ) as tmp_instance:
         instance = multipass.MultipassInstance(name=tmp_instance)
 
@@ -80,13 +80,13 @@ def test_launch(instance_name):
         instance.delete()
 
 
-def test_launch_existing_instance(core20_instance):
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+def test_launch_existing_instance(core22_instance):
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     instance = multipass.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="snapcraft:core20",
+        image_name="snapcraft:core22",
     )
 
     assert isinstance(instance, multipass.MultipassInstance)
@@ -98,10 +98,10 @@ def test_launch_existing_instance(core20_instance):
     assert proc.stdout == b"hi\n"
 
 
-def test_launch_os_incompatible_instance(core20_instance):
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+def test_launch_os_incompatible_instance(core22_instance):
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=pathlib.Path("/etc/os-release"),
         content=io.BytesIO(b"NAME=Fedora\nVERSION_ID=32\n"),
         file_mode="0644",
@@ -110,9 +110,9 @@ def test_launch_os_incompatible_instance(core20_instance):
     # Should raise compatibility error with auto_clean=False.
     with pytest.raises(BaseCompatibilityError) as exc_info:
         multipass.launch(
-            name=core20_instance.name,
+            name=core22_instance.name,
             base_configuration=base_configuration,
-            image_name="snapcraft:core20",
+            image_name="snapcraft:core22",
         )
 
     assert (
@@ -122,20 +122,20 @@ def test_launch_os_incompatible_instance(core20_instance):
 
     # Retry with auto_clean=True.
     multipass.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="snapcraft:core20",
+        image_name="snapcraft:core22",
         auto_clean=True,
     )
 
-    assert core20_instance.exists() is True
-    assert core20_instance.is_running() is True
+    assert core22_instance.exists() is True
+    assert core22_instance.is_running() is True
 
 
-def test_launch_instance_config_incompatible_instance(core20_instance):
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+def test_launch_instance_config_incompatible_instance(core22_instance):
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
         content=io.BytesIO(b"compatibility_tag: invalid\nsetup: true\n"),
         file_mode="0644",
@@ -144,9 +144,9 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
     # Should raise compatibility error with auto_clean=False.
     with pytest.raises(BaseCompatibilityError) as exc_info:
         multipass.launch(
-            name=core20_instance.name,
+            name=core22_instance.name,
             base_configuration=base_configuration,
-            image_name="snapcraft:core20",
+            image_name="snapcraft:core22",
         )
 
     assert exc_info.value.brief == (
@@ -156,21 +156,21 @@ def test_launch_instance_config_incompatible_instance(core20_instance):
 
     # Retry with auto_clean=True.
     multipass.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="snapcraft:core20",
+        image_name="snapcraft:core22",
         auto_clean=True,
     )
 
-    assert core20_instance.exists() is True
-    assert core20_instance.is_running() is True
+    assert core22_instance.exists() is True
+    assert core22_instance.is_running() is True
 
 
-def test_launch_instance_not_setup_without_auto_clean(core20_instance):
+def test_launch_instance_not_setup_without_auto_clean(core22_instance):
     """Raise an error if an existing instance is not setup and auto_clean is False."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
         content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
@@ -179,20 +179,20 @@ def test_launch_instance_not_setup_without_auto_clean(core20_instance):
     # will raise a compatibility error
     with pytest.raises(BaseCompatibilityError) as exc_info:
         multipass.launch(
-            name=core20_instance.name,
+            name=core22_instance.name,
             base_configuration=base_configuration,
-            image_name="snapcraft:core20",
+            image_name="snapcraft:core22",
             auto_clean=False,
         )
 
     assert exc_info.value == BaseCompatibilityError("instance is marked as not setup")
 
 
-def test_launch_instance_not_setup_with_auto_clean(core20_instance):
+def test_launch_instance_not_setup_with_auto_clean(core22_instance):
     """Clean the instance if it is not setup and auto_clean is True."""
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
-    core20_instance.push_file_io(
+    core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
         content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
         file_mode="0644",
@@ -200,11 +200,11 @@ def test_launch_instance_not_setup_with_auto_clean(core20_instance):
 
     # when auto_clean is true, the instance will be deleted and recreated
     multipass.launch(
-        name=core20_instance.name,
+        name=core22_instance.name,
         base_configuration=base_configuration,
-        image_name="snapcraft:core20",
+        image_name="snapcraft:core22",
         auto_clean=True,
     )
 
-    assert core20_instance.exists() is True
-    assert core20_instance.is_running() is True
+    assert core22_instance.exists() is True
+    assert core22_instance.is_running() is True

--- a/tests/integration/multipass/test_multipass_instance.py
+++ b/tests/integration/multipass/test_multipass_instance.py
@@ -251,7 +251,7 @@ def test_launch(instance_name):
     assert instance.exists() is False
 
     instance.launch(
-        image="snapcraft:core20",
+        image="snapcraft:core22",
         cpus=4,
         disk_gb=128,
         mem_gb=1,

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -685,7 +685,7 @@ def test_pre_setup_packages_devel(fake_executor, fake_process, mocker):
 
 
 def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     monkeypatch.setattr(
         InstanceConfiguration,
         "load",
@@ -702,7 +702,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
 
 def test_get_os_release(fake_process, fake_executor):
     """`_get_os_release` should parse data from `/etc/os-release` to a dict."""
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "cat", "/etc/os-release"],
         stdout="NAME=Ubuntu\nVERSION_ID=12.04\n",
@@ -743,7 +743,7 @@ def test_ensure_os_compatible_name_failure(
 ):
     """Raise an error if the OS name does not match."""
     mock_get_os_release.return_value = {"NAME": "Fedora", "VERSION_ID": "32"}
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     with pytest.raises(BaseCompatibilityError) as exc_info:
         base_config._ensure_os_compatible(executor=fake_executor)
@@ -760,20 +760,20 @@ def test_ensure_os_compatible_version_failure(
 ):
     """Raise an error if the OS version id does not match."""
     mock_get_os_release.return_value = {"NAME": "Ubuntu", "VERSION_ID": "12.04"}
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     with pytest.raises(BaseCompatibilityError) as exc_info:
         base_config._ensure_os_compatible(executor=fake_executor)
 
     assert exc_info.value == BaseCompatibilityError(
-        "Expected OS version '20.04', found '12.04'"
+        "Expected OS version '22.04', found '12.04'"
     )
 
     mock_get_os_release.assert_called_once()
 
 
 def test_setup_hostname_failure(fake_process, fake_executor):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "hostname", "-F", "/etc/hostname"],
         returncode=-1,
@@ -791,7 +791,7 @@ def test_setup_hostname_failure(fake_process, fake_executor):
 
 
 def test_setup_networkd_enable_failure(fake_process, fake_executor):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "systemctl", "enable", "systemd-networkd"],
         returncode=-1,
@@ -809,7 +809,7 @@ def test_setup_networkd_enable_failure(fake_process, fake_executor):
 
 
 def test_setup_networkd_restart_failure(fake_process, fake_executor):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "systemctl", "enable", "systemd-networkd"],
     )
@@ -830,7 +830,7 @@ def test_setup_networkd_restart_failure(fake_process, fake_executor):
 
 
 def test_setup_resolved_enable_failure(fake_process, fake_executor):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     fake_process.register_subprocess(
         [
             *DEFAULT_FAKE_CMD,
@@ -857,7 +857,7 @@ def test_setup_resolved_enable_failure(fake_process, fake_executor):
 
 
 def test_setup_resolved_restart_failure(fake_process, fake_executor):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     fake_process.register_subprocess(
         [
             *DEFAULT_FAKE_CMD,
@@ -893,7 +893,7 @@ def test_setup_snapd_proxy(fake_executor, fake_process):
         "https_proxy": "http://foo.bar:8081",
     }
     base_config = ubuntu.BuilddBase(
-        alias=ubuntu.BuilddBaseAlias.FOCAL,
+        alias=ubuntu.BuilddBaseAlias.JAMMY,
         environment=environment,  # type: ignore
     )
     fake_process.keep_last_process(True)
@@ -918,7 +918,7 @@ def test_setup_snapd_proxy(fake_executor, fake_process):
 
 @pytest.mark.parametrize("fail_index", list(range(0, 1)))
 def test_setup_snapd_proxy_failures(fake_process, fake_executor, fail_index):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     return_codes = [0, 0]
     return_codes[fail_index] = 1
@@ -945,7 +945,7 @@ def test_setup_snapd_proxy_failures(fake_process, fake_executor, fail_index):
 
 @pytest.mark.parametrize("fail_index", list(range(0, 2)))
 def test_pre_setup_snapd_failures(fake_process, fake_executor, fail_index):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     return_codes = [0, 0]
     return_codes[fail_index] = 1
@@ -982,7 +982,7 @@ def test_pre_setup_snapd_failures(fake_process, fake_executor, fail_index):
 
 
 def test_setup_snapd_failures(fake_process, fake_executor):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "bash", "-c", "exec 3<> /dev/tcp/snapcraft.io/443"],
@@ -1006,7 +1006,7 @@ def test_setup_snapd_failures(fake_process, fake_executor):
 
 @pytest.mark.parametrize("fail_index", list(range(0, 8)))
 def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index, mocker):
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     mock_datetime = mocker.patch("craft_providers.base.datetime")
     mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
 
@@ -1432,7 +1432,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
 def test_ensure_config_compatible_validation_error(fake_executor, mock_load):
     mock_load.side_effect = ValidationError("foo", InstanceConfiguration)
 
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     with pytest.raises(BaseConfigurationError) as exc_info:
         base_config._ensure_instance_config_compatible(executor=fake_executor)
@@ -1445,7 +1445,7 @@ def test_ensure_config_compatible_validation_error(fake_executor, mock_load):
 def test_ensure_config_compatible_empty_config_returns_none(fake_executor, mock_load):
     mock_load.return_value = None
 
-    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     assert (
         base_config._ensure_instance_config_compatible(executor=fake_executor) is None

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -500,7 +500,7 @@ def test_is_running_error(mock_lxc):
 
 def test_launch(mock_lxc, instance):
     instance.launch(
-        image="20.04",
+        image="22.04",
         image_remote="ubuntu",
     )
 
@@ -510,7 +510,7 @@ def test_launch(mock_lxc, instance):
             config_keys={},
             ephemeral=False,
             instance_name=instance.instance_name,
-            image="20.04",
+            image="22.04",
             image_remote="ubuntu",
             project=instance.project,
             remote=instance.remote,
@@ -521,7 +521,7 @@ def test_launch(mock_lxc, instance):
 @pytest.mark.skipif(sys.platform == "win32", reason="unsupported on windows")
 def test_launch_all_opts(mock_lxc, instance):
     instance.launch(
-        image="20.04",
+        image="22.04",
         image_remote="ubuntu",
         ephemeral=True,
         map_user_uid=True,
@@ -534,7 +534,7 @@ def test_launch_all_opts(mock_lxc, instance):
             config_keys={"raw.idmap": f"both {uid} 0"},
             ephemeral=True,
             instance_name=instance.instance_name,
-            image="20.04",
+            image="22.04",
             image_remote="ubuntu",
             project=instance.project,
             remote=instance.remote,
@@ -548,7 +548,7 @@ def test_launch_with_mknod(mock_lxc, instance):
     }
 
     instance.launch(
-        image="20.04",
+        image="22.04",
         image_remote="ubuntu",
     )
 
@@ -560,7 +560,7 @@ def test_launch_with_mknod(mock_lxc, instance):
             },
             ephemeral=False,
             instance_name=instance.instance_name,
-            image="20.04",
+            image="22.04",
             image_remote="ubuntu",
             project=instance.project,
             remote=instance.remote,

--- a/tests/unit/multipass/test_multipass.py
+++ b/tests/unit/multipass/test_multipass.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -38,7 +38,7 @@ EXAMPLE_INFO = """\
                 }
             },
             "image_hash": "c5f2f08c6a1adee1f2f96d84856bf0162d33ea182dae0e8ed45768a86182d110",
-            "image_release": "20.04 LTS",
+            "image_release": "22.04 LTS",
             "ipv4": [
                 "10.114.154.206"
             ],
@@ -53,7 +53,7 @@ EXAMPLE_INFO = """\
             },
             "mounts": {
             },
-            "release": "Ubuntu 20.04.2 LTS",
+            "release": "Ubuntu 22.04.2 LTS",
             "state": "Running"
         }
     }
@@ -67,7 +67,7 @@ EXAMPLE_LIST = """\
             "ipv4": [
             ],
             "name": "manageable-snipe",
-            "release": "20.04 LTS",
+            "release": "22.04 LTS",
             "state": "Starting"
         },
         {
@@ -75,7 +75,7 @@ EXAMPLE_LIST = """\
                 "10.114.154.206"
             ],
             "name": "flowing-hawfinch",
-            "release": "20.04 LTS",
+            "release": "22.04 LTS",
             "state": "Running"
         }
     ]

--- a/tests/unit/multipass/test_multipass_instance.py
+++ b/tests/unit/multipass/test_multipass_instance.py
@@ -51,7 +51,7 @@ EXAMPLE_INFO = {
             "image_hash": (
                 "c5f2f08c6a1adee1f2f96d84856bf0162d33ea182dae0e8ed45768a86182d110"
             ),
-            "image_release": "20.04 LTS",
+            "image_release": "22.04 LTS",
             "ipv4": [],
             "load": [],
             "memory": {},
@@ -64,12 +64,12 @@ EXAMPLE_INFO = {
             "image_hash": (
                 "7c5c8f24046ca7b82897e0ca49fbd4dbdc771c2abd616991d10e6e09cc43002f"
             ),
-            "image_release": "Snapcraft builder for Core 18",
+            "image_release": "Snapcraft builder for Core 22",
             "ipv4": ["10.114.154.133"],
             "load": [1.53, 0.84, 0.33],
             "memory": {"total": 2089697280, "used": 153190400},
             "mounts": EXAMPLE_MOUNTS,
-            "release": "Ubuntu 18.04.5 LTS",
+            "release": "Ubuntu 22.04.2 LTS",
             "state": "Running",
         },
     },

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -260,7 +260,7 @@ def test_launched_environment_launch_base_configuration_error(mock_launch, tmp_p
     error = BaseConfigurationError(brief="fail")
     mock_launch.side_effect = error
     provider = MultipassProvider()
-    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.FOCAL)
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
 
     with pytest.raises(MultipassError, match="fail") as raised:
         with provider.launched_environment(

--- a/tests/unit/util/test_os_release.py
+++ b/tests/unit/util/test_os_release.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -28,17 +28,17 @@ from craft_providers.util.os_release import parse_os_release
             textwrap.dedent(
                 """\
                 NAME="Ubuntu"
-                VERSION="20.10 (Groovy Gorilla)"
+                VERSION="22.04 (Jammy Jellyfish)"
                 ID=ubuntu
                 ID_LIKE=debian
-                PRETTY_NAME="Ubuntu 20.10"
-                VERSION_ID="20.10"
+                PRETTY_NAME="Ubuntu 22.04"
+                VERSION_ID="22.04"
                 HOME_URL="https://www.ubuntu.com/"
                 SUPPORT_URL="https://help.ubuntu.com/"
                 BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
                 PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-                VERSION_CODENAME=groovy
-                UBUNTU_CODENAME=groovy"""
+                VERSION_CODENAME=jammy
+                UBUNTU_CODENAME=jammy"""
             ),
             {
                 "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
@@ -46,13 +46,13 @@ from craft_providers.util.os_release import parse_os_release
                 "ID": "ubuntu",
                 "ID_LIKE": "debian",
                 "NAME": "Ubuntu",
-                "PRETTY_NAME": "Ubuntu 20.10",
+                "PRETTY_NAME": "Ubuntu 22.04",
                 "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
                 "SUPPORT_URL": "https://help.ubuntu.com/",
-                "UBUNTU_CODENAME": "groovy",
-                "VERSION": "20.10 (Groovy Gorilla)",
-                "VERSION_CODENAME": "groovy",
-                "VERSION_ID": "20.10",
+                "UBUNTU_CODENAME": "jammy",
+                "VERSION": "22.04 (Jammy Jellyfish)",
+                "VERSION_CODENAME": "jammy",
+                "VERSION_ID": "22.04",
             },
         ),
         (


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Welcome to the future!


Changes:
- Use `ubuntu-latest` runner
- Use `lxd` on `latest/stable`
- Use `core22` for tests and examples
- Remove `core16` tests

I need to get this done before moving to `tox`, as there is a strange error occurring with `core20` images + a `20.04` runner + lxd `4.0` (likely due to the ordering of tests). 

Resolves https://github.com/canonical/craft-providers/issues/270 and related to https://github.com/canonical/craft-providers/pull/278

(CRAFT-1726)