### PR TITLE
providers: add name and install recommendation properties

### DIFF
--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -58,6 +58,16 @@ class LXDProvider(Provider):
         self.lxd_project = lxd_project
         self.lxd_remote = lxd_remote
 
+    @property
+    def name(self) -> str:
+        """Name of the provider."""
+        return "LXD"
+
+    @property
+    def install_recommendation(self) -> str:
+        """Recommended way to install the provider."""
+        return "Visit https://ubuntu.com/lxd/install for instructions to install LXD."
+
     @classmethod
     def ensure_provider_is_available(cls) -> None:
         """Ensure provider is available and ready, installing if required.

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -142,6 +142,18 @@ class MultipassProvider(Provider):
     def __init__(self, instance: Multipass = Multipass()) -> None:
         self.multipass = instance
 
+    @property
+    def name(self) -> str:
+        """Name of the provider."""
+        return "Multipass"
+
+    @property
+    def install_recommendation(self) -> str:
+        """Recommended way to install the provider."""
+        return (
+            "Visit https://multipass.run/install for instructions to install Multipass."
+        )
+
     @classmethod
     def ensure_provider_is_available(cls) -> None:
         """Ensure provider is available, prompting the user to install it if required.

--- a/craft_providers/provider.py
+++ b/craft_providers/provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -35,6 +35,16 @@ logger = logging.getLogger(__name__)
 
 class Provider(ABC):
     """Build environment provider."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name of the provider."""
+
+    @property
+    @abstractmethod
+    def install_recommendation(self) -> str:
+        """Recommended way to install the provider."""
 
     def clean_project_environments(self, *, instance_name: str) -> None:
         """Clean the provider environment.

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -230,3 +230,20 @@ def test_launched_environment_unstable_error(
         "Cannot launch an unstable image 'test-image-name' from remote "
         "'test-remote-name'"
     )
+
+
+def test_lxd_name():
+    """Verify LXDProvider's name."""
+    provider = LXDProvider()
+
+    assert provider.name == "LXD"
+
+
+def test_lxd_install_recommendation():
+    """Verify LXDProvider's install recommendation."""
+    provider = LXDProvider()
+
+    assert (
+        provider.install_recommendation
+        == "Visit https://ubuntu.com/lxd/install for instructions to install LXD."
+    )

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -298,3 +298,20 @@ def test_remote_image_name(remote):
 def test_remote_is_stable(remote_image, is_stable):
     """RemoteImages should be properly marked as stable or unstable."""
     assert remote_image.is_stable == is_stable
+
+
+def test_multipass_name():
+    """Verify MultipassProvider's name."""
+    provider = MultipassProvider()
+
+    assert provider.name == "Multipass"
+
+
+def test_multipass_install_recommendation():
+    """Verify MultipassProvider's install recommendation."""
+    provider = MultipassProvider()
+
+    assert (
+        provider.install_recommendation
+        == "Visit https://multipass.run/install for instructions to install Multipass."
+    )


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Add a `name` and `install_recommendation` property to `Provider` classes.

This can be used in places like [this](https://github.com/canonical/charmcraft/blob/4b34df89d55e545513d8a1b5ac7b84e443541565/charmcraft/providers.py#L219)


Resolves #166 
(CRAFT-1474)