### PR TITLE
style: migrate from black to ruff for formatting

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -33,9 +33,8 @@ Other tools
 ###########
 Some other tools we use for code quality include:
 
-- Black_ for code formatting
 - pytest_ for testing
-- ruff_ for linting (and some additional formatting)
+- ruff_ for code formatting and linting
 
 A complete list is kept in our pyproject.toml_ file in dev dependencies.
 
@@ -61,11 +60,11 @@ interpreter installed. For example, to run with Python 3.10, run::
 
 While the use of pre-commit_ is optional, it is highly encouraged, as it runs
 automatic fixes for files when ``git commit`` is called, including code
-formatting with ``black`` and ``ruff``.  The versions available in ``apt``
-from Debian 11 (bullseye), Ubuntu 22.04 (jammy) and newer are sufficient, but
-you can also install the latest with ``pip install pre-commit``. Once you've
-installed it, run ``pre-commit install`` in this git repository to install the
-pre-commit hooks.
+formatting with ``ruff``.  The versions available in ``apt`` from Debian 11
+(bullseye), Ubuntu 22.04 (jammy) and newer are sufficient, but you can also
+install the latest with ``pip install pre-commit``. Once you've installed it,
+run ``pre-commit install`` in this git repository to install the pre-commit
+hooks.
 
 Tox environments and labels
 ###########################
@@ -122,7 +121,6 @@ Please follow these guidelines when committing code for this project:
 
 .. _Actions: https://github.com/canonical/craft-providers/actions
 .. _action-tmate: https://mxschmitt.github.io/action-tmate/
-.. _Black: https://black.readthedocs.io
 .. _`Canonical contributor licence agreement`: http://www.ubuntu.com/legal/contributors/
 .. _deadsnakes: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa
 .. _`git submodules`: https://git-scm.com/book/en/v2/Git-Tools-Submodules#_cloning_submodules

--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -1100,7 +1100,7 @@ class Base(ABC):
         # (because we're hitting port 443), as bash's TCP functionality will not
         # use it (supporting both lowercase and uppercase names, which is what
         # most applications do)
-        if os.getenv("HTTPS_PROXY") or os.getenv("https_proxy"):  # noqa: SIM112
+        if os.getenv("HTTPS_PROXY") or os.getenv("https_proxy"):
             return True
 
         # check if the port is open using bash's built-in tcp-client, communicating with

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -1102,8 +1102,8 @@ class LXC:
 
         The possible status are:
         - None: Either the instance is downloading or old that this is not set.
-        - STARTING: Instance is starting, the creation is successful. If it also STOPPED,
-            then there could be a boot issue.
+        - STARTING: Instance is starting, the creation is successful. If it also
+            STOPPED, then there could be a boot issue.
         - PREPARING: Instance is preparing, the boot is successful. If it also STOPPED,
             then the craft-providers or craft-app configuration / installation
             was interrupted or failed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,8 @@ dev = [
     "types-pyyaml==6.0.12.12",
 ]
 lint = [
-    "black==23.10.0",
     "codespell[toml]==2.2.6",
-    "ruff==0.1.1",
+    "ruff==0.1.3",
     "yamllint==1.32.0",
 ]
 types = [
@@ -114,9 +113,6 @@ craft_providers_docs = ["**"]
 
 [tool.distutils.bdist_wheel]
 universal = true
-
-[tool.black]
-target-version = ["py38"]
 
 [tool.codespell]
 ignore-words-list = "buildd,crate,keyserver,comandos,ro,dedent,dedented"
@@ -268,7 +264,6 @@ extend-select = [
 ignore = [
     "ANN10",  # Type annotations for `self` and `cls`
     #"E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
-    "E501",  # Line too long (reason: black will automatically fix this for us)
     "D105",  # Missing docstring in magic method (reason: magic methods already have definitions)
     "D107",  # Missing docstring in __init__ (reason: documented in class docstring)
     "D203",  # 1 blank line required before class docstring (reason: pep257 default)

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -848,7 +848,12 @@ def test_get_assertion_connection_error(mocker):
         snap_installer._get_assertion(["test1", "test2"])
     assert exc_info.value == snap_installer.SnapInstallationError(
         brief="failed to get assertions for snap",
-        details="* Command that failed: 'error'\n* Command exit code: 100\n* Command output: 'snap error'\n* Command standard error output: 'snap error details'",
+        details=(
+            "* Command that failed: 'error'\n"
+            "* Command exit code: 100\n"
+            "* Command output: 'snap error'\n"
+            "* Command standard error output: 'snap error details'"
+        ),
     )
     assert exc_info.value.__cause__ is not None
 
@@ -926,7 +931,13 @@ def test_get_target_snap_revision_from_snapd_process_error(fake_process, fake_ex
         snap_installer._get_target_snap_revision_from_snapd("test-snap", fake_executor)
     assert exc_info.value == snap_installer.SnapInstallationError(
         "Unable to get target snap revision.",
-        details="* Command that failed: 'fake-executor curl --silent --unix-socket /run/snapd.socket http://localhost/v2/snaps/test-snap'\n* Command exit code: 1\n* Command output: b'snap error'\n* Command standard error output: b'snap error details'",
+        details=(
+            "* Command that failed: 'fake-executor curl --silent --unix-socket "
+            "/run/snapd.socket http://localhost/v2/snaps/test-snap'\n"
+            "* Command exit code: 1\n"
+            "* Command output: b'snap error'\n"
+            "* Command standard error output: b'snap error details'"
+        ),
     )
     assert exc_info.value.__cause__ is not None
 

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -995,7 +995,7 @@ def test_launch_failed_retry_check(fake_process, mocker):
 
 
 def test_launch_failed_retry_failed(fake_process, mocker):
-    """Test that we retry launching an instance if it fails, but failed more than 3 times."""
+    """Test retry launching an instance if it fails and failed more than 3 times."""
     mock_launch = mocker.patch("craft_providers.lxd.lxc.LXC._run_lxc")
     mock_launch.side_effect = subprocess.CalledProcessError(1, ["lxc", "fail", " test"])
     mock_check = mocker.patch("craft_providers.lxd.lxc.LXC.check_instance_status")
@@ -1165,7 +1165,13 @@ def test_launch_error(fake_process, mocker):
 
     assert exc_info.value == LXDError(
         brief="Failed to launch instance 'test-instance'.",
-        details="* Command that failed: 'lxc --project test-project launch test-image-remote:test-image test-remote:test-instance --config user.craft_providers.status=STARTING --config user.craft_providers.timer=2023-01-01T00:00:00+00:00'\n* Command exit code: 1",
+        details=(
+            "* Command that failed: 'lxc --project test-project launch "
+            "test-image-remote:test-image test-remote:test-instance "
+            "--config user.craft_providers.status=STARTING --config "
+            "user.craft_providers.timer=2023-01-01T00:00:00+00:00'\n"
+            "* Command exit code: 1"
+        ),
         resolution=None,
     )
 
@@ -1364,8 +1370,15 @@ def test_check_instance_status_lxd_error(fake_process, mocker):
         )
 
     assert exc_info.value == LXDError(
-        brief="Failed to get value for config key 'user.craft_providers.status' for instance 'test-instance'.",
-        details="* Command that failed: 'lxc --project test-project config get test-remote:test-instance user.craft_providers.status'\n* Command exit code: 1",
+        brief=(
+            "Failed to get value for config key 'user.craft_providers.status' for "
+            "instance 'test-instance'."
+        ),
+        details=(
+            "* Command that failed: 'lxc --project test-project config get "
+            "test-remote:test-instance user.craft_providers.status'\n"
+            "* Command exit code: 1"
+        ),
         resolution=None,
     )
 
@@ -1378,7 +1391,10 @@ def test_check_instance_status_lxd_error_retry(fake_process, mocker):
     mock_instance.side_effect = [
         LXDError(
             brief="Failed to get instance info.",
-            details="* Command that failed: 'lxc --project test-project info test-remote:test-instance'\n* Command exit code: 1",
+            details=(
+                "* Command that failed: 'lxc --project test-project info "
+                "test-remote:test-instance'\n* Command exit code: 1"
+            ),
             resolution=None,
         ),
         {"Status": "STOPPED"},
@@ -1386,7 +1402,10 @@ def test_check_instance_status_lxd_error_retry(fake_process, mocker):
         {"Status": "RUNNING"},
         LXDError(
             brief="Failed to get instance info.",
-            details="* Command that failed: 'lxc --project test-project info test-remote:test-instance'\n* Command exit code: 1",
+            details=(
+                "* Command that failed: 'lxc --project test-project info "
+                "test-remote:test-instance'\n* Command exit code: 1"
+            ),
             resolution=None,
         ),
         {"Status": "RUNNING"},
@@ -1398,12 +1417,18 @@ def test_check_instance_status_lxd_error_retry(fake_process, mocker):
     mock_instance_config.side_effect = [
         LXDError(
             brief="Failed to get instance info.",
-            details="* Command that failed: 'lxc --project test-project info test-remote:test-instance'\n* Command exit code: 1",
+            details=(
+                "* Command that failed: 'lxc --project test-project info "
+                "test-remote:test-instance'\n* Command exit code: 1"
+            ),
             resolution=None,
         ),
         LXDError(
             brief="Failed to get instance info.",
-            details="* Command that failed: 'lxc --project test-project info test-remote:test-instance'\n* Command exit code: 1",
+            details=(
+                "* Command that failed: 'lxc --project test-project info "
+                "test-remote:test-instance'\n* Command exit code: 1"
+            ),
             resolution=None,
         ),
         "STARTING",
@@ -1414,7 +1439,10 @@ def test_check_instance_status_lxd_error_retry(fake_process, mocker):
         "2023-01-01T00:00:20+00:00",
         LXDError(
             brief="Failed to get instance info.",
-            details="* Command that failed: 'lxc --project test-project info test-remote:test-instance'\n* Command exit code: 1",
+            details=(
+                "* Command that failed: 'lxc --project test-project info "
+                "test-remote:test-instance'\n* Command exit code: 1"
+            ),
             resolution=None,
         ),
         "FINISHED",

--- a/tests/unit/multipass/test_multipass.py
+++ b/tests/unit/multipass/test_multipass.py
@@ -40,7 +40,8 @@ EXAMPLE_INFO = """\
                     "used": "1339375616"
                 }
             },
-            "image_hash": "c5f2f08c6a1adee1f2f96d84856bf0162d33ea182dae0e8ed45768a86182d110",
+            "image_hash":
+            "c5f2f08c6a1adee1f2f96d84856bf0162d33ea182dae0e8ed45768a86182d110",
             "image_release": "22.04 LTS",
             "ipv4": [
                 "10.114.154.206"

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -178,7 +178,7 @@ def test_mount_shared_cache_dirs(fake_process, fake_base, fake_executor, cache_d
 def test_mount_shared_cache_dirs_mkdir_failed(
     fake_process, fake_base, fake_executor, cache_dir, mocker
 ):
-    """Test mounting of cache directories with a cache directory set, but mkdir failed."""
+    """Test mounting of cache dirs with a cache dir set, but mkdir failed."""
     fake_base._cache_path = cache_dir
     user_cache_dir = pathlib.Path("/root/.cache")
 
@@ -202,7 +202,10 @@ def test_mount_shared_cache_dirs_mkdir_failed(
     [
         (
             [
-                'NAME="AlmaLinux"\nVERSION="9.1 (Lime Lynx)"\nID="almalinux"\nID_LIKE="rhel centos fedora"\nVERSION_ID="9.1"\n'
+                (
+                    'NAME="AlmaLinux"\nVERSION="9.1 (Lime Lynx)"\nID="almalinux"\n'
+                    'ID_LIKE="rhel centos fedora"\nVERSION_ID="9.1"\n'
+                ),
             ],
             {
                 "NAME": "AlmaLinux",
@@ -215,7 +218,10 @@ def test_mount_shared_cache_dirs_mkdir_failed(
         (
             [
                 "",
-                'NAME="AlmaLinux"\nVERSION="9.1 (Lime Lynx)"\nID="almalinux"\nID_LIKE="rhel centos fedora"\nVERSION_ID="9.1"\n',
+                (
+                    'NAME="AlmaLinux"\nVERSION="9.1 (Lime Lynx)"\nID="almalinux"\n'
+                    'ID_LIKE="rhel centos fedora"\nVERSION_ID="9.1"\n'
+                ),
             ],
             {
                 "NAME": "AlmaLinux",
@@ -227,7 +233,10 @@ def test_mount_shared_cache_dirs_mkdir_failed(
         ),
         (
             [
-                'NAME="CentOS Linux"\nVERSION="7 (Core)"\nID="centos"\nID_LIKE="rhel fedora"\nVERSION_ID="7"\n'
+                (
+                    'NAME="CentOS Linux"\nVERSION="7 (Core)"\nID="centos"\n'
+                    'ID_LIKE="rhel fedora"\nVERSION_ID="7"\n'
+                ),
             ],
             {
                 "NAME": "CentOS Linux",
@@ -240,7 +249,10 @@ def test_mount_shared_cache_dirs_mkdir_failed(
         (
             [
                 "",
-                'NAME="CentOS Linux"\nVERSION="7 (Core)"\nID="centos"\nID_LIKE="rhel fedora"\nVERSION_ID="7"\n',
+                (
+                    'NAME="CentOS Linux"\nVERSION="7 (Core)"\nID="centos"\n'
+                    'ID_LIKE="rhel fedora"\nVERSION_ID="7"\n'
+                ),
             ],
             {
                 "NAME": "CentOS Linux",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 env_list =  # Environments to run when called with no parameters.
-    format-{black,ruff,codespell}
+    format-{ruff,codespell}
     pre-commit
-    lint-{black,ruff,mypy,pyright,shellcheck,codespell,docs,yaml}
+    lint-{ruff,mypy,pyright,shellcheck,codespell,docs,yaml}
     unit-py3.{8,10,11}
     integration-py3.10
 minversion = 4.6
@@ -65,7 +65,7 @@ runner = ignore_env_name_mismatch
 find = git ls-files
 filter = file --mime-type -Nnf- | grep shellscript | cut -f1 -d:
 
-[testenv:lint-{black,ruff,shellcheck,codespell,yaml}]
+[testenv:lint-{ruff,shellcheck,codespell,yaml}]
 description = Lint the source code
 base = testenv, lint
 labels = lint
@@ -74,7 +74,7 @@ allowlist_externals =
 commands_pre =
     shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]filter} > {env_tmp_dir}/shellcheck_files'
 commands =
-    black: black --check --diff {tty:--color} {posargs} .
+    ruff: ruff format --check --respect-gitignore {posargs} .
     ruff: ruff check --respect-gitignore {posargs} .
     shellcheck: xargs -ra {env_tmp_dir}/shellcheck_files shellcheck
     codespell: codespell --toml {tox_root}/pyproject.toml {posargs}
@@ -94,13 +94,13 @@ commands =
     pyright: pyright {posargs}
     mypy: mypy --install-types --non-interactive {posargs:.}
 
-[testenv:format-{black,ruff,codespell}]
+[testenv:format-{ruff,codespell}]
 description = Automatically format source code
 base = testenv, lint
 labels = format
 commands =
-    black: black {tty:--color} {posargs} .
-    ruff: ruff --fix --respect-gitignore {posargs} .
+    ruff: ruff format --respect-gitignore {posargs} .
+    ruff: ruff check --fix --respect-gitignore {posargs} .
     codespell: codespell --toml {tox_root}/pyproject.toml --write-changes {posargs}
 
 [testenv:pre-commit]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Move from black to ruff for formatting (more details [here](https://astral.sh/blog/the-ruff-formatter)).

It looks like ruff has done a great job of making a black-compatible formatter.  The only difference in this repo is a warning for strings that exceed the line length.