### PR TITLE
bases: use default hostnames

### DIFF
--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -178,7 +178,7 @@ class LXDInstance(Executor):
         :raises LXDError: On unexpected error.
         """
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            shutil.copyfileobj(content, temp_file)
+            shutil.copyfileobj(content, temp_file)  # type: ignore
 
         temp_path = pathlib.Path(temp_file.name)
         self.lxc.file_push(


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Let LXD and Multipass set the instance's hostname to the name. LXD names are compatible with hostname naming conventions. Multipass names are compatible but do not have a maximum length. Multipass truncates the hostname to the first 64 characters of the name.

Note - this is a hotfix for the `1.10` branch for snapcraft `7.4`.

This required 2 cherry-picks from `main`.

(CRAFT-1767)