### PR TITLE
ci: colorize tox output

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,9 +29,9 @@ jobs:
       - name: Install Tox
         run: pip install tox
       - name: Lint documentation
-        run: tox run -e lint-docs
+        run: tox run --colored yes -e lint-docs
       - name: Build documentation
-        run: tox run -e build-docs
+        run: tox run --colored yes -e build-docs
       - name: Upload documentation
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
           python -m pip install 'tox>=4'
           echo "::endgroup::"
           echo "::group::Create virtual environments for linting processes."
-          tox run -m lint --notest
+          tox run --colored yes -m lint --notest
           echo "::endgroup::"
           echo "::group::Wait for snap to complete"
           snap watch --last=install
@@ -53,7 +53,7 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Run Linters
-        run: tox run --skip-pkg-install --no-list-dependencies -m lint
+        run: tox run --colored yes --skip-pkg-install --no-list-dependencies -m lint
   unit-tests:
     strategy:
       matrix:
@@ -80,15 +80,14 @@ jobs:
           echo "::endgroup::"
           mkdir -p results
       - name: Setup Tox environments
-        run: tox run -m unit-tests --notest
+        run: tox run --colored yes -m unit-tests --notest
       - name: Enable ssh access
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.enable_ssh_access }}
         with:
           limit-access-to-actor: true
       - name: Test with tox
-        # use `tox` instead of `.tox/.tox/bin/tox` to support Windows
-        run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json -m unit-tests
+        run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json --colored yes -m unit-tests
         env:
           PYTEST_ADDOPTS: "--no-header -vv -rN"
       - name: Upload code coverage
@@ -144,7 +143,7 @@ jobs:
           sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
           echo "::endgroup::"
       - name: Setup Tox environments
-        run: tox run -e integration-${{ matrix.python.tox-version }} --notest
+        run: tox run --colored yes -e integration-${{ matrix.python.tox-version }} --notest
       - name: Enable ssh access
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.enable_ssh_access }}
@@ -158,7 +157,7 @@ jobs:
           PYTEST_ADDOPTS: "--no-header -vv -rN"
         run: |
           sg lxd -c "lxc version"
-          sg lxd -c ".tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies -e integration-${{ matrix.python.tox-version }}"
+          sg lxd -c ".tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies --colored yes -e integration-${{ matrix.python.tox-version }}"
   integration-tests-macos:
     strategy:
       matrix:
@@ -190,7 +189,7 @@ jobs:
           done
           echo "::endgroup::"
       - name: Setup Tox environments
-        run: tox run -e integration-py${{ matrix.python }} --notest
+        run: tox run --colored yes -e integration-py${{ matrix.python }} --notest
       - name: Enable ssh access
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.enable_ssh_access }}
@@ -202,4 +201,4 @@ jobs:
           CRAFT_PROVIDERS_TESTS_ENABLE_MULTIPASS_UNINSTALL: 1
           PYTEST_ADDOPTS: "--no-header -vv -rN"
         run: |
-          .tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies -e integration-py${{ matrix.python }}
+          .tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies --colored yes -e integration-py${{ matrix.python }}


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Colorize the output of tox in Github CI.  

Tox does not colorize its output in Github because of the envvar `TERM` is set to `dumb`.  However, github handles colorized output quite nicely.

[Before](https://github.com/canonical/craft-providers/actions/runs/6672145538/job/18135507099#step:6:1)
[After](https://github.com/canonical/craft-providers/actions/runs/6733840789/job/18303418705?pr=442#step:6:1)