### PR TITLE
lxd: set hostname after copying from a base instance

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -615,5 +615,10 @@ def launch(
     # instance is now ready to be started and warmed up
     logger.warning("Starting instance.")
     instance.start()
+
+    # change the hostname from the base instance's hostname
+    # pylint: disable-next=protected-access
+    base_configuration._setup_hostname(executor=instance, deadline=None)  # type: ignore
+
     base_configuration.warmup(executor=instance)
     return instance

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -218,7 +218,7 @@ def test_launch_use_base_instance(get_instance_and_base_instance, instance_name)
 
     # collect the hostname of the instance
     instance_hostname = (
-        instance.execute_run(["cat", "/etc/hostname"], check=True, capture_output=True)
+        instance.execute_run(["hostname"], check=True, capture_output=True)
         .stdout.decode()
         .rstrip("\n")
     )

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -216,6 +216,15 @@ def test_launch_use_base_instance(get_instance_and_base_instance, instance_name)
     assert instance.exists()
     assert instance.is_running()
 
+    # collect the hostname of the instance
+    instance_hostname = (
+        instance.execute_run(["cat", "/etc/hostname"], check=True, capture_output=True)
+        .stdout.decode()
+        .rstrip("\n")
+    )
+
+    assert instance_hostname == base_configuration.hostname
+
 
 def test_launch_create_base_instance_with_correct_image_description(
     get_base_instance, instance_name

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -26,12 +26,12 @@ import pytest
 from freezegun import freeze_time
 from logassert import Exact  # type: ignore
 
-from craft_providers import Base, ProviderError, bases, lxd
+from craft_providers import ProviderError, bases, lxd
 
 
 @pytest.fixture
 def mock_base_configuration():
-    mock_base = Mock(spec=Base)
+    mock_base = Mock(spec=bases.BuilddBase)
     mock_base.compatibility_tag = "mock-compat-tag-v100"
     mock_base.get_command_environment.return_value = {"foo": "bar"}
     yield mock_base
@@ -183,11 +183,7 @@ def test_launch_use_base_instance(
         call.stop(),
         call.start(),
     ]
-    assert fake_base_instance.mock_calls == [
-        call.exists(),
-        call.__bool__(),
-        call.__bool__(),
-    ]
+    fake_base_instance.exists.assert_called_once()
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.get_command_environment(),
@@ -263,6 +259,7 @@ def test_launch_use_existing_base_instance(
     assert mock_base_configuration.mock_calls == [
         call.get_command_environment(),
         call.get_command_environment(),
+        call._setup_hostname(executor=fake_instance, deadline=None),
         call.warmup(executor=fake_instance),
     ]
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

When copying from a base instance, set the hostname of the instance.

This is a replacement for #337, where I thought that hostnames would be self-managed.  That is only the case for images with `cloud-init` configured and buildd images do not have `cloud-init` :sob: 

I also decided not to "clear" (remove) the base instance hostname.  It led to unpredictable behavior the next time I tried to set it.

(CRAFT-1767)