### PR TITLE
chore(docs): disable epub and pdf creation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,22 +2,15 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-
-# Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
-  - epub
 
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.10"
 
 python:
   install:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

The docs were failing to build when creating an epub and pdf of the docs.

You should now be able to see a link to readthedocs as one of the CI jobs in this PR.