### PR TITLE
hotfix: backport fixes to 1.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,8 +67,8 @@ jobs:
         uses: codecov/codecov-action@v1
 
   macos-integration-tests:
-    name: MacOS 10.15 Integration Tests
-    runs-on: macos-10.15
+    name: MacOS Integration Tests
+    runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -82,8 +82,10 @@ jobs:
         run: |
           brew update
           brew install multipass
-          multipass version
           sleep 20
+          multipass set local.driver=qemu
+          sleep 20
+          multipass version
       - name: Run integration tests on MacOS
         run: |
           export CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_INSTALL=1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,8 +46,7 @@ jobs:
           make test-pylint
       - name: Run pyright
         run: |
-          sudo snap install --classic node
-          sudo snap install --classic pyright
+          pip install "pyright==1.1.301"
           make test-pyright
       - name: Install LXD
         run: |

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -94,13 +94,15 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE = {
     bases.BuilddBaseAlias.JAMMY.value: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="22.04"
     ),
+    # kinetic image is not available on macos
     bases.BuilddBaseAlias.KINETIC.value: RemoteImage(
         remote=Remote.RELEASE, image_name="kinetic"
     ),
     bases.BuilddBaseAlias.LUNAR.value: RemoteImage(
-        remote=Remote.DAILY, image_name="lunar"
+        remote=Remote.RELEASE, image_name="lunar"
     ),
-    # XXX: devel image from snapcraft remote is not working (LP #2007419)
+    # XXX: snapcraft:devel image is not working (LP #2007419)
+    # daily:devel image is not available on macos
     bases.BuilddBaseAlias.DEVEL.value: RemoteImage(
         remote=Remote.DAILY, image_name="devel"
     ),

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ test_requires = [
     "flake8",
     "freezegun",
     "isort",
-    "mypy",
+    "mypy==1.1.1",
     "logassert",
     "pydocstyle",
     "pyfakefs",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ install_requires = [
     "pydantic",
     "pyyaml",
     "requests_unixsocket",
+    # Needed until requests-unixsocket supports urllib3 v2
+    # https://github.com/msabramo/requests-unixsocket/pull/69
+    "urllib3<2",
 ]
 
 dev_requires = [

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -16,6 +16,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+import sys
+
 import pytest
 
 from craft_providers.bases import BuilddBase, BuilddBaseAlias
@@ -43,15 +45,16 @@ def test_create_environment(installed_multipass, instance_name):
     assert test_instance.exists() is False
 
 
-@pytest.mark.parametrize(
-    "alias",
-    set(BuilddBaseAlias)
-    # skip devel images because they are not available on macos
-    - {BuilddBaseAlias.XENIAL, BuilddBaseAlias.LUNAR, BuilddBaseAlias.DEVEL},
-)
+@pytest.mark.parametrize("alias", set(BuilddBaseAlias) - {BuilddBaseAlias.XENIAL})
 def test_launched_environment(alias, installed_multipass, instance_name, tmp_path):
     """Verify `launched_environment()` creates and starts an instance then stops
     the instance when the method loses context."""
+    if sys.platform == "darwin" and alias == BuilddBaseAlias.KINETIC:
+        pytest.skip(reason="previous interim releases are not available on MacOS")
+
+    if sys.platform == "darwin" and alias == BuilddBaseAlias.DEVEL:
+        pytest.skip(reason="snapcraft:devel is not working on MacOS (LP #2007419)")
+
     provider = MultipassProvider()
 
     base_configuration = BuilddBase(alias=alias)


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

> :warning: Do not squash

In preparation for #337, which is a hotfix for `1.10`, this PR cherry-picks two commits for `1.10` and add 3 more commits to keep CI working.

(CRAFT-1767)