### PR TITLE
ci: add permanent ssh access to github runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,15 @@ on:
       - "release/*"
   pull_request:
 
+  # Allows triggering the workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      enable_ssh_access:
+        type: boolean
+        description: 'Enable ssh access'
+        required: false
+        default: false
+
 jobs:
   linters:
     runs-on: ubuntu-latest
@@ -37,6 +46,9 @@ jobs:
           echo "::group::Wait for snap to complete"
           snap watch --last=install
           echo "::endgroup::"
+      - name: Enable ssh access
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ inputs.enable_ssh_access }}
       - name: Run Linters
         run: tox run --skip-pkg-install --no-list-dependencies -m lint
   unit-tests:
@@ -66,6 +78,9 @@ jobs:
           mkdir -p results
       - name: Setup Tox environments
         run: tox run -m unit-tests --notest
+      - name: Enable ssh access
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ inputs.enable_ssh_access }}
       - name: Test with tox
         # use `tox` instead of `.tox/.tox/bin/tox` to support Windows
         run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json -m unit-tests
@@ -121,6 +136,9 @@ jobs:
           echo "::endgroup::"
       - name: Setup Tox environments
         run: tox run -e integration-${{ matrix.python.tox-version }} --notest
+      - name: Enable ssh access
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ inputs.enable_ssh_access }}
       - name: Run integration tests on Linux
         env:
           CRAFT_PROVIDERS_TESTS_ENABLE_SNAP_INSTALL: 1
@@ -164,6 +182,9 @@ jobs:
           echo "::endgroup::"
       - name: Setup Tox environments
         run: tox run -e integration-${{ matrix.python.tox-version }} --notest
+      - name: Enable ssh access
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ inputs.enable_ssh_access }}
       - name: Run integration tests on MacOS
         env:
           CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_INSTALL: 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,8 @@ jobs:
       - name: Enable ssh access
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.enable_ssh_access }}
+        with:
+          limit-access-to-actor: true
       - name: Run Linters
         run: tox run --skip-pkg-install --no-list-dependencies -m lint
   unit-tests:
@@ -81,6 +83,8 @@ jobs:
       - name: Enable ssh access
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.enable_ssh_access }}
+        with:
+          limit-access-to-actor: true
       - name: Test with tox
         # use `tox` instead of `.tox/.tox/bin/tox` to support Windows
         run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json -m unit-tests
@@ -139,6 +143,8 @@ jobs:
       - name: Enable ssh access
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.enable_ssh_access }}
+        with:
+          limit-access-to-actor: true
       - name: Run integration tests on Linux
         env:
           CRAFT_PROVIDERS_TESTS_ENABLE_SNAP_INSTALL: 1
@@ -185,6 +191,8 @@ jobs:
       - name: Enable ssh access
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.enable_ssh_access }}
+        with:
+          limit-access-to-actor: true
       - name: Run integration tests on MacOS
         env:
           CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_INSTALL: 1

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -89,6 +89,19 @@ You can also see all the environments by simply running ``tox list``
 Running ``tox run -m format`` and ``tox run -m lint`` before committing code is
 recommended.
 
+GitHub Actions
+##############
+
+GitHub Actions is used for CI/CD. There are workflows for building
+documentation, linting, releasing, and running unit and integration tests.
+The workflows run on Linux, MacOS, and Windows. You can get ssh access
+into a runner using action-tmate_. To get ssh access:
+
+#. Go to Actions_
+#. Choose the test suite (e.g. ``tests``)
+#. Choose a branch
+#. Press ``Run workflow`` and select ``Enable ssh access`` in the dropdown
+#. Open the workflow's logs and use the ssh address provided by ``action-tmate``
 
 Contributing code
 #################
@@ -104,6 +117,8 @@ Please follow these guidelines when committing code for this project:
 * Wrap the body at 72 characters
 * Use the body to explain what and why (instead of how)
 
+.. _Actions: https://github.com/canonical/craft-providers/actions
+.. _action-tmate: https://mxschmitt.github.io/action-tmate/
 .. _Black: https://black.readthedocs.io
 .. _`Canonical contributor licence agreement`: http://www.ubuntu.com/legal/contributors/
 .. _deadsnakes: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -103,6 +103,9 @@ into a runner using action-tmate_. To get ssh access:
 #. Press ``Run workflow`` and select ``Enable ssh access`` in the dropdown
 #. Open the workflow's logs and use the ssh address provided by ``action-tmate``
 
+`SSH access is limited`_ to the GitHub user who started the test suite, so you
+need to add your public `SSH key on GitHub`_.
+
 Contributing code
 #################
 
@@ -129,4 +132,6 @@ Please follow these guidelines when committing code for this project:
 .. _pytest: https://pytest.org
 .. _ruff: https://github.com/charliermarsh/ruff
 .. _ShellCheck: https://www.shellcheck.net/
+.. _`SSH access is limited`: https://github.com/marketplace/actions/debugging-with-tmate#use-registered-public-ssh-keys
+.. _`SSH key on GitHub`: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 .. _tox: https://tox.wiki

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ License
 -------
 Free software: GNU Lesser General Public License v3
 
- Documentation
+Documentation
 --------------
 https://canonical-craft-providers.readthedocs-hosted.com/en/latest/
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add ssh access to runners in the CI workflow using [action-tmate](https://github.com/marketplace/actions/debugging-with-tmate).

This is to live permanently in the workflow. It can be triggered by enabling debug when running an action, so no code changes or test branches are needed.

If it is useful, I can upstream the workflow changes to `starbase`.

This PR requires a leap of faith -  we need to merge the PR and then confirm it works as expected.  It worked great on my own fork, so I expect it will work here.

Resolves https://github.com/canonical/craft-providers/issues/311