### PR TITLE
fix(ubuntu): ensure apt installs are non-interactive

### DIFF
--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -100,6 +100,15 @@ class BuilddBase(Base):
         else:
             self._environment = environment
 
+        # ensure apt installs are always non-interactive
+        self._environment.update(
+            {
+                "DEBIAN_FRONTEND": "noninteractive",
+                "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                "DEBIAN_PRIORITY": "critical",
+            }
+        )
+
         if compatibility_tag:
             self.compatibility_tag = compatibility_tag
 

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -82,6 +82,9 @@ def mock_get_os_release(mocker):
             (
                 b"PATH=/usr/local/sbin:/usr/local/bin:"
                 b"/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n"
+                b"DEBIAN_FRONTEND=noninteractive\n"
+                b"DEBCONF_NONINTERACTIVE_SEEN=true\n"
+                b"DEBIAN_PRIORITY=critical\n"
             ),
         ),
         (
@@ -93,6 +96,9 @@ def mock_get_os_release(mocker):
             (
                 b"https_proxy=http://foo.bar:8081\n"
                 b"PATH=/snap\nhttp_proxy=http://foo.bar:8080\n"
+                b"DEBIAN_FRONTEND=noninteractive\n"
+                b"DEBCONF_NONINTERACTIVE_SEEN=true\n"
+                b"DEBIAN_PRIORITY=critical\n"
             ),
         ),
     ],


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Set the same environment variables as [craft-parts](https://github.com/canonical/craft-parts/blob/c11570597d4a397aba1744fa08adcd344682246e/craft_parts/packages/deb.py#L488) to ensure packages are installed non-interactively.

Source: https://matrix.to/#/!GGqzbFAUQprdPgYYCM:ubuntu.com/$yww83UdJUJtcD5mURgNA9K1xD9oMrscyZ5HaNqJoU6s?via=ubuntu.com&via=matrix.org&via=gnulinux.club

