### PR TITLE
docs(changelog): add 1.20.2 release notes

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -32,6 +32,7 @@ LXD
 LXDInstance
 LXDInstance's
 LXDProvider
+LTS
 macOS
 Mantic
 multipass

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+1.20.2 (2024-03-15)
+-------------------
+- Parse LXD versions with "LTS" suffix
+
 1.20.1 (2023-11-30)
 -------------------
 - Update base compatibility tag from ``base-v3`` to ``base-v4``


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This release is intended for snapcraft 7.x.  The integration tests will fail to launch almalinux 9, but that's OK because snapcraft doesn't use alma.