### PR TITLE
ci(deps): prevent renovate from updating types-requests or urllib3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,10 @@
 {
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:base"],
+  ignoreDeps: [
+    "types-requests",  // Don't update until we can support urllib3 >= 2.0
+    "urllib3",  // Can't update until requests-unixsocket supports urllib3 v2
+  ],
   labels: ["dependencies"],  // For convenient searching in GitHub
   pip_requirements: {
     fileMatch: ["^tox.ini$", "(^|/)requirements([\\w-]*)\\.txt$"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "requests_unixsocket",
     # Needed until requests-unixsocket supports urllib3 v2
     # https://github.com/msabramo/requests-unixsocket/pull/69
+    # When updating this, remove the constraints from renovate.json.
     "urllib3<2",
 ]
 classifiers = [


### PR DESCRIPTION
We can't update these because of requests-unixsocket

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
