### PR TITLE
feat: add check parameter to execute_run

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -66,6 +66,7 @@ class Executor(ABC):
         cwd: Optional[pathlib.PurePath] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         timeout: Optional[float] = None,
+        check: bool = False,
         **kwargs,
     ) -> subprocess.CompletedProcess:
         """Execute a command using subprocess.run().
@@ -78,12 +79,12 @@ class Executor(ABC):
         :param cwd: Working directory for the process inside the instance.
         :param env: Additional environment to set for process.
         :param timeout: Timeout (in seconds) for the command.
+        :param check: Raise an exception if the command fails.
         :param kwargs: Keyword args to pass to subprocess.run().
 
         :returns: Completed process.
 
-        :raises subprocess.CalledProcessError: if command fails and check is
-            True.
+        :raises subprocess.CalledProcessError: if command fails and check is True.
         """
 
     @abstractmethod

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -341,6 +341,7 @@ class LXC:
         remote: str = "local",
         runner: Callable = subprocess.run,
         timeout: Optional[float] = None,
+        check: bool = False,
         **kwargs,
     ):
         """Execute command in instance_name with specified runner.
@@ -356,9 +357,12 @@ class LXC:
             Popen.  First argument is finalized command with the attached
             kwargs.
         :param timeout: Timeout (in seconds) for the command.
+        :param check: Raise an exception if the command fails.
         :param kwargs: Additional kwargs for runner.
 
         :returns: Runner's instance.
+
+        :raises subprocess.CalledProcessError: if command fails and check is True.
         """
         final_cmd = [
             str(self.lxc_path),
@@ -379,7 +383,7 @@ class LXC:
         logger.debug("Executing in container: %s", shlex.join(final_cmd))
 
         if runner is subprocess.run:
-            return runner(final_cmd, timeout=timeout, **kwargs)
+            return runner(final_cmd, timeout=timeout, check=check, **kwargs)
 
         return runner(final_cmd, **kwargs)
 

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -267,6 +267,7 @@ class LXDInstance(Executor):
         cwd: Optional[pathlib.PurePath] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         timeout: Optional[float] = None,
+        check: bool = False,
         **kwargs,
     ) -> subprocess.CompletedProcess:
         """Execute a command using subprocess.run().
@@ -279,6 +280,7 @@ class LXDInstance(Executor):
         :param cwd: Working directory for the process inside the instance.
         :param env: Additional environment to set for process.
         :param timeout: Timeout (in seconds) for the command.
+        :param check: Raise an exception if the command fails.
         :param kwargs: Keyword args to pass to subprocess.run().
 
         :returns: Completed process.
@@ -296,6 +298,7 @@ class LXDInstance(Executor):
             runner=subprocess.run,
             timeout=timeout,
             cwd=cwd_path,
+            check=check,
             **kwargs,
         )
 

--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -94,6 +94,7 @@ class Multipass:
         instance_name: str,
         runner: Callable = subprocess.run,
         timeout: Optional[float] = None,
+        check: bool = False,
         **kwargs,
     ):
         """Execute command in instance_name with specified runner.
@@ -111,6 +112,7 @@ class Multipass:
             Popen.  First argument is finalized command with the attached
             kwargs.
         :param timeout: Timeout (in seconds) for the command.
+        :param check: Raise an exception if the command fails.
         :param kwargs: Additional kwargs for runner.
 
         :returns: Runner's instance.
@@ -122,7 +124,7 @@ class Multipass:
 
         # Only subprocess.run supports timeout
         if runner is subprocess.run:
-            return runner(final_cmd, timeout=timeout, **kwargs)
+            return runner(final_cmd, timeout=timeout, check=check, **kwargs)
 
         return runner(final_cmd, **kwargs)
 

--- a/craft_providers/multipass/multipass_instance.py
+++ b/craft_providers/multipass/multipass_instance.py
@@ -229,6 +229,7 @@ class MultipassInstance(Executor):
         cwd: Optional[pathlib.PurePath] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         timeout: Optional[float] = None,
+        check: bool = False,
         **kwargs,
     ) -> subprocess.CompletedProcess:
         """Execute a command in the instance using subprocess.run().
@@ -246,6 +247,7 @@ class MultipassInstance(Executor):
         :param cwd: working directory to execute the command
         :param env: Additional environment to set for process.
         :param timeout: Timeout (in seconds) for the command.
+        :param check: Raise an exception if the command fails.
         :param kwargs: Keyword args to pass to subprocess.run().
 
         :returns: Completed process.
@@ -257,6 +259,7 @@ class MultipassInstance(Executor):
             command=_rootify_multipass_command(command, cwd=cwd, env=env),
             runner=subprocess.run,
             timeout=timeout,
+            check=check,
             **kwargs,
         )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -87,13 +87,14 @@ class FakeExecutor(Executor):
         cwd: Optional[pathlib.Path] = None,
         env: Optional[Dict[str, Optional[str]]] = None,
         timeout: Optional[float] = None,
+        check: bool = False,
         **kwargs,
     ) -> subprocess.CompletedProcess:
         env_args = [] if env is None else env_cmd.formulate_command(env, chdir=cwd)
 
         final_cmd = [*DEFAULT_FAKE_CMD, *env_args, *command]
 
-        return subprocess.run(final_cmd, timeout=timeout, **kwargs)
+        return subprocess.run(final_cmd, timeout=timeout, check=check, **kwargs)
 
     def pull_file(self, *, source: pathlib.PurePath, destination: pathlib.Path) -> None:
         self.records_of_pull_file.append(

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -295,6 +295,7 @@ def test_execute_run(mock_lxc, instance):
             runner=subprocess.run,
             input="foo",
             timeout=None,
+            check=False,
         )
     ]
 
@@ -316,6 +317,26 @@ def test_execute_run_with_cwd(mock_lxc, instance):
             runner=subprocess.run,
             input="foo",
             timeout=None,
+            check=False,
+        )
+    ]
+
+
+@pytest.mark.parametrize("check", [True, False])
+def test_execute_run_with_check(check, mock_lxc, instance):
+    instance.execute_run(command=["test-command", "flags"], input="foo", check=check)
+
+    assert mock_lxc.mock_calls == [
+        mock.call.exec(
+            instance_name=instance.instance_name,
+            command=["test-command", "flags"],
+            cwd=None,
+            project=instance.project,
+            remote=instance.remote,
+            runner=subprocess.run,
+            input="foo",
+            timeout=None,
+            check=check,
         )
     ]
 
@@ -338,6 +359,7 @@ def test_execute_run_with_default_command_env(mock_lxc):
             remote=instance.remote,
             runner=subprocess.run,
             timeout=None,
+            check=False,
         )
     ]
 
@@ -362,6 +384,7 @@ def test_execute_run_with_default_command_env_unset(mock_lxc):
             remote=instance.remote,
             runner=subprocess.run,
             timeout=None,
+            check=False,
         )
     ]
 
@@ -378,6 +401,7 @@ def test_execute_run_with_env(mock_lxc, instance):
             remote=instance.remote,
             runner=subprocess.run,
             timeout=None,
+            check=False,
         )
     ]
 
@@ -403,6 +427,7 @@ def test_execute_run_with_env_unset(mock_lxc, instance):
             remote=instance.remote,
             runner=subprocess.run,
             timeout=None,
+            check=False,
         )
     ]
 

--- a/tests/unit/multipass/test_multipass_instance.py
+++ b/tests/unit/multipass/test_multipass_instance.py
@@ -288,6 +288,23 @@ def test_execute_run(mock_multipass, instance):
             runner=subprocess.run,
             input="foo",
             timeout=None,
+            check=False,
+        )
+    ]
+
+
+@pytest.mark.parametrize("check", [True, False])
+def test_execute_run_with_check(check, mock_multipass, instance):
+    instance.execute_run(command=["test-command", "flags"], input="foo", check=check)
+
+    assert mock_multipass.mock_calls == [
+        mock.call.exec(
+            instance_name="test-instance",
+            command=["sudo", "-H", "--", "test-command", "flags"],
+            runner=subprocess.run,
+            input="foo",
+            timeout=None,
+            check=check,
         )
     ]
 
@@ -309,6 +326,7 @@ def test_execute_run_with_cwd(mock_multipass, instance, tmp_path):
             ],
             runner=subprocess.run,
             timeout=None,
+            check=False,
         )
     ]
 
@@ -322,6 +340,7 @@ def test_execute_run_with_env(mock_multipass, instance):
             command=["sudo", "-H", "--", "env", "foo=bar", "test-command", "flags"],
             runner=subprocess.run,
             timeout=None,
+            check=False,
         )
     ]
 
@@ -347,6 +366,7 @@ def test_execute_run_with_env_unset(mock_multipass, instance):
             ],
             runner=subprocess.run,
             timeout=None,
+            check=False,
         )
     ]
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

For calls to `subprocess.run`, the default `check=False` was used or `check` was passed via `kwargs`.

Ruff 0.0.291 is now warning that this implicit behavior is a [poor practice](https://pycodequ.al/docs/pylint-messages/w1510-subprocess-run-check.html):
```
tox:lint-ruff
  lint-ruff: commands[0]> ruff check --respect-gitignore .
  tests/unit/conftest.py:96:16: PLW1510 `subprocess.run` without explicit `check` argument
```

Backward compatible.

This issue was raised by #408