### PR TITLE
ci(renovate): run tests on renovate branches

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,7 @@ on:
       - "feature/*"
       - "hotfix/*"
       - "release/*"
+      - "renovate/*"
   pull_request:
 
   # Allows triggering the workflow manually from the Actions tab


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Another weekend has passed with no Renovate PRs!

Following [this advice](https://github.com/renovatebot/renovate/discussions/22590#discussioncomment-6097210), tests run by default on renovate branches.

Order of failing events:
1. Renovate created/rebased the [`renovate/ruff`](https://github.com/canonical/craft-providers/tree/renovate/ruff) branch
2. No github tests run on renovate branches
3. An internal renovate test runs, but this does not count as a test because `internalChecksAsSuccess=False` (this was a recent [breaking change](https://github.com/renovatebot/renovate/releases/tag/35.0.0))
4. Renovate does not open the PR because [`prCreation = not-pending`](https://docs.renovatebot.com/configuration-options/#prcreation) because its waiting for a test to run
