### PR TITLE
feat(buildd): add support for ubuntu 24.04

### DIFF
--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -61,6 +61,7 @@ BASE_NAME_TO_BASE_ALIAS: Dict[BaseName, BaseAlias] = {
     BaseName("ubuntu", "22.04"): ubuntu.BuilddBaseAlias.JAMMY,
     BaseName("ubuntu", "23.04"): ubuntu.BuilddBaseAlias.LUNAR,
     BaseName("ubuntu", "23.10"): ubuntu.BuilddBaseAlias.MANTIC,
+    BaseName("ubuntu", "24.04"): ubuntu.BuilddBaseAlias.NOBLE,
     BaseName("ubuntu", "devel"): ubuntu.BuilddBaseAlias.DEVEL,
     BaseName("centos", "7"): centos.CentOSBaseAlias.SEVEN,
     BaseName("almalinux", "9"): almalinux.AlmaLinuxBaseAlias.NINE,

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -45,6 +45,7 @@ class BuilddBaseAlias(enum.Enum):
     JAMMY = "22.04"
     LUNAR = "23.04"
     MANTIC = "23.10"
+    NOBLE = "24.04"
     DEVEL = "devel"
 
 

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -144,6 +144,12 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
         remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
+    ubuntu.BuilddBaseAlias.NOBLE: RemoteImage(
+        image_name="core24",
+        remote_name=DAILY_REMOTE_NAME,
+        remote_address=DAILY_REMOTE_ADDRESS,
+        remote_protocol=ProtocolType.SIMPLESTREAMS,
+    ),
     ubuntu.BuilddBaseAlias.LUNAR: RemoteImage(
         image_name="lunar",
         remote_name=DAILY_REMOTE_NAME,

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -147,7 +147,7 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.NOBLE: RemoteImage(
         image_name="core24",
         remote_name=BUILDD_DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
+        remote_address=BUILDD_DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
     ubuntu.BuilddBaseAlias.LUNAR: RemoteImage(

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -146,7 +146,7 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ),
     ubuntu.BuilddBaseAlias.NOBLE: RemoteImage(
         image_name="core24",
-        remote_name=DAILY_REMOTE_NAME,
+        remote_name=BUILDD_DAILY_REMOTE_NAME,
         remote_address=DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -102,6 +102,9 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
         remote=Remote.RELEASE, image_name="mantic"
     ),
+    ubuntu.BuilddBaseAlias.NOBLE: RemoteImage(
+        remote=Remote.RELEASE, image_name="noble"
+    ),
     # XXX: snapcraft:devel image is not working (LP #2007419)
     # daily:devel image is not available on macos
     ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(remote=Remote.DAILY, image_name="devel"),

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -52,6 +52,9 @@ ALIASES.remove(BuilddBaseAlias.XENIAL)
 def test_launched_environment(alias, installed_multipass, instance_name, tmp_path):
     """Verify `launched_environment()` creates and starts an instance then stops
     the instance when the method loses context."""
+    if sys.platform == "darwin" and alias == BuilddBaseAlias.NOBLE:
+        pytest.skip(reason="Noble on MacOS are not available")
+
     if sys.platform == "darwin" and alias == BuilddBaseAlias.MANTIC:
         pytest.skip(reason="Mantic on MacOS are not available")
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Noble is open for development and all images are now published, all tooling is required to support noble ahead of noble release to actually release noble.

Add Noble as supported base, to be able to build & ship noble.