### PR TITLE
chore: drop lunar (ubuntu 23.04)

### DIFF
--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -59,7 +59,6 @@ BASE_NAME_TO_BASE_ALIAS: Dict[BaseName, BaseAlias] = {
     BaseName("ubuntu", "18.04"): ubuntu.BuilddBaseAlias.BIONIC,
     BaseName("ubuntu", "20.04"): ubuntu.BuilddBaseAlias.FOCAL,
     BaseName("ubuntu", "22.04"): ubuntu.BuilddBaseAlias.JAMMY,
-    BaseName("ubuntu", "23.04"): ubuntu.BuilddBaseAlias.LUNAR,
     BaseName("ubuntu", "23.10"): ubuntu.BuilddBaseAlias.MANTIC,
     BaseName("ubuntu", "24.04"): ubuntu.BuilddBaseAlias.NOBLE,
     BaseName("ubuntu", "devel"): ubuntu.BuilddBaseAlias.DEVEL,

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -43,7 +43,6 @@ class BuilddBaseAlias(enum.Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
-    LUNAR = "23.04"
     MANTIC = "23.10"
     NOBLE = "24.04"
     DEVEL = "devel"

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -35,11 +35,9 @@ logger = logging.getLogger(__name__)
 BUILDD_RELEASES_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd"
 BUILDD_RELEASES_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/releases"
 
-# XXX: lunar buildd daily images are not working (LP #2007419)
 BUILDD_DAILY_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd-daily"
 BUILDD_DAILY_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/daily"
 
-# temporarily use the cloud release images until daily buildd images are fixed
 DAILY_REMOTE_NAME = "ubuntu-daily"
 DAILY_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/daily"
 
@@ -123,7 +121,6 @@ class RemoteImage:
                 logger.debug("Remote %r was successfully added.", self.remote_name)
 
 
-# XXX: support xenial?
 # mapping from supported bases to actual lxd remote images
 _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.BIONIC: RemoteImage(
@@ -150,18 +147,16 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
         remote_address=BUILDD_DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
-    ubuntu.BuilddBaseAlias.LUNAR: RemoteImage(
-        image_name="lunar",
-        remote_name=DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
-        remote_protocol=ProtocolType.SIMPLESTREAMS,
-    ),
+    # mantic buildd daily blocked by
+    # https://bugs.launchpad.net/cloud-images/+bug/2007419
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
         image_name="mantic",
         remote_name=DAILY_REMOTE_NAME,
         remote_address=DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
+    # devel buildd daily image blocked by
+    # https://github.com/canonical/craft-providers/pull/489
     ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(
         image_name="devel",
         remote_name=DAILY_REMOTE_NAME,

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -96,9 +96,6 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.JAMMY: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="22.04"
     ),
-    ubuntu.BuilddBaseAlias.LUNAR: RemoteImage(
-        remote=Remote.RELEASE, image_name="lunar"
-    ),
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
         remote=Remote.RELEASE, image_name="mantic"
     ),

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -145,7 +145,8 @@ def test_add_remote_race_condition_error(fake_remote_image, mock_lxc, logs):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.LUNAR, "lunar"),
+        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
+        (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )
@@ -163,7 +164,8 @@ def test_get_image_remote(provider_base_alias, image_name):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.LUNAR, "lunar"),
+        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
+        (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Lunar is EOL'd as of January 2024. 