### PR TITLE
ci(github): remove starcraft team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-** @canonical/starcraft


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This reverts https://github.com/canonical/craft-providers/pull/425. 

The codeowners feature is a nuisance - it automatically sends review requests, even when the author is not ready for a PR review.