### PR TITLE
chore: drop Ubuntu 23.10 (Mantic)

### DIFF
--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -59,7 +59,6 @@ BASE_NAME_TO_BASE_ALIAS: Dict[BaseName, BaseAlias] = {
     BaseName("ubuntu", "18.04"): ubuntu.BuilddBaseAlias.BIONIC,
     BaseName("ubuntu", "20.04"): ubuntu.BuilddBaseAlias.FOCAL,
     BaseName("ubuntu", "22.04"): ubuntu.BuilddBaseAlias.JAMMY,
-    BaseName("ubuntu", "23.10"): ubuntu.BuilddBaseAlias.MANTIC,
     BaseName("ubuntu", "24.04"): ubuntu.BuilddBaseAlias.NOBLE,
     BaseName("ubuntu", "24.10"): ubuntu.BuilddBaseAlias.ORACULAR,
     BaseName("ubuntu", "devel"): ubuntu.BuilddBaseAlias.DEVEL,

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -43,7 +43,6 @@ class BuilddBaseAlias(enum.Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
-    MANTIC = "23.10"
     NOBLE = "24.04"
     ORACULAR = "24.10"
     DEVEL = "devel"

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -147,14 +147,6 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
         remote_address=BUILDD_DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
-    # mantic buildd daily blocked by
-    # https://bugs.launchpad.net/cloud-images/+bug/2007419
-    ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
-        image_name="mantic",
-        remote_name=DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
-        remote_protocol=ProtocolType.SIMPLESTREAMS,
-    ),
     ubuntu.BuilddBaseAlias.ORACULAR: RemoteImage(
         image_name="oracular",
         remote_name=BUILDD_DAILY_REMOTE_NAME,

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -96,9 +96,6 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.JAMMY: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="22.04"
     ),
-    ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
-        remote=Remote.RELEASE, image_name="mantic"
-    ),
     # this should use `image_name="24.04"` once noble is released (#511)
     ubuntu.BuilddBaseAlias.NOBLE: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="devel"

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -56,9 +56,6 @@ def test_launched_environment(alias, installed_multipass, instance_name, tmp_pat
     if sys.platform == "darwin" and alias == BuilddBaseAlias.NOBLE:
         pytest.skip(reason="Noble on MacOS are not available")
 
-    if sys.platform == "darwin" and alias == BuilddBaseAlias.MANTIC:
-        pytest.skip(reason="Mantic on MacOS are not available")
-
     if sys.platform == "darwin" and alias == BuilddBaseAlias.DEVEL:
         pytest.skip(reason="snapcraft:devel is not working on MacOS (LP #2007419)")
 

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -145,8 +145,8 @@ def test_add_remote_race_condition_error(fake_remote_image, mock_lxc, logs):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
         (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
+        (ubuntu.BuilddBaseAlias.ORACULAR, "oracular"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )
@@ -164,8 +164,8 @@ def test_get_image_remote(provider_base_alias, image_name):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
         (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
+        (ubuntu.BuilddBaseAlias.ORACULAR, "oracular"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Ubuntu 23.10 reached end of life on 2024-Jul-11.