### PR TITLE
base: retry retrieving /etc/os-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest-cov==4.1.0",
     "pytest-mock==3.10.0",
     "pytest-subprocess==1.5.0",
+    "pytest-time==0.2.0",
     "responses==0.23.1",
     "types-requests==2.31.0.1",
     "types-setuptools==67.8.0.0",


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This occasionally fails if the CPU is busy (most noticeable in CI). Retrying should reduce the chance of that.