### PR TITLE
style(lint): fix ruff 0.6.0 linting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,7 @@ repos:
       - id: check-toml
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    # renovate: datasource=pypi;depName=ruff
-    rev: "v0.1.7"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -61,7 +61,7 @@ def is_installed_dangerously(snap_name: str) -> bool:
     return get_host_snap_info(snap_name)["revision"].startswith("x")
 
 
-@pytest.fixture()
+@pytest.fixture
 def home_tmp_path():
     """Provide a temporary directory located in user's home directory.
 
@@ -74,7 +74,7 @@ def home_tmp_path():
         yield pathlib.Path(temp_dir)
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance_name():
     """Provide a random name for an instance to launch."""
     return generate_instance_name()
@@ -105,7 +105,7 @@ def installed_lxd():
         pytest.skip("lxd not installed, skipped")
 
 
-@pytest.fixture()
+@pytest.fixture
 def uninstalled_lxd():
     """Uninstall Lxd prior to test, if environment allows it.
 
@@ -150,7 +150,7 @@ def installed_multipass():
         pytest.skip("multipass not installed, skipped")
 
 
-@pytest.fixture()
+@pytest.fixture
 def uninstalled_multipass():
     """Uninstall Multipass prior to test, if environment allows it.
 
@@ -180,7 +180,7 @@ def uninstalled_multipass():
         multipass.install()
 
 
-@pytest.fixture()
+@pytest.fixture
 def core22_lxd_instance(installed_lxd, instance_name):
     """Fully configured buildd-based core22 LXD instance."""
     base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.JAMMY)
@@ -237,7 +237,7 @@ def installed_snap():
     return _installed_snap
 
 
-@pytest.fixture()
+@pytest.fixture
 def dangerously_installed_snap(tmpdir):
     """Fixture to provide contextmanager for a dangerously installed snap.
 

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -56,8 +56,8 @@ def installed_lxd_required(installed_lxd):
     """All LXD integration tests required LXD to be installed."""
 
 
-@pytest.fixture()
-@pytest.mark.with_sudo()
+@pytest.fixture
+@pytest.mark.with_sudo
 def installed_lxd_without_init(uninstalled_lxd):
     """Ensure lxd is installed, but not initialized.
 
@@ -134,18 +134,18 @@ def tmp_instance(
     assert instance_name not in lxc.list_names(project=project, remote=remote)
 
 
-@pytest.fixture()
+@pytest.fixture
 def lxc():
     return LXC()
 
 
-@pytest.fixture()
+@pytest.fixture
 def project_name():
     """Create temporary LXD project and assert expected properties."""
     return "ptest-" + "".join(random.choices(string.ascii_uppercase, k=4))
 
 
-@pytest.fixture()
+@pytest.fixture
 def project(lxc, project_name):
     """Create temporary LXD project and assert expected properties."""
     lxc_project.create_with_default_profile(lxc=lxc, project=project_name)

--- a/tests/integration/lxd/test_launcher.py
+++ b/tests/integration/lxd/test_launcher.py
@@ -54,7 +54,7 @@ def get_base_instance():
     return _base_instance
 
 
-@pytest.fixture()
+@pytest.fixture
 def base_configuration(tmp_path):
     """Returns a simple base configuration."""
     return ubuntu.BuilddBase(
@@ -64,7 +64,7 @@ def base_configuration(tmp_path):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def core22_instance(instance_name):
     """Yields a minimally setup core22 instance.
 
@@ -97,7 +97,7 @@ def core22_instance(instance_name):
             instance.delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_instance_and_base_instance(
     base_configuration, get_base_instance, instance_name
 ):

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -25,7 +25,7 @@ from craft_providers.lxd import LXDError, lxd_instance_status
 from . import conftest
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance(instance_name, session_project):
     with conftest.tmp_instance(
         name=instance_name, project=session_project

--- a/tests/integration/lxd/test_lxd.py
+++ b/tests/integration/lxd/test_lxd.py
@@ -20,7 +20,7 @@ import pytest
 from craft_providers.lxd import LXD
 
 
-@pytest.fixture()
+@pytest.fixture
 def lxd():
     return LXD()
 

--- a/tests/integration/lxd/test_lxd_instance.py
+++ b/tests/integration/lxd/test_lxd_instance.py
@@ -32,7 +32,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance(instance_name, project):
     with conftest.tmp_instance(
         name=instance_name,

--- a/tests/integration/multipass/test_basic.py
+++ b/tests/integration/multipass/test_basic.py
@@ -23,7 +23,7 @@ from craft_providers import multipass
 from craft_providers.bases import ubuntu
 
 
-@pytest.fixture()
+@pytest.fixture
 def simple_file(home_tmp_path):
     """Create a file in the home directory (accessible by Multipass)."""
     file = home_tmp_path / "src.txt"
@@ -31,7 +31,7 @@ def simple_file(home_tmp_path):
     return file
 
 
-@pytest.mark.smoketest()
+@pytest.mark.smoketest
 def test_smoketest(instance_name, home_tmp_path):
     """Launch an instance and run some basic tasks."""
 

--- a/tests/integration/multipass/test_launch.py
+++ b/tests/integration/multipass/test_launch.py
@@ -29,7 +29,7 @@ from . import conftest
 pytestmark = [pytest.mark.xdist_group("multipass_launch_tests")]
 
 
-@pytest.fixture()
+@pytest.fixture
 def core22_instance(instance_name):
     """Yields a minimally setup core22 instance.
 

--- a/tests/integration/multipass/test_multipass.py
+++ b/tests/integration/multipass/test_multipass.py
@@ -24,7 +24,7 @@ from craft_providers.multipass import Multipass
 from . import conftest
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance(instance_name):
     with conftest.tmp_instance(
         instance_name=instance_name,
@@ -32,7 +32,7 @@ def instance(instance_name):
         yield tmp_instance
 
 
-@pytest.fixture()
+@pytest.fixture
 def multipass():
     return Multipass()
 
@@ -181,7 +181,7 @@ def test_transfer_destination_io(instance, multipass, home_tmp_path):
     assert out_path.read_text() == "this is a test"
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_transfer_destination_io_large(instance, multipass, home_tmp_path):
     test_file = home_tmp_path / "test.txt"
 
@@ -224,7 +224,7 @@ def test_transfer_source_io(instance, multipass):
     assert proc.stdout == b"this is a test"
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_transfer_source_io_large(instance, multipass, home_tmp_path):
     test_file = home_tmp_path / "test.txt"
 

--- a/tests/integration/multipass/test_multipass_instance.py
+++ b/tests/integration/multipass/test_multipass_instance.py
@@ -29,7 +29,7 @@ from . import conftest
 pytestmark = pytest.mark.flaky(reruns=3, reruns_delay=2)
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance(instance_name):
     with conftest.tmp_instance(
         instance_name=instance_name,
@@ -46,7 +46,7 @@ def reusable_instance(reusable_instance_name):
         yield MultipassInstance(name=tmp_instance)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simple_file(home_tmp_path):
     """Create a file in the home directory (accessible by Multipass)."""
     file = home_tmp_path / "src.txt"

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -48,7 +48,7 @@ ALIASES = list(BuilddBaseAlias)
 ALIASES.remove(BuilddBaseAlias.XENIAL)
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 @pytest.mark.parametrize("alias", ALIASES)
 def test_launched_environment(alias, installed_multipass, instance_name, tmp_path):
     """Verify `launched_environment()` creates and starts an instance then stops

--- a/tests/unit/actions/test_snap_installer.py
+++ b/tests/unit/actions/test_snap_installer.py
@@ -35,7 +35,7 @@ from craft_providers.instance_config import InstanceConfiguration
 from logassert import Exact  # type: ignore
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_requests():
     """Mock requests_unixsocket."""
     with mock.patch(

--- a/tests/unit/bases/test_almalinux.py
+++ b/tests/unit/bases/test_almalinux.py
@@ -35,7 +35,7 @@ from logassert import Exact  # type: ignore
 from tests.unit.conftest import DEFAULT_FAKE_CMD
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
@@ -43,22 +43,22 @@ def mock_load(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_filesystem(fs):
     return fs
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_install_from_store(mocker):
     return mocker.patch("craft_providers.actions.snap_installer.install_from_store")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_inject_from_host(mocker):
     return mocker.patch("craft_providers.actions.snap_installer.inject_from_host")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_os_release(mocker):
     return mocker.patch.object(
         almalinux.AlmaLinuxBase,

--- a/tests/unit/bases/test_centos_7.py
+++ b/tests/unit/bases/test_centos_7.py
@@ -35,7 +35,7 @@ from logassert import Exact  # type: ignore
 from tests.unit.conftest import DEFAULT_FAKE_CMD
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
@@ -43,22 +43,22 @@ def mock_load(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_filesystem(fs):
     return fs
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_install_from_store(mocker):
     return mocker.patch("craft_providers.actions.snap_installer.install_from_store")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_inject_from_host(mocker):
     return mocker.patch("craft_providers.actions.snap_installer.inject_from_host")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_os_release(mocker):
     return mocker.patch.object(
         centos.CentOSBase,

--- a/tests/unit/bases/test_instance_config.py
+++ b/tests/unit/bases/test_instance_config.py
@@ -26,7 +26,7 @@ from craft_providers.instance_config import InstanceConfiguration
 from pydantic import ValidationError
 
 
-@pytest.fixture()
+@pytest.fixture
 def default_config_data():
     return {
         "compatibility_tag": "tag-foo-v2",
@@ -38,13 +38,13 @@ def default_config_data():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_executor():
     executor_mock = mock.Mock(spec=Executor)
     return executor_mock
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_fixture(fake_home_temporary_file):
     """Creates an instance config file containing data passed to the fixture."""
 

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -36,7 +36,7 @@ from logassert import Exact  # type: ignore
 from tests.unit.conftest import DEFAULT_FAKE_CMD
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_load(mocker):
     return mocker.patch(
         "craft_providers.instance_config.InstanceConfiguration.load",
@@ -44,22 +44,22 @@ def mock_load(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_filesystem(fs):
     return fs
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_install_from_store(mocker):
     return mocker.patch("craft_providers.actions.snap_installer.install_from_store")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_inject_from_host(mocker):
     return mocker.patch("craft_providers.actions.snap_installer.inject_from_host")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_os_release(mocker):
     return mocker.patch.object(
         ubuntu.BuilddBase,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -129,12 +129,12 @@ class FakeExecutor(Executor):
         return True
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_executor():
     return FakeExecutor()
 
 
-@pytest.fixture()
+@pytest.fixture
 def responses():
     """Simple helper to use responses module as a fixture.
 
@@ -181,7 +181,7 @@ def fake_home_temporary_file(monkeypatch, tmp_path):
     return temp_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def stub_verify_network(fake_process):
     """Ensures network check for Executor.execute_run(verify_network=True) succeeds."""
     fake_process.register_subprocess(
@@ -190,7 +190,7 @@ def stub_verify_network(fake_process):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_validation_error():
     """Returns a stubbed ValidationError for pydantic."""
     return ValidationError.from_exception_data(

--- a/tests/unit/lxd/test_installer.py
+++ b/tests/unit/lxd/test_installer.py
@@ -36,7 +36,7 @@ from craft_providers.lxd import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_is_installed():
     with mock.patch(
         "craft_providers.lxd.installer.is_installed", return_value=True
@@ -44,7 +44,7 @@ def mock_is_installed():
         yield mock_is_installed
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_is_user_permitted():
     with mock.patch(
         "craft_providers.lxd.installer.is_user_permitted", return_value=True
@@ -52,7 +52,7 @@ def mock_is_user_permitted():
         yield mock_is_user_permitted
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_is_initialized():
     with mock.patch(
         "craft_providers.lxd.installer.is_initialized", return_value=True
@@ -60,7 +60,7 @@ def mock_is_initialized():
         yield mock_is_initialized
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lxd():
     mock_lxd = mock.Mock(spec=LXD)
     mock_lxd.is_supported_version.return_value = True
@@ -70,7 +70,7 @@ def mock_lxd():
     return mock_lxd
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_os_geteuid():
     with mock.patch.object(
         os, "geteuid", return_value=500, create=True
@@ -78,7 +78,7 @@ def mock_os_geteuid():
         yield mock_os_geteuid
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_os_getgroups():
     with mock.patch.object(
         os, "getgroups", return_value=[], create=True
@@ -86,7 +86,7 @@ def mock_os_getgroups():
         yield mock_os_getgroups
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_os_access():
     with mock.patch.object(
         os, "access", return_value=True, create=True

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -29,7 +29,7 @@ from freezegun import freeze_time
 from logassert import Exact  # type: ignore
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_base_configuration():
     mock_base = Mock(spec=Base)
     mock_base.compatibility_tag = "mock-compat-tag-v200"
@@ -37,19 +37,19 @@ def mock_base_configuration():
     return mock_base
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lxc(mocker):
     _mock_lxc = mocker.patch("craft_providers.lxd.launcher.LXC", spec=lxd.LXC)
     _mock_lxc.return_value.project_list.return_value = ["default", "test-project"]
     return _mock_lxc.return_value
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_platform(mocker):
     mocker.patch("sys.platform", "linux")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_timezone(fake_process):
     fake_process.register_subprocess(
         ["timedatectl", "show", "-p", "Timezone", "--value"],
@@ -58,7 +58,7 @@ def mock_timezone(fake_process):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_instance():
     """Returns a fake LXD Instance"""
     instance = MagicMock()
@@ -73,7 +73,7 @@ def fake_instance():
     return instance
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_base_instance(fake_process):
     """Returns a fake base LXD Instance"""
     base_instance = MagicMock()
@@ -101,7 +101,7 @@ def fake_base_instance(fake_process):
     return base_instance
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lxd_instance(fake_instance, fake_base_instance, mocker):
     """Mock LXD instance to return fake_instance then fake_base_instance."""
     return mocker.patch(
@@ -111,17 +111,17 @@ def mock_lxd_instance(fake_instance, fake_base_instance, mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_is_valid(mocker):
     return mocker.patch("craft_providers.lxd.launcher._is_valid", return_value=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_check_id_map(mocker):
     return mocker.patch("craft_providers.lxd.launcher._check_id_map", return_value=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_disable_timer_update_thread(mocker):
     return mocker.patch("craft_providers.lxd.launcher.InstanceTimer.run")
 

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -26,7 +26,7 @@ from craft_providers.lxd.lxc import StdinType
 from freezegun import freeze_time
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_getpid(mocker):
     return mocker.patch("os.getpid", return_value=123)
 

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -50,7 +50,7 @@ _INVALID_INSTANCE = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def project_path(tmp_path):
     project_path = tmp_path / "git" / "project"
     project_path.mkdir(parents=True)
@@ -82,7 +82,7 @@ def mock_lxc(project_path):
         yield lxc
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_named_temporary_file():
     with mock.patch(
         "craft_providers.lxd.lxd_instance.tempfile.NamedTemporaryFile",
@@ -92,19 +92,19 @@ def mock_named_temporary_file():
         yield mock_tf.return_value
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_shutil_copyfileobj():
     with mock.patch.object(shutil, "copyfileobj") as mock_copyfileobj:
         yield mock_copyfileobj
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_os_unlink():
     with mock.patch.object(os, "unlink") as mock_unlink:
         yield mock_unlink
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance(mock_lxc):
     return LXDInstance(name=_TEST_INSTANCE["name"], lxc=mock_lxc)
 

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -23,7 +23,7 @@ from craft_providers.errors import BaseConfigurationError
 from craft_providers.lxd import LXDError, LXDProvider, LXDUnstableImageError
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_remote_image(mocker):
     _mock_remote_image = mocker.patch("craft_providers.lxd.remotes.RemoteImage")
     _mock_remote_image.image_name = "test-image-name"
@@ -31,7 +31,7 @@ def mock_remote_image(mocker):
     return _mock_remote_image
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_remote_image(mock_remote_image, mocker):
     _mock_get_remote_image = mocker.patch(
         "craft_providers.lxd.lxd_provider.get_remote_image",
@@ -40,7 +40,7 @@ def mock_get_remote_image(mock_remote_image, mocker):
     return _mock_get_remote_image
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_buildd_base_configuration(mocker):
     mock_base_config = mocker.patch(
         "craft_providers.bases.ubuntu.BuilddBase", autospec=True
@@ -50,7 +50,7 @@ def mock_buildd_base_configuration(mocker):
     return mock_base_config
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lxc(mocker):
     return mocker.patch("craft_providers.lxd.LXC", autospec=True)
 
@@ -62,7 +62,7 @@ def mock_ensure_lxd_is_ready(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_install(mocker):
     return mocker.patch("craft_providers.lxd.lxd_provider.install")
 
@@ -74,7 +74,7 @@ def mock_is_installed(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_launch(mocker):
     return mocker.patch("craft_providers.lxd.lxd_provider.launch", autospec=True)
 

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -24,12 +24,12 @@ from craft_providers.bases import ubuntu
 from craft_providers.lxd import remotes
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lxc(mocker):
     return mocker.patch("craft_providers.lxd.launcher.LXC", spec=lxd.LXC)
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_remote_image(mocker):
     return remotes.RemoteImage(
         image_name="test-image-name",
@@ -39,14 +39,14 @@ def fake_remote_image(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_remote_image(mocker):
     return mocker.patch(
         "craft_providers.lxd.remotes.RemoteImage", spec=remotes.RemoteImage
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_get_remote_image(mocker, mock_remote_image):
     return mocker.patch(
         "craft_providers.lxd.remotes.get_remote_image", return_value=mock_remote_image

--- a/tests/unit/multipass/test_installer.py
+++ b/tests/unit/multipass/test_installer.py
@@ -26,7 +26,7 @@ from craft_providers import multipass
 pytestmark = pytest.mark.usefixtures("instant_sleep")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_details_from_process_error():
     details = "<details>"
     with mock.patch(

--- a/tests/unit/multipass/test_launch.py
+++ b/tests/unit/multipass/test_launch.py
@@ -21,12 +21,12 @@ import pytest
 from craft_providers import Base, bases, multipass
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_base_configuration():
     return mock.Mock(spec=Base)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_multipass_instance():
     with mock.patch(
         "craft_providers.multipass._launch.MultipassInstance",

--- a/tests/unit/multipass/test_multipass.py
+++ b/tests/unit/multipass/test_multipass.py
@@ -86,7 +86,7 @@ EXAMPLE_LIST = """\
 """
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_details_from_process_error():
     details = "<details>"
     with mock.patch(
@@ -96,7 +96,7 @@ def mock_details_from_process_error():
         yield mock_details
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_details_from_command_error():
     details = "<details>"
     with mock.patch(

--- a/tests/unit/multipass/test_multipass_instance.py
+++ b/tests/unit/multipass/test_multipass_instance.py
@@ -76,7 +76,7 @@ EXAMPLE_INFO = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def project_path(tmp_path):
     project_path = tmp_path / "git" / "project"
     project_path.mkdir(parents=True)
@@ -99,12 +99,12 @@ def mock_multipass(project_path):
         yield multipass_mock
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance(mock_multipass):
     return MultipassInstance(name="test-instance", multipass=mock_multipass)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simple_file(tmp_path):
     """Create a file in the test directory."""
     file = tmp_path / "src.txt"

--- a/tests/unit/multipass/test_multipass_provider.py
+++ b/tests/unit/multipass/test_multipass_provider.py
@@ -27,7 +27,7 @@ from craft_providers.multipass.multipass_provider import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_buildd_base_configuration(mocker):
     mock_base_config = mocker.patch(
         "craft_providers.bases.ubuntu.BuilddBase", autospec=True
@@ -37,7 +37,7 @@ def mock_buildd_base_configuration(mocker):
     return mock_base_config
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_multipass(mocker):
     return mocker.patch("craft_providers.multipass.Multipass", autospec=True)
 
@@ -50,7 +50,7 @@ def mock_ensure_multipass_is_ready(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_install(mocker):
     return mocker.patch("craft_providers.multipass.multipass_provider.install")
 
@@ -62,14 +62,14 @@ def mock_is_installed(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_launch(mocker):
     return mocker.patch(
         "craft_providers.multipass.multipass_provider.launch", autospec=True
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_remote_image(mocker):
     """Returns a mock RemoteImage object."""
     _mock_remote_image = mocker.patch(

--- a/tests/unit/multipass/test_ready.py
+++ b/tests/unit/multipass/test_ready.py
@@ -26,7 +26,7 @@ from craft_providers.multipass import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_is_installed():
     with mock.patch(
         "craft_providers.multipass._ready.is_installed", return_value=True
@@ -34,7 +34,7 @@ def mock_is_installed():
         yield mock_is_installed
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_multipass():
     mock_client = mock.Mock(spec=Multipass)
     mock_client.is_supported_version.return_value = True

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -61,12 +61,12 @@ class FakeBase(base.Base):
         pass
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_base() -> base.Base:
     return FakeBase()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_executor():
     return mock.Mock(spec=Executor)
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_executor_local_pull(fake_executor):
     """Provide an executor that copies the file locally on 'pull'."""
 
@@ -33,7 +33,7 @@ def fake_executor_local_pull(fake_executor):
     return fake_executor
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_home_temp_file(mocker, tmp_path):
     """Mock `home_temporary_file()`."""
 


### PR DESCRIPTION
Also bumps the pre-commit config to use rolling ruff versions

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
