### PR TITLE
tests: update LXD error message

### DIFF
--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -133,8 +133,7 @@ def test_copy_error(instance, instance_name, lxc, session_project):
             f"{instance_name} local:{instance_name}'\n"
             "* Command exit code: 1\n"
             "* Command standard error output: b'Error: Failed creating instance "
-            'record: Add instance info to the database: This "instances" entry '
-            "already exists\\n'"
+            f'record: Instance "{instance_name}" already exists\\n\''
         ),
     )
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This was failing intermittently yesterday and consistently failing today, so this error message probably changed in a progressive release of the LXD snap.

The alternative is to drop this test - craft-providers doesn't need to test an invalid LXD operation as an integration test.