### PR TITLE
lint: fix ruff warnings SIM108, SIM112, SIM117, TRY300

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -1025,7 +1025,7 @@ class Base(ABC):
         # (because we're hitting port 443), as bash's TCP functionality will not
         # use it (supporting both lowercase and uppercase names, which is what
         # most applications do)
-        if os.getenv("HTTPS_PROXY") or os.getenv("https_proxy"):
+        if os.getenv("HTTPS_PROXY") or os.getenv("https_proxy"):  # noqa: SIM112
             return True
 
         # check if the port is open using bash's built-in tcp-client, communicating with

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -286,7 +286,6 @@ def _launch_existing_instance(
 
     try:
         base_configuration.warmup(executor=instance)
-        return True
     except bases.BaseCompatibilityError as error:
         # delete the instance so a new instance can be created
         if auto_clean:
@@ -298,6 +297,8 @@ def _launch_existing_instance(
             instance.delete()
             return False
         raise
+
+    return True
 
 
 def _check_id_map(

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -135,11 +135,8 @@ class LXDProvider(Provider):
                 ),
             )
 
-        if image.is_stable:
-            expiration = timedelta(days=90)
-        else:
-            # unstable images should be refreshed more often
-            expiration = timedelta(days=14)
+        # unstable images should be refreshed more often
+        expiration = timedelta(days=90) if image.is_stable else timedelta(days=14)
 
         try:
             instance = launch(

--- a/craft_providers/multipass/_launch.py
+++ b/craft_providers/multipass/_launch.py
@@ -60,7 +60,6 @@ def launch(
         instance.start()
         try:
             base_configuration.warmup(executor=instance)
-            return instance
         except bases.BaseCompatibilityError as error:
             if auto_clean:
                 logger.debug(
@@ -71,6 +70,8 @@ def launch(
                 instance.delete()
             else:
                 raise
+        else:
+            return instance
 
     instance.launch(
         cpus=cpus,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,8 @@ ignore = [
     "D213",  # Multi-line docstring summary should start at the second line (reason: pep257 default)
     "D215",  # Section underline is over-indented (reason: pep257 default)
     "A003",  # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
+    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
+              # (reason: this creates long lines that get wrapped and reduces readability)
 
     # Ignored due to common usage in current code
     "TRY003",  # Avoid specifying long messages outside the exception class
@@ -263,11 +265,7 @@ ignore = [
     "S311", # Standard pseudo-random generators are not suitable for cryptographic purposes
     "S324", # Probable use of insecure hash functions in `hashlib`
     "S506", # Probable use of unsafe loader `BaseLoader` with `yaml.load`. Allows instantiation of arbitrary "object"s. Consider `yaml.safe_load`.
-    "SIM108", # Use ternary operator instead of `if`-`else`-block
-    "SIM112", # Use capitalized environment variable `HTTPS_PROXY` instead of `https_proxy`
-    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "TRY002", # Create your own exception
-    "TRY300", # Consider moving this statement to an `else` block
 ]
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----


Resolves: 
- `SIM108`: Use ternary operator instead of `if`-`else`-block
- `SIM112`: Use capitalized environment variable `HTTPS_PROXY` instead of `https_proxy`
- `SIM117`: Use a single `with` statement with multiple contexts instead of nested `with` statements
- `TRY300`: Consider moving this statement to an `else` block