### PR TITLE
fix: require disk device in default lxd profile

### DIFF
--- a/tests/integration/lxd/test_installer.py
+++ b/tests/integration/lxd/test_installer.py
@@ -51,8 +51,8 @@ def test_ensure_lxd_is_ready(installed_lxd_without_init):
     assert exc_info.value == lxd.LXDError(
         brief="LXD has not been properly initialized.",
         details=(
-            "The default LXD profile is empty or does not contain a disk device with
-            a path of '/'."
+            "The default LXD profile is empty or does not contain a disk device with "
+            "a path of '/'."
         ),
         resolution="Execute 'lxd init --auto' to initialize LXD.\n"
         "Visit https://documentation.ubuntu.com/lxd/en/latest/getting_started/ for "

--- a/tests/integration/lxd/test_installer.py
+++ b/tests/integration/lxd/test_installer.py
@@ -50,6 +50,10 @@ def test_ensure_lxd_is_ready(installed_lxd_without_init):
 
     assert exc_info.value == lxd.LXDError(
         brief="LXD has not been properly initialized.",
+        details=(
+            "The default LXD profile is empty or does not contain a disk device with
+            a path of '/'."
+        ),
         resolution="Execute 'lxd init --auto' to initialize LXD.\n"
         "Visit https://documentation.ubuntu.com/lxd/en/latest/getting_started/ for "
         "instructions on installing and configuring LXD for your operating system.",


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

When checking if lxd is initialized, require the default lxd profile to contain a disk device with a path of `/`.


https://github.com/canonical/craft-providers/issues/429
(CRAFT-2174)