### PR TITLE
[DRAFT] ci: run linux integration tests on self-hosted runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Configure environment
         run: |
           echo "::group::Begin snap install"
-          echo "Installing snaps in the background while running apt and pip..."
+          echo "Installing snaps in the background while running pip..."
           sudo snap install --no-wait --classic pyright
           sudo snap install --no-wait shellcheck
           echo "::endgroup::"
@@ -106,10 +106,10 @@ jobs:
     strategy:
       matrix:
         python: [
-          {system-version: "3.8", tox-version: "py3.8"},
+          #{system-version: "3.8", tox-version: "py3.8"},
           {system-version: "3.10", tox-version: "py3.10"},
-          {system-version: "3.11", tox-version: "py3.11"},
-          {system-version: "3.12-dev", tox-version: "py3.12"},
+          #{system-version: "3.11", tox-version: "py3.11"},
+          #{system-version: "3.12-dev", tox-version: "py3.12"},
         ]
     # does not work with canonical/setup-lxd github action (see https://github.com/canonical/craft-providers/issues/271)
     runs-on: [self-hosted, linux, X64, jammy, large]
@@ -125,6 +125,9 @@ jobs:
           cache: 'pip'
       - name: Configure environment
         run: |
+          echo "::group::libpython install"
+          sudo apt install -y libpython${{ matrix.python.system-version }}-dev
+          echo "::endgroup::"
           echo "::group::pip install"
           python -m pip install 'tox>=4.6'
           echo "::endgroup::"
@@ -141,11 +144,6 @@ jobs:
           echo "::endgroup::"
       - name: Setup Tox environments
         run: tox run -e integration-${{ matrix.python.tox-version }} --notest
-      - name: Enable ssh access
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ inputs.enable_ssh_access }}
-        with:
-          limit-access-to-actor: true
       - name: Run integration tests on Linux
         env:
           CRAFT_PROVIDERS_TESTS_ENABLE_SNAP_INSTALL: 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,7 +112,7 @@ jobs:
           {system-version: "3.12-dev", tox-version: "py3.12"},
         ]
     # does not work with canonical/setup-lxd github action (see https://github.com/canonical/craft-providers/issues/271)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Use self-hosted runners for Linux integration tests, since the default github runners don't have enough disk space.

Unblocks #330 