### PR TITLE
fix(multipass): use Ubuntu 24.04 image

### DIFF
--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -99,9 +99,8 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
         remote=Remote.RELEASE, image_name="mantic"
     ),
-    # this should use `image_name="24.04"` once noble is released (#511)
     ubuntu.BuilddBaseAlias.NOBLE: RemoteImage(
-        remote=Remote.SNAPCRAFT, image_name="devel"
+        remote=Remote.SNAPCRAFT, image_name="24.04"
     ),
     ubuntu.BuilddBaseAlias.ORACULAR: RemoteImage(
         remote=Remote.DAILY, image_name="oracular"


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Use the buildd daily image for 24.04 for the Noble alias with Multipass

Fixes #511
Source: https://matrix.to/#/!GGqzbFAUQprdPgYYCM:ubuntu.com/$222ie8jdhmvzWbHqDyXE8QPgPtr4dUSph0J9T4pD6Xc?via=ubuntu.com&via=matrix.org&via=kde.org