### PR TITLE
lint: fix ruff warning PLC1901

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -73,7 +73,7 @@ class Snap(pydantic.BaseModel, extra=pydantic.Extra.forbid):
 
         :raises BaseConfigurationError: if channel is empty
         """
-        if channel == "":
+        if channel == "":  # noqa: PLC1901
             raise BaseConfigurationError(
                 brief="channel cannot be empty",
                 resolution="set channel to a non-empty string or `None`",

--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -73,7 +73,7 @@ class Snap(pydantic.BaseModel, extra=pydantic.Extra.forbid):
 
         :raises BaseConfigurationError: if channel is empty
         """
-        if channel == "":  # noqa: PLC1901
+        if channel is not None and not channel:
             raise BaseConfigurationError(
                 brief="channel cannot be empty",
                 resolution="set channel to a non-empty string or `None`",

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -97,7 +97,7 @@ class LXDInstance(Executor):
         """
         # remove anything that is not an alphanumeric characters or hyphen
         name_with_valid_chars = re.sub(r"[^\w-]", "", self.name)
-        if name_with_valid_chars == "":
+        if not name_with_valid_chars:
             raise LXDError(
                 brief=f"failed to create LXD instance with name {self.name!r}.",
                 details="name must contain at least one alphanumeric character",
@@ -107,7 +107,7 @@ class LXDInstance(Executor):
         trimmed_name = re.compile(r"^[0-9-]*(?P<valid_name>.*?)[-]*$").search(
             name_with_valid_chars
         )
-        if not trimmed_name or trimmed_name.group("valid_name") == "":
+        if not trimmed_name or not trimmed_name.group("valid_name"):
             raise LXDError(
                 brief=f"failed to create LXD instance with name {self.name!r}.",
                 details="name must contain at least one alphanumeric character",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,6 @@ ignore = [
     "FBT003", # Boolean positional value in function call
     "N805", # First argument of a method should be named `self`
     "PGH003", # Use specific rule codes when ignoring type issues
-    "PLC1901", # channel == ""` can be simplified to `not channel` as an empty string is falsey
     "PLR0913", # Too many arguments to function call
     "PLR0915", # Too many statements
     "PLR2004", # Magic value used in comparison

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -61,7 +61,7 @@ def test_config_get_non_existent_key(instance, instance_name, lxc, project):
         instance_name=instance, key="non-existant-key", project=project
     )
 
-    assert value == ""
+    assert not value
 
 
 def test_copy(instance, instance_name, lxc, project):


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Resolves:
- `PLC1901`: `string == ""` can be simplified to `not string` as an empty string is falsey