### PR TITLE
chore(bases): bump compatibility tag to v3

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -97,7 +97,7 @@ class Base(ABC):
     _timeout_unpredictable: Optional[float] = TIMEOUT_UNPREDICTABLE
     _cache_path: Optional[pathlib.Path] = None
     alias: Enum
-    compatibility_tag: str = "base-v2"
+    compatibility_tag: str = "base-v3"
 
     @abstractmethod
     def __init__(

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -39,7 +39,7 @@ def get_base_instance():
     def _base_instance(
         image_name: str = "22.04",
         image_remote: str = "ubuntu",
-        compatibility_tag: str = "buildd-base-v2",
+        compatibility_tag: str = "buildd-base-v3",
         project: str = "default",
     ):
         """Get the base instance."""
@@ -302,7 +302,7 @@ def test_launch_create_base_instance_with_correct_image_description(
 
     assert (
         lxc_result[0]["expanded_config"]["image.description"]
-        == "base-instance-buildd-base-v2-ubuntu-22.04"
+        == "base-instance-buildd-base-v3-ubuntu-22.04"
     )
 
 
@@ -704,7 +704,7 @@ def test_launch_instance_config_incompatible_without_auto_clean(
 
     assert exc_info.value.brief == (
         "Incompatible base detected:"
-        " Expected image compatibility tag 'buildd-base-v2', found 'invalid'."
+        " Expected image compatibility tag 'buildd-base-v3', found 'invalid'."
     )
 
 
@@ -737,7 +737,7 @@ def test_launch_instance_not_setup_without_auto_clean(
     """Raise an error if an existing instance is not setup and auto_clean is False."""
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v3\nsetup: false\n"),
         file_mode="0644",
     )
 
@@ -758,7 +758,7 @@ def test_launch_instance_not_setup_with_auto_clean(base_configuration, core22_in
     """Clean the instance if it is not setup and auto_clean is True."""
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v3\nsetup: false\n"),
         file_mode="0644",
     )
 

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -153,7 +153,7 @@ def test_launch_instance_config_incompatible_instance(core22_instance):
 
     assert exc_info.value.brief == (
         "Incompatible base detected:"
-        " Expected image compatibility tag 'buildd-base-v2', found 'invalid'."
+        " Expected image compatibility tag 'buildd-base-v3', found 'invalid'."
     )
 
     # Retry with auto_clean=True.
@@ -174,7 +174,7 @@ def test_launch_instance_not_setup_without_auto_clean(core22_instance):
 
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v3\nsetup: false\n"),
         file_mode="0644",
     )
 
@@ -196,7 +196,7 @@ def test_launch_instance_not_setup_with_auto_clean(core22_instance):
 
     core22_instance.push_file_io(
         destination=base_configuration._instance_config_path,
-        content=io.BytesIO(b"compatibility_tag: buildd-base-v2\nsetup: false\n"),
+        content=io.BytesIO(b"compatibility_tag: buildd-base-v3\nsetup: false\n"),
         file_mode="0644",
     )
 

--- a/tests/unit/bases/test_almalinux.py
+++ b/tests/unit/bases/test_almalinux.py
@@ -40,7 +40,7 @@ from tests.unit.conftest import DEFAULT_FAKE_CMD
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
-        return_value=InstanceConfiguration(compatibility_tag="almalinux-base-v2"),
+        return_value=InstanceConfiguration(compatibility_tag="almalinux-base-v3"),
     )
 
 
@@ -149,7 +149,7 @@ def mock_get_os_release(mocker):
     ],
 )
 @pytest.mark.parametrize(
-    ("tag", "expected_tag"), [(None, "almalinux-base-v2"), ("test-tag", "test-tag")]
+    ("tag", "expected_tag"), [(None, "almalinux-base-v3"), ("test-tag", "test-tag")]
 )
 def test_setup(
     fake_process,
@@ -653,7 +653,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
         base_config._ensure_instance_config_compatible(executor=fake_executor)
 
     assert exc_info.value == BaseCompatibilityError(
-        "Expected image compatibility tag 'almalinux-base-v2', found 'invalid-tag'"
+        "Expected image compatibility tag 'almalinux-base-v3', found 'invalid-tag'"
     )
 
 
@@ -1056,7 +1056,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
     assert fake_executor.records_of_push_file_io == [
         {
             "content": (
-                "compatibility_tag: almalinux-base-v2\n"
+                "compatibility_tag: almalinux-base-v3\n"
                 f"setup: {str(status).lower()}\n".encode()
             ),
             "destination": "/etc/craft-instance.conf",
@@ -1165,7 +1165,7 @@ def test_warmup_overall(
     environment, fake_process, fake_executor, mock_load, mocker, cache_path
 ):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v2", setup=True
+        compatibility_tag="almalinux-base-v3", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
 
@@ -1220,7 +1220,7 @@ def test_warmup_overall(
 
 def test_warmup_bad_os(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v2", setup=True
+        compatibility_tag="almalinux-base-v3", setup=True
     )
     base_config = almalinux.AlmaLinuxBase(
         alias=almalinux.AlmaLinuxBaseAlias.NINE,
@@ -1245,7 +1245,7 @@ def test_warmup_bad_os(fake_process, fake_executor, mock_load):
 
 def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v2", setup=True
+        compatibility_tag="almalinux-base-v3", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(
@@ -1274,7 +1274,7 @@ def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
 def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
     """Raise a BaseConfigurationError if the instance is not setup."""
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v2", setup=setup
+        compatibility_tag="almalinux-base-v3", setup=setup
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(
@@ -1302,7 +1302,7 @@ def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
 
 def test_warmup_never_ready(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v2", setup=True
+        compatibility_tag="almalinux-base-v3", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(
@@ -1335,7 +1335,7 @@ def test_warmup_never_ready(fake_process, fake_executor, mock_load):
 
 def test_warmup_never_network(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="almalinux-base-v2", setup=True
+        compatibility_tag="almalinux-base-v3", setup=True
     )
     alias = almalinux.AlmaLinuxBaseAlias.NINE
     base_config = almalinux.AlmaLinuxBase(

--- a/tests/unit/bases/test_centos_7.py
+++ b/tests/unit/bases/test_centos_7.py
@@ -40,7 +40,7 @@ from tests.unit.conftest import DEFAULT_FAKE_CMD
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
-        return_value=InstanceConfiguration(compatibility_tag="centos-base-v2"),
+        return_value=InstanceConfiguration(compatibility_tag="centos-base-v3"),
     )
 
 
@@ -150,7 +150,7 @@ def mock_get_os_release(mocker):
     ],
 )
 @pytest.mark.parametrize(
-    ("tag", "expected_tag"), [(None, "centos-base-v2"), ("test-tag", "test-tag")]
+    ("tag", "expected_tag"), [(None, "centos-base-v3"), ("test-tag", "test-tag")]
 )
 def test_setup(
     fake_process,
@@ -603,7 +603,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
         base_config._ensure_instance_config_compatible(executor=fake_executor)
 
     assert exc_info.value == BaseCompatibilityError(
-        "Expected image compatibility tag 'centos-base-v2', found 'invalid-tag'"
+        "Expected image compatibility tag 'centos-base-v3', found 'invalid-tag'"
     )
 
 
@@ -1003,7 +1003,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
     assert fake_executor.records_of_push_file_io == [
         {
             "content": (
-                "compatibility_tag: centos-base-v2\n"
+                "compatibility_tag: centos-base-v3\n"
                 f"setup: {str(status).lower()}\n".encode()
             ),
             "destination": "/etc/craft-instance.conf",
@@ -1112,7 +1112,7 @@ def test_warmup_overall(
     environment, fake_process, fake_executor, mock_load, mocker, cache_path
 ):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v2", setup=True
+        compatibility_tag="centos-base-v3", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
 
@@ -1164,7 +1164,7 @@ def test_warmup_overall(
 
 def test_warmup_bad_os(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v2", setup=True
+        compatibility_tag="centos-base-v3", setup=True
     )
     base_config = centos.CentOSBase(
         alias=centos.CentOSBaseAlias.SEVEN,
@@ -1189,7 +1189,7 @@ def test_warmup_bad_os(fake_process, fake_executor, mock_load):
 
 def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v2", setup=True
+        compatibility_tag="centos-base-v3", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(
@@ -1218,7 +1218,7 @@ def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
 def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
     """Raise a BaseConfigurationError if the instance is not setup."""
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v2", setup=setup
+        compatibility_tag="centos-base-v3", setup=setup
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(
@@ -1246,7 +1246,7 @@ def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
 
 def test_warmup_never_ready(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v2", setup=True
+        compatibility_tag="centos-base-v3", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(
@@ -1279,7 +1279,7 @@ def test_warmup_never_ready(fake_process, fake_executor, mock_load):
 
 def test_warmup_never_network(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="centos-base-v2", setup=True
+        compatibility_tag="centos-base-v3", setup=True
     )
     alias = centos.CentOSBaseAlias.SEVEN
     base_config = centos.CentOSBase(

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -41,7 +41,7 @@ from tests.unit.conftest import DEFAULT_FAKE_CMD
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
-        return_value=InstanceConfiguration(compatibility_tag="buildd-base-v2"),
+        return_value=InstanceConfiguration(compatibility_tag="buildd-base-v3"),
     )
 
 
@@ -146,7 +146,7 @@ def mock_get_os_release(mocker):
     ],
 )
 @pytest.mark.parametrize(
-    ("tag", "expected_tag"), [(None, "buildd-base-v2"), ("test-tag", "test-tag")]
+    ("tag", "expected_tag"), [(None, "buildd-base-v3"), ("test-tag", "test-tag")]
 )
 def test_setup(
     fake_process,
@@ -682,7 +682,7 @@ def test_ensure_image_version_compatible_failure(fake_executor, monkeypatch):
         base_config._ensure_instance_config_compatible(executor=fake_executor)
 
     assert exc_info.value == BaseCompatibilityError(
-        "Expected image compatibility tag 'buildd-base-v2', found 'invalid-tag'"
+        "Expected image compatibility tag 'buildd-base-v3', found 'invalid-tag'"
     )
 
 
@@ -1437,7 +1437,7 @@ def test_update_setup_status(fake_executor, mock_load, status):
     assert fake_executor.records_of_push_file_io == [
         {
             "content": (
-                "compatibility_tag: buildd-base-v2\n"
+                "compatibility_tag: buildd-base-v3\n"
                 f"setup: {str(status).lower()}\n".encode()
             ),
             "destination": "/etc/craft-instance.conf",
@@ -1546,7 +1546,7 @@ def test_warmup_overall(
     environment, fake_process, fake_executor, mock_load, mocker, cache_path
 ):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v2", setup=True
+        compatibility_tag="buildd-base-v3", setup=True
     )
 
     alias = ubuntu.BuilddBaseAlias.JAMMY
@@ -1595,7 +1595,7 @@ def test_warmup_overall(
 
 def test_warmup_bad_os(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v2", setup=True
+        compatibility_tag="buildd-base-v3", setup=True
     )
     base_config = ubuntu.BuilddBase(
         alias=ubuntu.BuilddBaseAlias.JAMMY,
@@ -1620,7 +1620,7 @@ def test_warmup_bad_os(fake_process, fake_executor, mock_load):
 
 def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v2", setup=True
+        compatibility_tag="buildd-base-v3", setup=True
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(
@@ -1649,7 +1649,7 @@ def test_warmup_bad_instance_config(fake_process, fake_executor, mock_load):
 def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
     """Raise a BaseConfigurationError if the instance is not setup."""
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v2", setup=setup
+        compatibility_tag="buildd-base-v3", setup=setup
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(
@@ -1677,7 +1677,7 @@ def test_warmup_not_setup(setup, fake_process, fake_executor, mock_load):
 
 def test_warmup_never_ready(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v2", setup=True
+        compatibility_tag="buildd-base-v3", setup=True
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(
@@ -1709,7 +1709,7 @@ def test_warmup_never_ready(fake_process, fake_executor, mock_load):
 
 def test_warmup_never_network(fake_process, fake_executor, mock_load):
     mock_load.return_value = InstanceConfiguration(
-        compatibility_tag="buildd-base-v2", setup=True
+        compatibility_tag="buildd-base-v3", setup=True
     )
     alias = ubuntu.BuilddBaseAlias.JAMMY
     base_config = ubuntu.BuilddBase(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -161,14 +161,14 @@ def test_mount_shared_cache_dirs(fake_process, fake_base, fake_executor, cache_d
         expected = {
             "host_source": pathlib.WindowsPath("d:")
             / cache_dir
-            / "base-v2"
+            / "base-v3"
             / "FakeBaseAlias.TREBLE"
             / "pip",
             "target": user_cache_dir / "pip",
         }
     else:
         expected = {
-            "host_source": cache_dir / "base-v2" / "FakeBaseAlias.TREBLE" / "pip",
+            "host_source": cache_dir / "base-v3" / "FakeBaseAlias.TREBLE" / "pip",
             "target": user_cache_dir / "pip",
         }
     assert fake_executor.records_of_mount == [expected]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Bump compatibility tag from `v2` to `v3`.

LXD instances created with `craft-providers==1.16.0` may fail to start with `craft-providers>=1.17.0`.

Release vs compatibility tag:
- 1.14 - v1
- 1.15 - v2 ([timer added](https://github.com/canonical/craft-providers/pull/376))
- 1.16 - v2 ([incompatible change made to timer](https://github.com/canonical/craft-providers/pull/376))
- 1.17 - v2
- 1.18 - v2
- 1.19 - v2