### PR TITLE
fix: don't mount cache directories in lxd base instances

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -979,6 +979,7 @@ class Base(ABC):
         *,
         executor: Executor,
         timeout: Optional[float] = TIMEOUT_UNPREDICTABLE,
+        mount_cache: bool = True,
     ) -> None:
         """Prepare base instance for use by the application.
 
@@ -1015,7 +1016,8 @@ class Base(ABC):
 
         self._update_compatibility_tag(executor=executor)
 
-        self._mount_shared_cache_dirs(executor=executor)
+        if mount_cache:
+            self._mount_shared_cache_dirs(executor=executor)
 
         self._pre_setup_os(executor=executor)
         self._setup_os(executor=executor)

--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -143,7 +143,10 @@ def _create_instance(
             )
             config_timer = InstanceTimer(base_instance)
             config_timer.start()
-            base_configuration.setup(executor=base_instance)
+
+            # The base configuration shouldn't mount cache directories because if
+            # they get deleted, copying the base instance will fail.
+            base_configuration.setup(executor=base_instance, mount_cache=False)
             _set_timezone(
                 base_instance,
                 base_instance.project,

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -55,11 +55,12 @@ def get_base_instance():
 
 
 @pytest.fixture()
-def base_configuration():
+def base_configuration(tmp_path):
     """Returns a simple base configuration."""
     return ubuntu.BuilddBase(
         alias=ubuntu.BuilddBaseAlias.JAMMY,
         hostname="test-hostname",
+        cache_path=tmp_path / "cache"
     )
 
 
@@ -224,6 +225,7 @@ def test_launch_use_base_instance(
     # fingerprint the base instance
     base_instance.start()
     base_instance.execute_run(["touch", "/base-instance"])
+    assert base_instance.execute_run(["ls", "/root/.cache/pip/"], check=False).returncode == 2
     base_instance.stop()
 
     # delete the instance so a new instance is created from the base instance
@@ -269,6 +271,8 @@ def test_launch_use_base_instance(
     )
 
     assert instance_hostname == instance.instance_name
+
+    instance.execute_run(["ls", "/root/.cache/pip/"], check=True)
 
 
 def test_launch_create_base_instance_with_correct_image_description(


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
