### PR TITLE
build(deps): use the ruff snap

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,6 +37,7 @@ jobs:
           echo "Installing snaps in the background while running apt and pip..."
           sudo snap install --no-wait --classic pyright
           sudo snap install --no-wait shellcheck
+          sudo snap install --no-wait ruff
           echo "::endgroup::"
           echo "::group::pip install"
           python -m pip install 'tox>=4'

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -25,6 +25,7 @@ you with tox, but you'll need to install:
   ``snap install --classic pyright``)
 - ShellCheck_  (also available via snap: ``snap install shellcheck``)
 - pre-commit_
+- ruff_ (also available via snap: ``snap install ruff``)
 
 Once you have all of those installed, you can install the necessary virtual
 environments for this repository using tox.
@@ -35,7 +36,6 @@ Some other tools we use for code quality include:
 
 - Black_ for code formatting
 - pytest_ for testing
-- ruff_ for linting (and some additional formatting)
 
 A complete list is kept in our pyproject.toml_ file in dev dependencies.
 
@@ -130,7 +130,7 @@ Please follow these guidelines when committing code for this project:
 .. _pyproject.toml: ./pyproject.toml
 .. _Pyright: https://github.com/microsoft/pyright
 .. _pytest: https://pytest.org
-.. _ruff: https://github.com/charliermarsh/ruff
+.. _ruff: https://github.com/astral-sh/ruff
 .. _ShellCheck: https://www.shellcheck.net/
 .. _`SSH access is limited`: https://github.com/marketplace/actions/debugging-with-tmate#use-registered-public-ssh-keys
 .. _`SSH key on GitHub`: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dev = [
 lint = [
     "black==24.4.2",
     "codespell[toml]==2.2.6",
-    "ruff==0.4.10",
     "yamllint==1.35.1",
 ]
 types = [

--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,7 @@ base = testenv, lint
 labels = lint
 allowlist_externals =
     shellcheck: bash, xargs
+    ruff: ruff
 commands_pre =
     shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]filter} > {env_tmp_dir}/shellcheck_files'
 commands =
@@ -120,6 +121,8 @@ commands =
 description = Automatically format source code
 base = testenv, lint
 labels = format
+allowlist_externals =
+    ruff: ruff
 commands =
     black: black {tty:--color} {posargs} .
     ruff: ruff --fix --respect-gitignore {posargs} .

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ allowlist_externals =
     ruff: ruff
 commands =
     black: black {tty:--color} {posargs} .
-    ruff: ruff --fix --respect-gitignore {posargs} .
+    ruff: ruff check --fix --respect-gitignore {posargs} .
     codespell: codespell --toml {tox_root}/pyproject.toml --write-changes {posargs}
 
 [testenv:pre-commit]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This replaces a frozen version of ruff from pip with the latest snap of ruff, helping us dogfood our own ecosystem.