### PR TITLE
[DRAFT] feat(buildd): use buildd images for mantic and devel

### DIFF
--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -152,14 +152,14 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ),
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
         image_name="mantic",
-        remote_name=DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
+        remote_name=BUILDD_DAILY_REMOTE_NAME,
+        remote_address=BUILDD_DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
     ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(
         image_name="devel",
-        remote_name=DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
+        remote_name=BUILDD_DAILY_REMOTE_NAME,
+        remote_address=BUILDD_DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
     centos.CentOSBaseAlias.SEVEN: RemoteImage(

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -100,11 +100,12 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
         remote=Remote.RELEASE, image_name="lunar"
     ),
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
-        remote=Remote.RELEASE, image_name="mantic"
+        remote=Remote.SNAPCRAFT, image_name="mantic"
     ),
-    # XXX: snapcraft:devel image is not working (LP #2007419)
     # daily:devel image is not available on macos
-    ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(remote=Remote.DAILY, image_name="devel"),
+    ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(
+        remote=Remote.SNAPCRAFT, image_name="devel"
+    ),
 }
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This PR is blocked by https://bugs.launchpad.net/cloud-images/+bug/2007419.

Once it is resolved, craft-providers should be able to use `buildd` images again for 23.10 and onwards.

I will also need to follow up with the Multipass team and see if we can launch `buildd` daily images via multipass.