### PR TITLE
bases: use `snap refresh --hold`

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -28,7 +28,6 @@ import re
 import subprocess
 import sys
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta
 from enum import Enum
 from textwrap import dedent
 from typing import Dict, List, Optional, Type, final
@@ -576,17 +575,19 @@ class Base(ABC):
     def _disable_and_wait_for_snap_refresh(self, executor: Executor) -> None:
         """Disable automatic snap refreshes and wait for refreshes to complete.
 
-        Craft-providers manages the installation and versions of snaps inside the
-        build environment, so automatic refreshes of snaps by snapd are disabled.
+        Automatic snap refreshes are disabled because craft-providers manages the
+        installation and versions of snaps inside the build environment.
+
+        :param executor: Executor for target container.
+
+        :raises BaseConfigurationError: if snap refreshes cannot be disabled or an
+        error occurs while waiting for pending refreshes to complete.
         """
-        # disable refresh for 1 day
-        hold_time = datetime.now() + timedelta(days=1)
         logger.debug("Holding refreshes for snaps.")
 
-        # TODO: run `snap refresh --hold` once during setup (`--hold` is not yet stable)
         try:
             executor.execute_run(
-                ["snap", "set", "system", f"refresh.hold={hold_time.isoformat()}Z"],
+                ["snap", "refresh", "--hold"],
                 capture_output=True,
                 check=True,
                 timeout=self._timeout_simple,
@@ -835,6 +836,13 @@ class Base(ABC):
         self._disable_and_wait_for_snap_refresh(executor=executor)
         self._setup_snapd_proxy(executor=executor)
 
+    def _warmup_snapd(self, executor: Executor) -> None:
+        """Warmup snapd.
+
+        This step usually does not need to be overridden.
+        """
+        self._setup_snapd_proxy(executor=executor)
+
     def _pre_setup_snaps(self, executor: Executor) -> None:
         """Do anything before setting up the snaps.
 
@@ -1022,7 +1030,7 @@ class Base(ABC):
         self._setup_wait_for_system_ready(executor=executor)
         self._setup_wait_for_network(executor=executor)
 
-        self._post_setup_snapd(executor=executor)
+        self._warmup_snapd(executor=executor)
 
         self._pre_setup_snaps(executor=executor)
         self._setup_snaps(executor=executor)

--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -92,7 +92,7 @@ class Base(ABC):
     _timeout_complex: Optional[float] = TIMEOUT_COMPLEX
     _timeout_unpredictable: Optional[float] = TIMEOUT_UNPREDICTABLE
     alias: Enum
-    compatibility_tag: str = "base-v1"
+    compatibility_tag: str = "base-v2"
 
     @abstractmethod
     def __init__(

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -38,7 +38,7 @@ def get_base_instance():
     def _base_instance(
         image_name: str = "22.04",
         image_remote: str = "ubuntu",
-        compatibility_tag: str = "buildd-base-v1",
+        compatibility_tag: str = "buildd-base-v2",
         project: str = "default",
     ):
         """Get the base instance."""
@@ -301,7 +301,7 @@ def test_launch_create_base_instance_with_correct_image_description(
 
     assert (
         lxc_result[0]["expanded_config"]["image.description"]
-        == "base-instance-buildd-base-v1-ubuntu-22.04"
+        == "base-instance-buildd-base-v2-ubuntu-22.04"
     )
 
 
@@ -646,7 +646,7 @@ def test_launch_instance_config_incompatible_without_auto_clean(
 
     assert exc_info.value.brief == (
         "Incompatible base detected:"
-        " Expected image compatibility tag 'buildd-base-v1', found 'invalid'."
+        " Expected image compatibility tag 'buildd-base-v2', found 'invalid'."
     )
 
 
@@ -679,7 +679,7 @@ def test_launch_instance_not_setup_without_auto_clean(
     """Raise an error if an existing instance is not setup and auto_clean is False."""
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
         file_mode="0644",
     )
 
@@ -700,7 +700,7 @@ def test_launch_instance_not_setup_with_auto_clean(base_configuration, core22_in
     """Clean the instance if it is not setup and auto_clean is True."""
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
         file_mode="0644",
     )
 

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -153,7 +153,7 @@ def test_launch_instance_config_incompatible_instance(core22_instance):
 
     assert exc_info.value.brief == (
         "Incompatible base detected:"
-        " Expected image compatibility tag 'buildd-base-v1', found 'invalid'."
+        " Expected image compatibility tag 'buildd-base-v2', found 'invalid'."
     )
 
     # Retry with auto_clean=True.
@@ -174,7 +174,7 @@ def test_launch_instance_not_setup_without_auto_clean(core22_instance):
 
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
         file_mode="0644",
     )
 
@@ -196,7 +196,7 @@ def test_launch_instance_not_setup_with_auto_clean(core22_instance):
 
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v1\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
         file_mode="0644",
     )
 

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -55,7 +55,7 @@ def config_fixture(fake_home_temporary_file, request):
     """
     config_content = textwrap.dedent(
         f"""\
-        compatibility_tag: tag-foo-v1
+        compatibility_tag: tag-foo-v2
         snaps:
           test-name:
             revision: '{request.param}'

--- a/tests/unit/bases/test_almalinux.py
+++ b/tests/unit/bases/test_almalinux.py
@@ -41,7 +41,7 @@ from tests.unit.conftest import DEFAULT_FAKE_CMD
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
-        return_value=InstanceConfiguration(compatibility_tag="almalinux-base-v1"),
+        return_value=InstanceConfiguration(compatibility_tag="almalinux-base-v2"),
     )
 
 
@@ -150,7 +150,7 @@ def mock_get_os_release(mocker):
     ],
 )
 @pytest.mark.parametrize(
-    ("tag", "expected_tag"), [(None, "almalinux-base-v1"), ("test-tag", "test-tag")]
+    ("tag", "expected_tag"), [(None, "almalinux-base-v2"), ("test-tag", "test-tag")]
 )
 def test_setup(
     fake_process,
@@ -654,7 +654,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
         base_config._ensure_instance_config_compatible(executor=fake_executor)
 
     assert exc_info.value == BaseCompatibilityError(
-        "Expected image compatibility tag 'almalinux-base-v1', found 'invalid-tag'"
+        "Expected image compatibility tag 'almalinux-base-v2', found 'invalid-tag'"
     )
 
 
@@ -1057,7 +1057,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
     assert fake_executor.records_of_push_file_io == [
         {
             "content": (
-                "compatibility_tag: almalinux-base-v1\n"
+                "compatibility_tag: almalinux-base-v2\n"
                 f"setup: {str(status).lower()}\n".encode()
             ),
             "destination": "/etc/craft-instance.conf",
@@ -1163,7 +1163,7 @@ def test_ensuresetup_completed_not_setup(status, fake_executor, mock_load):
 )
 def test_warmup_overall(environment, fake_process, fake_executor, mock_load, mocker):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v1", setup=True
+        compatibility_tag="almalinux-base-v2", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
 
@@ -1211,7 +1211,7 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
 
 def test_warmup_bad_os(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v1", setup=True
+        compatibility_tag="almalinux-base-v2", setup=True
     )
     base_config = almalinux.AlmaLinuxBase(
         alias=almalinux.AlmaLinuxBaseAlias.NINE,
@@ -1236,7 +1236,7 @@ def test_warmup_bad_os(fake_process, fake_executor, mock_load):
 
 def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v1", setup=True
+        compatibility_tag="almalinux-base-v2", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(
@@ -1265,7 +1265,7 @@ def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
 def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
     """Raise a BaseConfigurationError if the instance is not setup."""
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v1", setup=setup
+        compatibility_tag="almalinux-base-v2", setup=setup
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(
@@ -1293,7 +1293,7 @@ def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
 
 def test_warmup_never_ready(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v1", setup=True
+        compatibility_tag="almalinux-base-v2", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(
@@ -1326,7 +1326,7 @@ def test_warmup_never_ready(fake_process, fake_executor, mock_load):
 
 def test_warmup_never_network(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v1", setup=True
+        compatibility_tag="almalinux-base-v2", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(

--- a/tests/unit/bases/test_centos_7.py
+++ b/tests/unit/bases/test_centos_7.py
@@ -17,7 +17,6 @@
 
 
 import subprocess
-from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import ANY, call, patch
@@ -175,11 +174,6 @@ def test_setup(
 ):
     mock_load.return_value = InstanceConfiguration(compatibility_tag=expected_tag)
 
-    mock_datetime = mocker.patch("craft_providers.base.datetime")
-    mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
-    # expected datetime will be 24 hours after the current time
-    expected_datetime = "2022-01-03T03:04:05.000006"
-
     if environment is None:
         environment = centos.CentOSBase.default_command_environment()
 
@@ -299,15 +293,7 @@ def test_setup(
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "wait", "system", "seed.loaded"]
     )
-    fake_process.register_subprocess(
-        [
-            *DEFAULT_FAKE_CMD,
-            "snap",
-            "set",
-            "system",
-            f"refresh.hold={expected_datetime}Z",
-        ]
-    )
+    fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"])
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "watch", "--last=auto-refresh?"]
     )
@@ -795,7 +781,6 @@ def test_pre_setup_snapd_failures(fake_process, fake_executor, fail_index):
 @pytest.mark.usefixtures("stub_verify_network")
 def test_setup_snapd_failures(fake_process, fake_executor):
     base_config = centos.CentOSBase(alias=centos.CentOSBaseAlias.SEVEN)
-
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "yum", "install", "-y", "snapd"],
         returncode=1,
@@ -812,16 +797,11 @@ def test_setup_snapd_failures(fake_process, fake_executor):
     )
 
 
-@pytest.mark.usefixtures("stub_verify_network")
 @pytest.mark.parametrize("fail_index", list(range(0, 8)))
-def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index, mocker):
+def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index):
     base_config = centos.CentOSBase(alias=centos.CentOSBaseAlias.SEVEN)
-    mock_datetime = mocker.patch("craft_providers.base.datetime")
-    mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
-
-    return_codes = [0, 0, 0, 0, 0, 0, 0, 0]
+    return_codes = [0] * 8
     return_codes[fail_index] = 1
-
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "ln", "-sf", "/var/lib/snapd/snap", "/snap"],
         returncode=return_codes[0],
@@ -839,13 +819,7 @@ def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index, mock
         returncode=return_codes[3],
     )
     fake_process.register_subprocess(
-        [
-            *DEFAULT_FAKE_CMD,
-            "snap",
-            "set",
-            "system",
-            "refresh.hold=2022-01-03T03:04:05.000006Z",
-        ],
+        [*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"],
         returncode=return_codes[4],
     )
     fake_process.register_subprocess(
@@ -863,6 +837,31 @@ def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index, mock
 
     with pytest.raises(BaseConfigurationError):
         base_config._post_setup_snapd(executor=fake_executor)
+
+
+@pytest.mark.parametrize("fail_index", list(range(0, 2)))
+def test_post_warmup_snapd_failures(fake_process, fake_executor, fail_index):
+    base_config = centos.CentOSBase(alias=centos.CentOSBaseAlias.SEVEN)
+    return_codes = [0] * 2
+    return_codes[fail_index] = 1
+    fake_process.register_subprocess(
+        [*DEFAULT_FAKE_CMD, "snap", "unset", "system", "proxy.http"],
+        returncode=return_codes[0],
+    )
+    fake_process.register_subprocess(
+        [*DEFAULT_FAKE_CMD, "snap", "unset", "system", "proxy.https"],
+        returncode=return_codes[1],
+    )
+
+    with pytest.raises(BaseConfigurationError) as raised:
+        base_config._warmup_snapd(executor=fake_executor)
+
+    assert raised.value == BaseConfigurationError(
+        brief="Failed to set the snapd proxy.",
+        details=details_from_called_process_error(
+            raised.value.__cause__  # type: ignore
+        ),
+    )
 
 
 @pytest.mark.parametrize("alias", list(centos.CentOSBaseAlias))
@@ -1113,11 +1112,6 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
     mock_load.return_value = InstanceConfiguration(
         compatibility_tag="centos-base-v1", setup=True
     )
-    mock_datetime = mocker.patch("craft_providers.base.datetime")
-    mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
-    # expected datetime will be 24 hours after the current time
-    expected_datetime = "2022-01-03T03:04:05.000006"
-
     alias = centos.CentOSBaseAlias.SEVEN
 
     if environment is None:
@@ -1143,18 +1137,6 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
         [*DEFAULT_FAKE_CMD, "getent", "hosts", "snapcraft.io"]
     )
     fake_process.register_subprocess(
-        [
-            *DEFAULT_FAKE_CMD,
-            "snap",
-            "set",
-            "system",
-            f"refresh.hold={expected_datetime}Z",
-        ]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "watch", "--last=auto-refresh?"]
-    )
-    fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "set", "system", "proxy.http=http://foo.bar:8080"]
     )
     fake_process.register_subprocess(
@@ -1165,18 +1147,6 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
     )
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "unset", "system", "proxy.https"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "ln", "-sf", "/var/lib/snapd/snap", "/snap"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "systemctl", "enable", "--now", "snapd.socket"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "systemctl", "restart", "snapd.service"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "wait", "system", "seed.loaded"]
     )
 
     base_config.warmup(executor=fake_executor)
@@ -1576,7 +1546,7 @@ def test_disable_and_wait_for_snap_refresh_hold_error(fake_process, fake_executo
     """Raise BaseConfigurationError when the command to hold snap refreshes fails."""
     base_config = centos.CentOSBase(alias=centos.CentOSBaseAlias.SEVEN)
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "set", "system", fake_process.any()],
+        [*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"],
         returncode=-1,
     )
 
@@ -1594,9 +1564,7 @@ def test_disable_and_wait_for_snap_refresh_hold_error(fake_process, fake_executo
 def test_disable_and_wait_for_snap_refresh_wait_error(fake_process, fake_executor):
     """Raise BaseConfigurationError when the `snap watch` command fails."""
     base_config = centos.CentOSBase(alias=centos.CentOSBaseAlias.SEVEN)
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "set", "system", fake_process.any()],
-    )
+    fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"])
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "watch", "--last=auto-refresh?"],
         returncode=-1,

--- a/tests/unit/bases/test_centos_7.py
+++ b/tests/unit/bases/test_centos_7.py
@@ -41,7 +41,7 @@ from tests.unit.conftest import DEFAULT_FAKE_CMD
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
-        return_value=InstanceConfiguration(compatibility_tag="centos-base-v1"),
+        return_value=InstanceConfiguration(compatibility_tag="centos-base-v2"),
     )
 
 
@@ -151,7 +151,7 @@ def mock_get_os_release(mocker):
     ],
 )
 @pytest.mark.parametrize(
-    ("tag", "expected_tag"), [(None, "centos-base-v1"), ("test-tag", "test-tag")]
+    ("tag", "expected_tag"), [(None, "centos-base-v2"), ("test-tag", "test-tag")]
 )
 def test_setup(
     fake_process,
@@ -604,7 +604,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
         base_config._ensure_instance_config_compatible(executor=fake_executor)
 
     assert exc_info.value == BaseCompatibilityError(
-        "Expected image compatibility tag 'centos-base-v1', found 'invalid-tag'"
+        "Expected image compatibility tag 'centos-base-v2', found 'invalid-tag'"
     )
 
 
@@ -1004,7 +1004,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
     assert fake_executor.records_of_push_file_io == [
         {
             "content": (
-                "compatibility_tag: centos-base-v1\n"
+                "compatibility_tag: centos-base-v2\n"
                 f"setup: {str(status).lower()}\n".encode()
             ),
             "destination": "/etc/craft-instance.conf",
@@ -1110,7 +1110,7 @@ def test_ensure_setup_completed_not_setup(status, fake_executor, mock_load):
 )
 def test_warmup_overall(environment, fake_process, fake_executor, mock_load, mocker):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v1", setup=True
+        compatibility_tag="centos-base-v2", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
 
@@ -1158,7 +1158,7 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
 
 def test_warmup_bad_os(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v1", setup=True
+        compatibility_tag="centos-base-v2", setup=True
     )
     base_config = centos.CentOSBase(
         alias=centos.CentOSBaseAlias.SEVEN,
@@ -1183,7 +1183,7 @@ def test_warmup_bad_os(fake_process, fake_executor, mock_load):
 
 def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v1", setup=True
+        compatibility_tag="centos-base-v2", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(
@@ -1212,7 +1212,7 @@ def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
 def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
     """Raise a BaseConfigurationError if the instance is not setup."""
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v1", setup=setup
+        compatibility_tag="centos-base-v2", setup=setup
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(
@@ -1240,7 +1240,7 @@ def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
 
 def test_warmup_never_ready(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v1", setup=True
+        compatibility_tag="centos-base-v2", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(
@@ -1273,7 +1273,7 @@ def test_warmup_never_ready(fake_process, fake_executor, mock_load):
 
 def test_warmup_never_network(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v1", setup=True
+        compatibility_tag="centos-base-v2", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(

--- a/tests/unit/bases/test_instance_config.py
+++ b/tests/unit/bases/test_instance_config.py
@@ -29,7 +29,7 @@ from pydantic import ValidationError
 @pytest.fixture()
 def default_config_data():
     return {
-        "compatibility_tag": "tag-foo-v1",
+        "compatibility_tag": "tag-foo-v2",
         "setup": True,
         "snaps": {
             "charmcraft": {"revision": 834},
@@ -66,7 +66,7 @@ def test_instance_config_defaults():
 
 
 def test_save(mock_executor):
-    config = InstanceConfiguration(compatibility_tag="tag-foo-v1")
+    config = InstanceConfiguration(compatibility_tag="tag-foo-v2")
     config_path = pathlib.PurePosixPath("/etc/crafty-crafty.conf")
 
     config.save(executor=mock_executor, config_path=config_path)
@@ -79,7 +79,7 @@ def test_save(mock_executor):
 
     assert (
         mock_executor.mock_calls[0].kwargs["content"].read()
-        == b"compatibility_tag: tag-foo-v1\n"
+        == b"compatibility_tag: tag-foo-v2\n"
     )
 
 
@@ -119,7 +119,7 @@ def test_load_with_valid_config(mock_executor, config_fixture, default_config_da
 
     assert config_instance is not None
     assert dict(config_instance) == {
-        "compatibility_tag": "tag-foo-v1",
+        "compatibility_tag": "tag-foo-v2",
         "setup": True,
         "snaps": {"charmcraft": {"revision": 834}, "core22": {"revision": 147}},
     }

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -41,7 +41,7 @@ from tests.unit.conftest import DEFAULT_FAKE_CMD
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
-        return_value=InstanceConfiguration(compatibility_tag="buildd-base-v1"),
+        return_value=InstanceConfiguration(compatibility_tag="buildd-base-v2"),
     )
 
 
@@ -146,7 +146,7 @@ def mock_get_os_release(mocker):
     ],
 )
 @pytest.mark.parametrize(
-    ("tag", "expected_tag"), [(None, "buildd-base-v1"), ("test-tag", "test-tag")]
+    ("tag", "expected_tag"), [(None, "buildd-base-v2"), ("test-tag", "test-tag")]
 )
 def test_setup(
     fake_process,
@@ -682,7 +682,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
         base_config._ensure_instance_config_compatible(executor=fake_executor)
 
     assert exc_info.value == BaseCompatibilityError(
-        "Expected image compatibility tag 'buildd-base-v1', found 'invalid-tag'"
+        "Expected image compatibility tag 'buildd-base-v2', found 'invalid-tag'"
     )
 
 
@@ -1403,7 +1403,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
     assert fake_executor.records_of_push_file_io == [
         {
             "content": (
-                "compatibility_tag: buildd-base-v1\n"
+                "compatibility_tag: buildd-base-v2\n"
                 f"setup: {str(status).lower()}\n".encode()
             ),
             "destination": "/etc/craft-instance.conf",
@@ -1509,7 +1509,7 @@ def test_ensure_setup_completed_not_setup(status, fake_executor, mock_load):
 )
 def test_warmup_overall(environment, fake_process, fake_executor, mock_load, mocker):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v1", setup=True
+        compatibility_tag="buildd-base-v2", setup=True
     )
 
     alias = ubuntu.BuilddBaseAlias.JAMMY
@@ -1558,7 +1558,7 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
 
 def test_warmup_bad_os(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v1", setup=True
+        compatibility_tag="buildd-base-v2", setup=True
     )
     base_config = ubuntu.BuilddBase(
         alias=ubuntu.BuilddBaseAlias.JAMMY,
@@ -1583,7 +1583,7 @@ def test_warmup_bad_os(fake_process, fake_executor, mock_load):
 
 def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v1", setup=True
+        compatibility_tag="buildd-base-v2", setup=True
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(
@@ -1612,7 +1612,7 @@ def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
 def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
     """Raise a BaseConfigurationError if the instance is not setup."""
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v1", setup=setup
+        compatibility_tag="buildd-base-v2", setup=setup
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(
@@ -1640,7 +1640,7 @@ def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
 
 def test_warmup_never_ready(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v1", setup=True
+        compatibility_tag="buildd-base-v2", setup=True
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(
@@ -1672,7 +1672,7 @@ def test_warmup_never_ready(fake_process, fake_executor, mock_load):
 
 def test_warmup_never_network(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v1", setup=True
+        compatibility_tag="buildd-base-v2", setup=True
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -17,7 +17,6 @@
 
 
 import subprocess
-from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import ANY, call, patch
@@ -170,11 +169,6 @@ def test_setup(
 ):
     mock_load.return_value = InstanceConfiguration(compatibility_tag=expected_tag)
 
-    mock_datetime = mocker.patch("craft_providers.base.datetime")
-    mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
-    # expected datetime will be 24 hours after the current time
-    expected_datetime = "2022-01-03T03:04:05.000006"
-
     if environment is None:
         environment = ubuntu.BuilddBase.default_command_environment()
 
@@ -316,15 +310,7 @@ def test_setup(
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "wait", "system", "seed.loaded"]
     )
-    fake_process.register_subprocess(
-        [
-            *DEFAULT_FAKE_CMD,
-            "snap",
-            "set",
-            "system",
-            f"refresh.hold={expected_datetime}Z",
-        ]
-    )
+    fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"])
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "watch", "--last=auto-refresh?"]
     )
@@ -978,7 +964,6 @@ def test_pre_setup_snapd_failures(fake_process, fake_executor, fail_index):
 @pytest.mark.usefixtures("stub_verify_network")
 def test_setup_snapd_failures(fake_process, fake_executor):
     base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
-
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "apt-get", "install", "-y", "snapd"],
         returncode=1,
@@ -995,14 +980,10 @@ def test_setup_snapd_failures(fake_process, fake_executor):
     )
 
 
-@pytest.mark.usefixtures("stub_verify_network")
 @pytest.mark.parametrize("fail_index", list(range(0, 8)))
-def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index, mocker):
+def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index):
     base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
-    mock_datetime = mocker.patch("craft_providers.base.datetime")
-    mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
-
-    return_codes = [0, 0, 0, 0, 0, 0, 0, 0]
+    return_codes = [0] * 8
     return_codes[fail_index] = 1
 
     fake_process.register_subprocess(
@@ -1022,13 +1003,7 @@ def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index, mock
         returncode=return_codes[3],
     )
     fake_process.register_subprocess(
-        [
-            *DEFAULT_FAKE_CMD,
-            "snap",
-            "set",
-            "system",
-            "refresh.hold=2022-01-03T03:04:05.000006Z",
-        ],
+        [*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"],
         returncode=return_codes[4],
     )
     fake_process.register_subprocess(
@@ -1046,6 +1021,32 @@ def test_post_setup_snapd_failures(fake_process, fake_executor, fail_index, mock
 
     with pytest.raises(BaseConfigurationError):
         base_config._post_setup_snapd(executor=fake_executor)
+
+
+@pytest.mark.parametrize("fail_index", list(range(0, 2)))
+def test_warmup_snapd_failures(fake_process, fake_executor, fail_index):
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
+    return_codes = [0] * 2
+    return_codes[fail_index] = 1
+
+    fake_process.register_subprocess(
+        [*DEFAULT_FAKE_CMD, "snap", "unset", "system", "proxy.http"],
+        returncode=return_codes[0],
+    )
+    fake_process.register_subprocess(
+        [*DEFAULT_FAKE_CMD, "snap", "unset", "system", "proxy.https"],
+        returncode=return_codes[1],
+    )
+
+    with pytest.raises(BaseConfigurationError) as raised:
+        base_config._warmup_snapd(executor=fake_executor)
+
+    assert raised.value == BaseConfigurationError(
+        brief="Failed to set the snapd proxy.",
+        details=details_from_called_process_error(
+            raised.value.__cause__  # type: ignore
+        ),
+    )
 
 
 @pytest.mark.parametrize("alias", list(ubuntu.BuilddBaseAlias))
@@ -1510,10 +1511,6 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
     mock_load.return_value = InstanceConfiguration(
         compatibility_tag="buildd-base-v1", setup=True
     )
-    mock_datetime = mocker.patch("craft_providers.base.datetime")
-    mock_datetime.now.return_value = datetime(2022, 1, 2, 3, 4, 5, 6)
-    # expected datetime will be 24 hours after the current time
-    expected_datetime = "2022-01-03T03:04:05.000006"
 
     alias = ubuntu.BuilddBaseAlias.JAMMY
 
@@ -1540,18 +1537,6 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
         [*DEFAULT_FAKE_CMD, "getent", "hosts", "snapcraft.io"]
     )
     fake_process.register_subprocess(
-        [
-            *DEFAULT_FAKE_CMD,
-            "snap",
-            "set",
-            "system",
-            f"refresh.hold={expected_datetime}Z",
-        ]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "watch", "--last=auto-refresh?"]
-    )
-    fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "set", "system", "proxy.http=http://foo.bar:8080"]
     )
     fake_process.register_subprocess(
@@ -1562,18 +1547,6 @@ def test_warmup_overall(environment, fake_process, fake_executor, mock_load, moc
     )
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "unset", "system", "proxy.https"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "ln", "-sf", "/var/lib/snapd/snap", "/snap"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "systemctl", "enable", "--now", "snapd.socket"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "systemctl", "restart", "snapd.service"]
-    )
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "wait", "system", "seed.loaded"]
     )
 
     base_config.warmup(executor=fake_executor)
@@ -1971,7 +1944,7 @@ def test_disable_and_wait_for_snap_refresh_hold_error(fake_process, fake_executo
     """Raise BaseConfigurationError when the command to hold snap refreshes fails."""
     base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
     fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "set", "system", fake_process.any()],
+        [*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"],
         returncode=-1,
     )
 
@@ -1989,9 +1962,7 @@ def test_disable_and_wait_for_snap_refresh_hold_error(fake_process, fake_executo
 def test_disable_and_wait_for_snap_refresh_wait_error(fake_process, fake_executor):
     """Raise BaseConfigurationError when the `snap watch` command fails."""
     base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
-    fake_process.register_subprocess(
-        [*DEFAULT_FAKE_CMD, "snap", "set", "system", fake_process.any()],
-    )
+    fake_process.register_subprocess([*DEFAULT_FAKE_CMD, "snap", "refresh", "--hold"])
     fake_process.register_subprocess(
         [*DEFAULT_FAKE_CMD, "snap", "watch", "--last=auto-refresh?"],
         returncode=-1,

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -30,7 +30,7 @@ from logassert import Exact  # type: ignore
 @pytest.fixture()
 def mock_base_configuration():
     mock_base = Mock(spec=Base)
-    mock_base.compatibility_tag = "mock-compat-tag-v100"
+    mock_base.compatibility_tag = "mock-compat-tag-v200"
     mock_base.get_command_environment.return_value = {"foo": "bar"}
     return mock_base
 
@@ -204,7 +204,7 @@ def test_launch_use_base_instance(
             default_command_environment={"foo": "bar"},
         ),
         call(
-            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
+            name="base-instance-mock-compat-tag-v200-image-remote-image-name",
             project="test-project",
             remote="test-remote",
             default_command_environment={"foo": "bar"},
@@ -292,7 +292,7 @@ def test_launch_use_existing_base_instance(
             default_command_environment={"foo": "bar"},
         ),
         call(
-            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
+            name="base-instance-mock-compat-tag-v200-image-remote-image-name",
             project="test-project",
             remote="test-remote",
             default_command_environment={"foo": "bar"},
@@ -406,7 +406,7 @@ def test_launch_existing_base_instance_invalid(
             default_command_environment={"foo": "bar"},
         ),
         call(
-            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
+            name="base-instance-mock-compat-tag-v200-image-remote-image-name",
             project="test-project",
             remote="test-remote",
             default_command_environment={"foo": "bar"},
@@ -937,7 +937,7 @@ def test_use_snapshots_deprecated(
             default_command_environment={"foo": "bar"},
         ),
         call(
-            name="base-instance-mock-compat-tag-v100-image-remote-image-name",
+            name="base-instance-mock-compat-tag-v200-image-remote-image-name",
             project="test-project",
             remote="test-remote",
             default_command_environment={"foo": "bar"},

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -46,7 +46,7 @@ def mock_buildd_base_configuration(mocker):
         "craft_providers.bases.ubuntu.BuilddBase", autospec=True
     )
     mock_base_config.alias = ubuntu.BuilddBaseAlias.JAMMY
-    mock_base_config.compatibility_tag = "buildd-base-v1"
+    mock_base_config.compatibility_tag = "buildd-base-v2"
     return mock_base_config
 
 

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -33,7 +33,7 @@ def mock_buildd_base_configuration(mocker):
         "craft_providers.bases.ubuntu.BuilddBase", autospec=True
     )
     mock_base_config.alias = ubuntu.BuilddBaseAlias.JAMMY
-    mock_base_config.compatibility_tag = "buildd-base-v1"
+    mock_base_config.compatibility_tag = "buildd-base-v2"
     return mock_base_config
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

### Overview
- Replace `snap set system refresh.hold=<24h>` with `snap refresh --hold`
- Execute this call only during `setup` instead of `setup` and `warmup`
- Bump compatibility tag

### Details

This required moving a few other snapd-related calls to only execute during `setup`. 

In `craft-providers<1.13.0`, these snapd calls were [only made once](https://github.com/canonical/craft-providers/blob/3ea09344578f03a458676fac51784bbe6ea7f305/craft_providers/bases/ubuntu.py#L378-L379) during `setup`.  During the [base refactor](https://github.com/canonical/craft-providers/pull/274) in `1.13.0`, these calls were made during `setup` and `warmup`.  I've reverted to the previous behavior because it works, speeds up warmup, and is a neat and tidy way to make this change.

Compatibility tag bump is in a separate commit for your viewing pleasure.


Resolves #184 

https://github.com/canonical/charmcraft/issues/1202
(CRAFT-1984)