### PR TITLE
lxd: update logging semantics

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -210,7 +210,7 @@ def _get_host_snap(snap_name: str) -> Iterator[pathlib.Path]:
         try:
             _download_host_snap(snap_name=snap_name, output=snap_path)
         except SnapInstallationError:
-            logger.warning(
+            logger.debug(
                 "Failed to fetch snap from snapd,"
                 " falling back to `snap pack` to recreate"
             )

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -529,6 +529,7 @@ class LXDInstance(Executor):
 
         :raises LXDError: on unexpected error.
         """
+        logger.info("Starting instance")
         self.lxc.start(
             instance_name=self.instance_name, project=self.project, remote=self.remote
         )

--- a/tests/integration/actions/test_snap_installer.py
+++ b/tests/integration/actions/test_snap_installer.py
@@ -121,9 +121,10 @@ def test_inject_from_host_using_pack_fallback(
     )
 
     log_messages = [r.message for r in caplog.records]
-    assert log_messages == [
+    expected = (
         "Failed to fetch snap from snapd, falling back to `snap pack` to recreate"
-    ]
+    )
+    assert expected in log_messages
 
 
 def test_install_from_store_strict(core22_lxd_instance, installed_snap, caplog):

--- a/tests/integration/actions/test_snap_installer.py
+++ b/tests/integration/actions/test_snap_installer.py
@@ -17,6 +17,7 @@
 
 """Tests for snap installer."""
 
+import logging
 import re
 from textwrap import dedent
 
@@ -107,6 +108,8 @@ def test_inject_from_host_using_pack_fallback(
     core22_lxd_instance, empty_test_snap, caplog
 ):
     """Verify a snap is packed if the local download fails."""
+    caplog.set_level(logging.DEBUG)
+
     snap_installer.inject_from_host(
         executor=core22_lxd_instance,
         snap_name=empty_test_snap,

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -308,6 +308,47 @@ def test_launch_use_existing_base_instance(
     ]
 
 
+def test_launch_use_existing_base_instance_already_running(
+    fake_instance,
+    fake_base_instance,
+    mock_base_configuration,
+    mock_is_valid,
+    mock_lxc,
+    mock_lxd_instance,
+    mock_platform,
+    mock_timezone,
+):
+    """Launch an existing instance which is already running."""
+    fake_base_instance.exists.return_value = True
+    fake_base_instance.is_running.return_value = True
+
+    fake_instance.is_running.return_value = True
+
+    lxd.launch(
+        name=fake_instance.name,
+        base_configuration=mock_base_configuration,
+        image_name="image-name",
+        image_remote="image-remote",
+        map_user_uid=True,
+        uid=1234,
+        use_base_instance=True,
+        project="test-project",
+        remote="test-remote",
+        lxc=mock_lxc,
+    )
+
+    assert fake_instance.mock_calls == [
+        call.exists(),
+        call.is_running(),
+        call.stop(),
+        call.start(),
+    ]
+    assert fake_base_instance.mock_calls == [
+        call.exists(),
+        call.is_running(),
+    ]
+
+
 def test_launch_existing_base_instance_invalid(
     fake_instance,
     fake_base_instance,

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -771,7 +771,7 @@ def test_launch_existing_instance_id_map_mismatch_with_auto_clean(
             f"Cleaning incompatible instance '{fake_instance.instance_name}' (reason: "
             "the instance's id map ('raw.idmap') is not configured as expected)."
         )
-        in logs.warning
+        in logs.debug
     )
 
 
@@ -975,7 +975,7 @@ def test_is_valid_lxd_error(logs, mocker, mock_lxc):
     )
 
     assert not is_valid
-    assert Exact("Could not get instance info with error: test error") in logs.warning
+    assert Exact("Could not get instance info with error: test error") in logs.debug
 
 
 def test_is_valid_key_error(logs, mocker, mock_lxc):
@@ -991,7 +991,7 @@ def test_is_valid_key_error(logs, mocker, mock_lxc):
     )
 
     assert not is_valid
-    assert Exact("Instance does not have a 'Created' date.") in logs.warning
+    assert Exact("Instance does not have a 'Created' date.") in logs.debug
 
 
 def test_is_valid_value_error(logs, mocker, mock_lxc):
@@ -1012,7 +1012,7 @@ def test_is_valid_value_error(logs, mocker, mock_lxc):
             "Could not parse instance's 'Created' date with error: ValueError(\"time "
             "data 'bad-datetime-value' does not match format '%Y/%m/%d %H:%M %Z'\")"
         )
-        in logs.warning
+        in logs.debug
     )
 
 


### PR DESCRIPTION
This commit does two things:

- Update almost all instances of log.warning() to log.debug() in lxd- related code. The rationale is that the majority of those messages are meant to assist developers in debugging/troubleshooting, and not really meant for end-users.
- Add a couple of log.info() messages. These are only a couple on purpose, as the intent is to provide a _bit_ more information during instance fetching/setup without overwhelming the end-user with info that is ultimately not relevant to them ("implementation details"). For example, we say that we're "Starting the instance" but not that we are "Configuring networking". Since the debug messages are preserved, the information is ultimately still available in logfiles.

Note that multipass code still needs to be updated.

Fixes #377

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
