### PR TITLE
tests: re-enable alma linux integration tests

### DIFF
--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -45,12 +45,7 @@ def test_create_environment(installed_lxd, instance_name):
     "alias",
     [
         *set(ubuntu.BuilddBaseAlias) - {ubuntu.BuilddBaseAlias.XENIAL},
-        pytest.param(
-            almalinux.AlmaLinuxBaseAlias.NINE,
-            marks=pytest.mark.xfail(
-                strict=True, reason="alma images are not available (#502)"
-            ),
-        ),
+        almalinux.AlmaLinuxBaseAlias.NINE,
     ],
 )
 def test_launched_environment(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

See https://discourse.ubuntu.com/t/new-lxd-image-server-available-images-lxd-canonical-com/43824

Fixes #502