### PR TITLE
lxc: create status data in lxd to avoid race

### DIFF
--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -534,6 +534,15 @@ class LXDInstance(Executor):
             instance_name=self.instance_name, project=self.project, remote=self.remote
         )
 
+    def restart(self) -> None:
+        """Restart instance.
+
+        :raises LXDError: on unexpected error.
+        """
+        self.lxc.restart(
+            instance_name=self.instance_name, project=self.project, remote=self.remote
+        )
+
     def stop(self) -> None:
         """Stop instance.
 
@@ -593,3 +602,37 @@ class LXDInstance(Executor):
                 project=self.project,
                 remote=self.remote,
             )
+
+    def config_get(self, key: str) -> str:
+        """Get instance configuration value.
+
+        :param key: Configuration key to get.
+
+        :returns: Configuration value.
+
+        :raises LXDError: On unexpected error.
+        """
+        return self.lxc.config_get(
+            instance_name=self.instance_name,
+            key=key,
+            project=self.project,
+            remote=self.remote,
+        )
+
+    def config_set(self, key: str, value: str) -> None:
+        """Set instance configuration value.
+
+        :param key: Configuration key to set.
+        :param value: Configuration key to the value.
+
+        :returns: None.
+
+        :raises LXDError: On unexpected error.
+        """
+        self.lxc.config_set(
+            instance_name=self.instance_name,
+            key=key,
+            value=value,
+            project=self.project,
+            remote=self.remote,
+        )

--- a/craft_providers/lxd/lxd_instance_status.py
+++ b/craft_providers/lxd/lxd_instance_status.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""LXD Instance Status."""
+
+from enum import Enum
+
+
+class ProviderInstanceStatus(Enum):
+    """Status of the instance."""
+
+    PREPARING = "PREPARING"
+    FINISHED = "FINISHED"
+    STARTING = "STARTING"

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import tempfile
 from unittest import mock
+from unittest.mock import call
 
 import pytest
 from craft_providers import errors
@@ -106,6 +107,33 @@ def mock_os_unlink():
 @pytest.fixture()
 def instance(mock_lxc):
     return LXDInstance(name=_TEST_INSTANCE["name"], lxc=mock_lxc)
+
+
+def test_config_get(mock_lxc, instance):
+    instance.config_get(key="test-key")
+
+    assert mock_lxc.mock_calls == [
+        call.config_get(
+            instance_name="test-instance-fa2d407652a1c51f6019",
+            key="test-key",
+            project="default",
+            remote="local",
+        )
+    ]
+
+
+def test_config_set(mock_lxc, instance):
+    instance.config_set(key="test-key", value="test-value")
+
+    assert mock_lxc.mock_calls == [
+        call.config_set(
+            instance_name="test-instance-fa2d407652a1c51f6019",
+            key="test-key",
+            value="test-value",
+            project="default",
+            remote="local",
+        )
+    ]
 
 
 def test_push_file_io(
@@ -779,6 +807,18 @@ def test_start(mock_lxc, instance):
             instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
+        )
+    ]
+
+
+def test_restart(mock_lxc, instance):
+    instance.restart()
+
+    assert mock_lxc.mock_calls == [
+        call.restart(
+            instance_name="test-instance-fa2d407652a1c51f6019",
+            project="default",
+            remote="local",
         )
     ]
 


### PR DESCRIPTION
Use `user.craft_providers.status` and `user.craft_providers.timer` in LXD to detect current status to avoid race
that try to create same instance from different process.

Also added restart() to instance to avoid ephemeral delete it when stop for configuration.

Fixes #341