### PR TITLE
tests: disable 24.10 integration tests

### DIFF
--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -25,10 +25,30 @@ from contextlib import contextmanager
 from typing import Any, Dict, Optional
 
 import pytest
+from craft_providers.bases import ubuntu
 from craft_providers.lxd import LXC
 from craft_providers.lxd import project as lxc_project
 from craft_providers.lxd.lxd_instance import LXDInstance
 from craft_providers.lxd.lxd_provider import LXDProvider
+
+_xfail_bases = {
+    ubuntu.BuilddBaseAlias.XENIAL: "Fails to setup snapd (#582)",
+    ubuntu.BuilddBaseAlias.ORACULAR: "24.10 fails setup (#598)",
+    ubuntu.BuilddBaseAlias.DEVEL: "24.10 fails setup (#598)",
+}
+"""List of bases that are expected to fail and a reason why."""
+
+UBUNTU_BASES_PARAM = [
+    (
+        pytest.param(
+            base, marks=pytest.mark.xfail(reason=_xfail_bases[base], strict=True)
+        )
+        if base in _xfail_bases
+        else base
+    )
+    for base in ubuntu.BuilddBaseAlias
+]
+"""List of testable Ubuntu bases."""
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022-2023 Canonical Ltd.
+# Copyright 2022-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,8 +17,10 @@
 #
 
 import pytest
-from craft_providers.bases import almalinux, get_base_from_alias, ubuntu
+from craft_providers.bases import almalinux, get_base_from_alias
 from craft_providers.lxd import LXDProvider, is_installed
+
+from .conftest import UBUNTU_BASES_PARAM
 
 
 def test_ensure_provider_is_available_not_installed(uninstalled_lxd):
@@ -42,11 +44,7 @@ def test_create_environment(installed_lxd, instance_name):
 
 
 @pytest.mark.parametrize(
-    "alias",
-    [
-        *set(ubuntu.BuilddBaseAlias) - {ubuntu.BuilddBaseAlias.XENIAL},
-        almalinux.AlmaLinuxBaseAlias.NINE,
-    ],
+    "alias", [*UBUNTU_BASES_PARAM, almalinux.AlmaLinuxBaseAlias.NINE]
 )
 def test_launched_environment(
     alias, installed_lxd, instance_name, tmp_path, session_provider

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,8 @@ import pytest
 from craft_providers import lxd
 from craft_providers.bases import ubuntu
 
+from .conftest import UBUNTU_BASES_PARAM
+
 # The LXD tests can be flaky, erroring out with a BaseCompatibilityError:
 # "Clean incompatible instance and retry the requested operation."
 # This is due to an upstream LXD bug that appears to still be present in LXD 5.14:
@@ -28,10 +30,7 @@ from craft_providers.bases import ubuntu
 pytestmark = pytest.mark.flaky(reruns=3, reruns_delay=2)
 
 
-# exclude XENIAL because it is not supported for LXD
-@pytest.mark.parametrize(
-    "alias", set(ubuntu.BuilddBaseAlias) - {ubuntu.BuilddBaseAlias.XENIAL}
-)
+@pytest.mark.parametrize("alias", UBUNTU_BASES_PARAM)
 def test_configure_and_launch_remote(instance_name, alias):
     """Verify remotes are configured and images can be launched."""
     base_configuration = ubuntu.BuilddBase(alias=alias)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Disable 24.10 tests due to #598.

Long-term failures are common in craft-providers, so I added some fixturing to make this easier to maintain.

Similar to https://github.com/canonical/snapcraft/pull/4922
Fixes #593
(CRAFT-3104)