### PR TITLE
ci: disable auto-publish to pypi

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -34,19 +34,6 @@ jobs:
         with:
           name: pypi-packages
           path: dist/
-  pypi:
-    needs: ["source-wheel"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get packages
-        uses: actions/download-artifact@v3
-        with:
-          name: pypi-packages
-          path: dist/
-      - name: Publish to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
   github-release:
     needs: ["source-wheel"]
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Disable pypi autopublishing.  It hasn't worked anyways because there hasn't been a pypi token in github.