### PR TITLE
ci(renovate): allow more branches and PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -93,7 +93,8 @@
   timezone: "Etc/UTC",
   automergeSchedule: ["every weekend"],
   schedule: ["every weekend"],
-  prConcurrentLimit: 2, // No more than 2 open PRs at a time.
+  prConcurrentLimit: 3, // No more than 3 open PRs at a time.
+  branchConcurrentLimit: 20, // No more than 20 open branches at a time.
   prCreation: "not-pending", // Wait until status checks have completed before raising the PR
   prNotPendingHours: 4, // ...unless the status checks have been running for 4+ hours.
   prHourlyLimit: 1, // No more than 1 PR per hour.


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Renovate has not been working because `branchConcurrentLimit` was implicitly set to `prConcurrentLimit`.  This caused each branch to be "yellow" and renovate would refuse to open a PR.

```
DEBUG: Calculating branchConcurrentLimit (2)
DEBUG: 4 already existing branches found: renovate/doc-dependencies,renovate/dev-dependencies,renovate/major-github-actions,renovate/ruff
DEBUG: Branch concurrent limit remaining: 0
DEBUG: Calculated maximum branches remaining this run: 0
DEBUG: Branches limit = 0
```


When `prConcurrentLimit` is not set, the default for `branchConcurrentLimit` is 10.  I raised it to 20 because we already have 8 `packageRules` groups and it's not unreasonable that one of our repos could have 10 renovate branches.