### PR TITLE
ci: clean disk on github runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -125,6 +125,10 @@ jobs:
           cache: 'pip'
       - name: Configure environment
         run: |
+          echo "::group::clean disk"
+          # removing the android sdk and libraries doubles available disk space from 14GB to 28GB
+          sudo rm -rf /usr/local/lib/android/
+          echo "::endgroup::"
           echo "::group::pip install"
           python -m pip install 'tox>=4.6'
           echo "::endgroup::"


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Removing the android sdk and libraries doubles available disk space from ~14GB to ~28GB.  I chose this one because it's easy to remove and a big one.  This should be enough disk space for the foreseeable future.

Unblocks #330.  (I tested on top of #330 and the CI [passed](https://github.com/canonical/craft-providers/actions/runs/6591827692/job/17913377570?pr=431)).
