### PR TITLE
lxd: clear hostname of base instance

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -332,6 +332,20 @@ class Base(ABC):
             error=error,
         )
 
+    def clear_hostname(self, executor: Executor) -> None:
+        """Clear hostname by removing /etc/hostname."""
+        try:
+            self._execute_run(
+                ["rm", "-f", "/etc/hostname"],
+                executor=executor,
+                timeout=self._timeout_simple,
+            )
+        except subprocess.CalledProcessError as error:
+            raise BaseConfigurationError(
+                brief="Failed to clear hostname.",
+                details=details_from_called_process_error(error),
+            ) from error
+
     def _setup_hostname(self, executor: Executor) -> None:
         """Configure hostname, installing /etc/hostname."""
         executor.push_file_io(

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -77,6 +77,11 @@ def _create_instance(
     if not base_instance and not map_user_uid:
         return
 
+    if base_instance:
+        # unset instance hostname before copying to base instance and before stopping
+        # the instance
+        base_configuration.clear_hostname(executor=instance)
+
     # the instance needs to be stopped before copying or updating the id map
     instance.stop()
 
@@ -107,6 +112,11 @@ def _create_instance(
 
     # now restart and wait for the instance to be ready
     instance.start()
+
+    if base_instance:
+        # re-set the hostname after startup
+        base_configuration._setup_hostname(executor=instance)
+
     base_configuration.wait_until_ready(executor=instance)
 
 
@@ -614,5 +624,9 @@ def launch(
     # instance is now ready to be started and warmed up
     logger.warning("Starting instance.")
     instance.start()
+
+    # set the hostname because the base instance does not have a hostname
+    base_configuration._setup_hostname(executor=instance)
+
     base_configuration.warmup(executor=instance)
     return instance

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -214,8 +214,32 @@ def test_launch_use_base_instance(get_instance_and_base_instance, instance_name)
     instance.execute_run(["stat", "/base-instance"], check=True)
     instance.execute_run(["stat", "/instance"], check=True)
 
+    # collect the hostname of the base instance
+    base_instance.start()
+    base_instance_hostname = (
+        base_instance.execute_run(
+            ["cat", "/etc/hostname"], check=True, capture_output=True
+        )
+        .stdout.decode()
+        .rstrip("\n")
+    )
+    base_instance.stop()
+
+    # `/etc/hostname` was removed during the creation of the base instance, so lxc will
+    # set the hostname to the instance name
+    assert base_instance_hostname == base_instance.instance_name
+
     assert instance.exists()
     assert instance.is_running()
+
+    # collect the hostname of the instance
+    instance_hostname = (
+        instance.execute_run(["cat", "/etc/hostname"], check=True, capture_output=True)
+        .stdout.decode()
+        .rstrip("\n")
+    )
+
+    assert instance_hostname == "test-hostname"
 
 
 def test_launch_create_base_instance_with_correct_image_description(

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -181,15 +181,13 @@ def test_launch_use_base_instance(
         call.stop(),
         call.start(),
     ]
-    assert fake_base_instance.mock_calls == [
-        call.exists(),
-        call.__bool__(),
-        call.__bool__(),
-    ]
+    fake_base_instance.exists.assert_called_once()
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.get_command_environment(),
         call.setup(executor=fake_instance),
+        call.clear_hostname(executor=fake_instance),
+        call._setup_hostname(executor=fake_instance),
         call.wait_until_ready(executor=fake_instance),
     ]
 
@@ -261,6 +259,7 @@ def test_launch_use_existing_base_instance(
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.get_command_environment(),
+        call._setup_hostname(executor=fake_instance),
         call.warmup(executor=fake_instance),
     ]
 
@@ -325,16 +324,14 @@ def test_launch_existing_base_instance_invalid(
         call.stop(),
         call.start(),
     ]
-    assert fake_base_instance.mock_calls == [
-        call.exists(),
-        call.delete(),
-        call.__bool__(),
-        call.__bool__(),
-    ]
+    fake_base_instance.exists.assert_called_once()
+    fake_base_instance.delete.assert_called_once()
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.get_command_environment(),
         call.setup(executor=fake_instance),
+        call.clear_hostname(executor=fake_instance),
+        call._setup_hostname(executor=fake_instance),
         call.wait_until_ready(executor=fake_instance),
     ]
 
@@ -801,15 +798,13 @@ def test_use_snapshots_deprecated(
         call.stop(),
         call.start(),
     ]
-    assert fake_base_instance.mock_calls == [
-        call.exists(),
-        call.__bool__(),
-        call.__bool__(),
-    ]
+    fake_base_instance.exists.assert_called_once()
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.get_command_environment(),
         call.setup(executor=fake_instance),
+        call.clear_hostname(executor=fake_instance),
+        call._setup_hostname(executor=fake_instance),
         call.wait_until_ready(executor=fake_instance),
     ]
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -135,3 +135,20 @@ def test_wait_for_network_timeout(fake_base, fake_executor, fake_process, callba
 
     with pytest.raises(BaseConfigurationError):
         fake_base._setup_wait_for_system_ready(fake_executor)
+
+
+def test_clear_hostname(fake_base, fake_executor, fake_process):
+    fake_process.register([*FAKE_EXECUTOR_CMD, "rm", "-f", "/etc/hostname"])
+
+    fake_base.clear_hostname(fake_executor)
+
+
+def test_clear_hostname_failure(fake_base, fake_executor, fake_process):
+    fake_process.register(
+        [*FAKE_EXECUTOR_CMD, "rm", "-f", "/etc/hostname"], returncode=1
+    )
+
+    with pytest.raises(BaseConfigurationError) as raised:
+        fake_base.clear_hostname(fake_executor)
+
+    assert raised.value.brief == "Failed to clear hostname."


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The hostname is cleared before creating a LXD base instance from an instance. The hostname is set when creating a new instance from the base instance.

Depends on https://github.com/canonical/craft-providers/pull/305 (which adds some unit test fixtures for the `Base` class), so only the last commit is relevant here.

Source: 
- https://github.com/snapcore/snapcraft/issues/4181

(CRAFT-1767)