### PR TITLE
ci(github): disable fast failure for integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -103,6 +103,7 @@ jobs:
           path: results/
   integration-tests-linux:
     strategy:
+      fail-fast: false
       matrix:
         python: [
           {system-version: "3.8", tox-version: "py3.8"},


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Currently, we run 4 integration tests on Linux runners, each for a different version of python.

Often, 1 flaky test will fail and cause all 4 jobs to be canceled.  This is time-consuming for the developer and uses a lot more runners than needed.