### PR TITLE
feat(lxd): store and check PID when launching instances

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -314,6 +314,12 @@ def _is_valid(*, instance: LXDInstance, expiration: timedelta) -> bool:
         )
         return False
 
+    try:
+        _wait_for_instance_ready(instance)
+    except LXDError as err:
+        logger.debug("Instance is not valid: %s", err)
+        return False
+
     logger.debug("Instance is valid.")
     return True
 
@@ -814,13 +820,6 @@ def launch(
             lxc=lxc,
         )
         return instance
-
-    # check if the base instance is still being created
-    base_instance.lxc.check_instance_status(
-        instance_name=base_instance.instance_name,
-        project=project,
-        remote=remote,
-    )
 
     # at this point, there is a valid base instance to be copied to a new instance
     logger.info("Creating instance from base instance")

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -270,7 +270,7 @@ def _is_valid(*, instance: LXDInstance, expiration: timedelta) -> bool:
 
     Instances are valid if they are ready and not expired (too old).
     An instance is ready if it is set up and stopped.
-    An instance's age is measured by it's creation date. For example, if the expiration
+    An instance's age is measured by its creation date. For example, if the expiration
     is 90 days, then the instance will expire 91 days after it was created.
 
     If errors occur during the validity check, the instance is assumed to be invalid.

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -1098,7 +1098,12 @@ class LXC:
         project: str = "default",
         remote: str = "local",
     ) -> None:
-        """Check build status of instance.
+        """Repeatedly check if an instance is ready until the function times out.
+
+        If another process is setting up an instance, the instance's timer will keep
+        incrementing. This function will wait until the other process finishes setting
+        up the instance or times out and stops incrementing the timer. In the latter
+        case, a timeout will occur after 60 seconds of the timer not being incremented.
 
         The possible status are:
         - None: Either the instance is downloading or old that this is not set.
@@ -1109,6 +1114,8 @@ class LXC:
             was interrupted or failed.
         - FINISHED: Instance is ready, all configuration and installation is successful.
             When it also STOPPED, then the instance is ready to be copied.
+
+        :raises LXDError: If the instance is not ready.
         """
         instance_status: Optional[str] = None
         instance_info: Dict[str, Any] = {"Status": ""}
@@ -1117,8 +1124,9 @@ class LXC:
         # 20 * 3 seconds = 1 minute no change in timer
         timer_queue: deque = deque([-2, -1], maxlen=20)
 
-        # Retry unless the timer queue is all the same
+        # retry until the instance's timer hasn't changed for the last 20 iterations
         while len(set(timer_queue)) > 1:
+            logger.debug("Checking if instance is ready.")
             try:
                 # Get instance info
                 instance_info = self.info(
@@ -1159,7 +1167,7 @@ class LXC:
                 logger.debug("Instance %s is ready.", instance_name)
                 return
 
+            logger.debug("Instance is not ready.")
             time.sleep(3)
 
-        # No timer change for 1 minute and the instance is still not ready.
-        raise LXDError("Instance setup failed. Check LXD logs for more details.")
+        raise LXDError(brief="Timed out waiting for instance to be ready.")

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -19,6 +19,7 @@
 import contextlib
 import enum
 import logging
+import os
 import pathlib
 import shlex
 import subprocess
@@ -579,6 +580,7 @@ class LXC:
         _default_instance_metadata: Dict[str, str] = {
             "user.craft_providers.status": ProviderInstanceStatus.STARTING.value,
             "user.craft_providers.timer": datetime.now(timezone.utc).isoformat(),
+            "user.craft_providers.pid": str(os.getpid()),
         }
         retry_count: int = 0
         if config_keys:

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -639,3 +639,11 @@ class LXDInstance(Executor):
             project=self.project,
             remote=self.remote,
         )
+
+    def info(self) -> Dict[str, Any]:
+        """Get info for an instance."""
+        return self.lxc.info(
+            instance_name=self.instance_name,
+            project=self.project,
+            remote=self.remote,
+        )

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -17,9 +17,10 @@
 
 import pathlib
 import subprocess
+from datetime import datetime
 
 import pytest
-from craft_providers.lxd import LXDError
+from craft_providers.lxd import LXDError, lxd_instance_status
 
 from . import conftest
 
@@ -30,6 +31,33 @@ def instance(instance_name, session_project):
         name=instance_name, project=session_project
     ) as tmp_instance:
         yield tmp_instance
+
+
+def test_launch_default_config(instance, lxc, session_project):
+    """Verify default config values when launching."""
+    status = lxc.config_get(
+        instance_name=instance,
+        key="user.craft_providers.status",
+        project=session_project,
+    )
+    timer = lxc.config_get(
+        instance_name=instance,
+        key="user.craft_providers.timer",
+        project=session_project,
+    )
+    pid = lxc.config_get(
+        instance_name=instance,
+        key="user.craft_providers.pid",
+        project=session_project,
+    )
+
+    assert status in [
+        status.value for status in lxd_instance_status.ProviderInstanceStatus
+    ]
+    # assert timer is a valid ISO datetime
+    datetime.fromisoformat(timer)
+    # assert PID is an integer
+    int(pid)
 
 
 def test_exec(instance, lxc, session_project):

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -264,3 +264,9 @@ def test_start_stop(reusable_instance):
     reusable_instance.start()
 
     assert reusable_instance.is_running() is True
+
+
+def test_info(reusable_instance):
+    info = reusable_instance.info()
+
+    assert info.get("Name") == reusable_instance.instance_name

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -1493,7 +1493,7 @@ def test_check_instance_status_error_timeout(fake_process, mocker):
         )
 
     assert exc_info.value == LXDError(
-        brief="Instance setup failed. Check LXD logs for more details.",
+        brief="Timed out waiting for instance to be ready."
     )
 
 

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -26,6 +26,11 @@ from craft_providers.lxd.lxc import StdinType
 from freezegun import freeze_time
 
 
+@pytest.fixture()
+def mock_getpid(mocker):
+    return mocker.patch("os.getpid", return_value=123)
+
+
 def test_lxc_run_default(mocker, tmp_path):
     """Test _lxc_run with default arguments."""
     mock_run = mocker.patch("subprocess.run")
@@ -911,6 +916,7 @@ def test_info_parse_error(fake_process):
     )
 
 
+@pytest.mark.usefixtures("mock_getpid")
 def test_launch(fake_process):
     fake_process.register_subprocess(
         [
@@ -924,6 +930,8 @@ def test_launch(fake_process):
             "user.craft_providers.status=STARTING",
             "--config",
             "user.craft_providers.timer=2023-01-01T00:00:00+00:00",
+            "--config",
+            "user.craft_providers.pid=123",
         ]
     )
 
@@ -952,6 +960,7 @@ def test_launch(fake_process):
     assert len(fake_process.calls) == 1
 
 
+@pytest.mark.usefixtures("mock_getpid")
 def test_launch_failed_retry_check(fake_process, mocker):
     """Test that we use check_instance_status if launch fails."""
     mock_launch = mocker.patch("craft_providers.lxd.lxc.LXC._run_lxc")
@@ -980,6 +989,8 @@ def test_launch_failed_retry_check(fake_process, mocker):
                 "user.craft_providers.status=STARTING",
                 "--config",
                 "user.craft_providers.timer=2023-01-01T00:00:00+00:00",
+                "--config",
+                "user.craft_providers.pid=123",
             ],
             capture_output=True,
             stdin=StdinType.INTERACTIVE,
@@ -994,6 +1005,7 @@ def test_launch_failed_retry_check(fake_process, mocker):
     ]
 
 
+@pytest.mark.usefixtures("mock_getpid")
 def test_launch_failed_retry_failed(fake_process, mocker):
     """Test that we retry launching an instance if it fails, but failed more than 3 times."""
     mock_launch = mocker.patch("craft_providers.lxd.lxc.LXC._run_lxc")
@@ -1022,6 +1034,8 @@ def test_launch_failed_retry_failed(fake_process, mocker):
                 "user.craft_providers.status=STARTING",
                 "--config",
                 "user.craft_providers.timer=2023-01-01T00:00:00+00:00",
+                "--config",
+                "user.craft_providers.pid=123",
             ],
             capture_output=True,
             stdin=StdinType.INTERACTIVE,
@@ -1041,6 +1055,8 @@ def test_launch_failed_retry_failed(fake_process, mocker):
                 "user.craft_providers.status=STARTING",
                 "--config",
                 "user.craft_providers.timer=2023-01-01T00:00:00+00:00",
+                "--config",
+                "user.craft_providers.pid=123",
             ],
             capture_output=True,
             stdin=StdinType.INTERACTIVE,
@@ -1060,6 +1076,8 @@ def test_launch_failed_retry_failed(fake_process, mocker):
                 "user.craft_providers.status=STARTING",
                 "--config",
                 "user.craft_providers.timer=2023-01-01T00:00:00+00:00",
+                "--config",
+                "user.craft_providers.pid=123",
             ],
             capture_output=True,
             stdin=StdinType.INTERACTIVE,
@@ -1068,6 +1086,7 @@ def test_launch_failed_retry_failed(fake_process, mocker):
     ]
 
 
+@pytest.mark.usefixtures("mock_getpid")
 def test_launch_all_opts(fake_process):
     fake_process.register_subprocess(
         [
@@ -1086,6 +1105,8 @@ def test_launch_all_opts(fake_process):
             "user.craft_providers.status=STARTING",
             "--config",
             "user.craft_providers.timer=2023-01-01T00:00:00+00:00",
+            "--config",
+            "user.craft_providers.pid=123",
         ]
     )
 
@@ -1116,6 +1137,7 @@ def test_launch_all_opts(fake_process):
     assert len(fake_process.calls) == 1
 
 
+@pytest.mark.usefixtures("mock_getpid")
 def test_launch_error(fake_process, mocker):
     fake_process.register_subprocess(
         [
@@ -1129,6 +1151,8 @@ def test_launch_error(fake_process, mocker):
             "user.craft_providers.status=STARTING",
             "--config",
             "user.craft_providers.timer=2023-01-01T00:00:00+00:00",
+            "--config",
+            "user.craft_providers.pid=123",
         ],
         returncode=1,
         occurrences=4,
@@ -1165,7 +1189,7 @@ def test_launch_error(fake_process, mocker):
 
     assert exc_info.value == LXDError(
         brief="Failed to launch instance 'test-instance'.",
-        details="* Command that failed: 'lxc --project test-project launch test-image-remote:test-image test-remote:test-instance --config user.craft_providers.status=STARTING --config user.craft_providers.timer=2023-01-01T00:00:00+00:00'\n* Command exit code: 1",
+        details="* Command that failed: 'lxc --project test-project launch test-image-remote:test-image test-remote:test-instance --config user.craft_providers.status=STARTING --config user.craft_providers.timer=2023-01-01T00:00:00+00:00 --config user.craft_providers.pid=123'\n* Command exit code: 1",
         resolution=None,
     )
 

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -136,6 +136,18 @@ def test_config_set(mock_lxc, instance):
     ]
 
 
+def test_info(mock_lxc, instance):
+    instance.info()
+
+    assert mock_lxc.mock_calls == [
+        call.info(
+            instance_name="test-instance-fa2d407652a1c51f6019",
+            project="default",
+            remote="local",
+        )
+    ]
+
+
 def test_push_file_io(
     mock_lxc,
     mock_named_temporary_file,


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

The PID of the process that creates an instance is stored in the instance's LXD config and is used when launching an instance.

The `is_valid()` check for base instances now ensures an instance is stopped and has been fully setup.  If another process is busy launching and setting up the base instance, then `is_valid()` will wait (and eventually time out).  If the process that launched the base instance is inactive, then the instance is auto-cleaned (deleted and recreated).

This last statement has a slight behavioral change.  Previously, craft-providers raised a generic error (`Instance setup failed. Check LXD logs for more details`) and required the user to delete the base instance manually.  Now, the bad base instance will be auto-cleaned.  I think this is OK because this aligns with the design of the rest of `launcher` module where errors and misconfigured instances are auto-cleaned.

I recommend reviewing this per-commit.

The base instance has a new config value (the pid), so this must be paired with #465.

Fixes #448
Fixes #455 
(CRAFT-2221)