### PR TITLE
fix: check if lxd snap is installed

### DIFF
--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -19,6 +19,8 @@
 
 import logging
 import os
+import pathlib
+import shutil
 import subprocess
 import sys
 
@@ -107,6 +109,13 @@ def is_installed() -> bool:
     """
     logger.debug("Checking if LXD is installed.")
 
+    # check if non-snap lxd socket exists (for Arch or NixOS)
+    if (
+        pathlib.Path("/var/lib/lxd/unix.socket").is_socket()
+        and shutil.which("lxd") is not None
+    ):
+        return True
+
     # query snapd API
     url = "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/lxd"
     try:
@@ -132,7 +141,7 @@ def is_installed() -> bool:
     logger.debug(f"LXD snap status: {status}")
     # snap status can be "installed" or "active" - "installed" revisions
     # are filtered from this API call with `select: enabled`
-    return bool(status == "active")
+    return bool(status == "active") and shutil.which("lxd") is not None
 
 
 def is_user_permitted() -> bool:

--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -110,9 +110,7 @@ def is_installed() -> bool:
     # query snapd API
     url = "http+unix://%2Frun%2Fsnapd.socket/v2/snaps/lxd"
     try:
-        snap_info = requests_unixsocket.get(
-            url=url, params={"select": "enabled"}
-        )
+        snap_info = requests_unixsocket.get(url=url, params={"select": "enabled"})
     except requests.exceptions.ConnectionError as error:
         raise errors.ProviderError(
             brief="Unable to connect to snapd service."
@@ -129,9 +127,7 @@ def is_installed() -> bool:
     try:
         status = snap_info.json()["result"]["status"]
     except KeyError:
-        raise errors.ProviderError(
-            brief="Unexpected response from snapd service."
-        )
+        raise errors.ProviderError(brief="Unexpected response from snapd service.")
 
     logger.debug(f"LXD snap status: {status}")
     # snap status can be "installed" or "active" - "installed" revisions

--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -126,7 +126,7 @@ def is_installed() -> bool:
     # for completeness
     try:
         status = snap_info.json()["result"]["status"]
-    except KeyError:
+    except (TypeError, KeyError):
         raise errors.ProviderError(brief="Unexpected response from snapd service.")
 
     logger.debug(f"LXD snap status: {status}")

--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -56,7 +56,7 @@ def install(sudo: bool = True) -> str:
 
     cmd += ["snap", "install", "lxd"]
 
-    logger.debug("installing lxd")
+    logger.debug("installing LXD")
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as error:
@@ -68,7 +68,7 @@ def install(sudo: bool = True) -> str:
     lxd = LXD()
     lxd.wait_ready(sudo=sudo)
 
-    logger.debug("initializing lxd")
+    logger.debug("initializing LXD")
     lxd.init(auto=True, sudo=sudo)
 
     if not is_user_permitted():

--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 
 import requests
-import requests_unixsocket
+import requests_unixsocket  # type: ignore
 
 from craft_providers.errors import details_from_called_process_error
 

--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -68,7 +68,7 @@ def install(sudo: bool = True) -> str:
     lxd = LXD()
     lxd.wait_ready(sudo=sudo)
 
-    logger.debug("initializing LXD")
+    logger.debug("initialising LXD")
     lxd.init(auto=True, sudo=sudo)
 
     if not is_user_permitted():

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -554,7 +554,7 @@ class LXC:
                 ),
             ) from error
 
-    def launch(  # noqa: PLR0912
+    def launch(
         self,
         *,
         instance_name: str,

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -554,7 +554,7 @@ class LXC:
                 ),
             ) from error
 
-    def launch(
+    def launch(  # noqa: PLR0912
         self,
         *,
         instance_name: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ dynamic = ["version", "readme"]
 dependencies = [
     "packaging>=14.1",
     "pydantic<2.0",
+    # see https://github.com/psf/requests/issues/6707
+    "requests<2.32",
     "pyyaml",
     "requests_unixsocket",
     # Needed until requests-unixsocket supports urllib3 v2

--- a/tests/unit/lxd/test_installer.py
+++ b/tests/unit/lxd/test_installer.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+from typing import Any, Dict
 from unittest import mock
 from unittest.mock import call
 
@@ -316,7 +317,7 @@ def test_is_installed(mocker, status, exception, installed):
         def raise_for_status(self) -> None:
             pass
 
-        def json(self) -> dict[str, any]:
+        def json(self) -> Dict[str, Any]:
             return status
 
     mock_get = mocker.patch("requests_unixsocket.get", return_value=FakeSnapInfo())

--- a/tests/unit/lxd/test_installer.py
+++ b/tests/unit/lxd/test_installer.py
@@ -326,7 +326,7 @@ def test_is_installed(
 
     mock_get = mocker.patch("requests_unixsocket.get", return_value=FakeSnapInfo())
     mocker.patch("pathlib.Path.is_socket", return_value=has_nonsnap_socket)
-    mocker.patch("shutil.which", new=lambda x: "lxd" if has_lxd_executable else None)
+    mocker.patch("shutil.which", return_value="lxd" if has_lxd_executable else None)
 
     if has_nonsnap_socket and has_lxd_executable:
         assert is_installed()

--- a/tests/unit/lxd/test_installer.py
+++ b/tests/unit/lxd/test_installer.py
@@ -333,7 +333,6 @@ def test_is_installed(mocker, status, exception, installed):
     )
 
 
-
 @pytest.mark.skipif(sys.platform != "linux", reason=f"unsupported on {sys.platform}")
 def test_is_user_permitted(mock_os_access):
     mock_os_access.return_value = True


### PR DESCRIPTION
Check if the lxd snap is installed by querying the snapd socket
instead of looking for an executable in the path, as lxd can use
auto-installer stubs.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
