### PR TITLE
fix: require multipass>=1.14.1 for Ubuntu 24.04 (Noble)

### DIFF
--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -59,7 +59,6 @@ BASE_NAME_TO_BASE_ALIAS: Dict[BaseName, BaseAlias] = {
     BaseName("ubuntu", "18.04"): ubuntu.BuilddBaseAlias.BIONIC,
     BaseName("ubuntu", "20.04"): ubuntu.BuilddBaseAlias.FOCAL,
     BaseName("ubuntu", "22.04"): ubuntu.BuilddBaseAlias.JAMMY,
-    BaseName("ubuntu", "23.10"): ubuntu.BuilddBaseAlias.MANTIC,
     BaseName("ubuntu", "24.04"): ubuntu.BuilddBaseAlias.NOBLE,
     BaseName("ubuntu", "24.10"): ubuntu.BuilddBaseAlias.ORACULAR,
     BaseName("ubuntu", "devel"): ubuntu.BuilddBaseAlias.DEVEL,

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -43,7 +43,6 @@ class BuilddBaseAlias(enum.Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
-    MANTIC = "23.10"
     NOBLE = "24.04"
     ORACULAR = "24.10"
     DEVEL = "devel"

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -147,14 +147,6 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
         remote_address=BUILDD_DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
-    # mantic buildd daily blocked by
-    # https://bugs.launchpad.net/cloud-images/+bug/2007419
-    ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
-        image_name="mantic",
-        remote_name=DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
-        remote_protocol=ProtocolType.SIMPLESTREAMS,
-    ),
     ubuntu.BuilddBaseAlias.ORACULAR: RemoteImage(
         image_name="oracular",
         remote_name=BUILDD_DAILY_REMOTE_NAME,

--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -48,6 +48,7 @@ class Multipass:
     :cvar minimum_required_version: Minimum required version for compatibility.
     """
 
+    # TODO: bump to 1.14.1 once it is released (#638)
     minimum_required_version = "1.7"
 
     def __init__(

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -96,9 +96,6 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.JAMMY: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="22.04"
     ),
-    ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
-        remote=Remote.RELEASE, image_name="mantic"
-    ),
     # this should use `image_name="24.04"` once noble is released (#511)
     ubuntu.BuilddBaseAlias.NOBLE: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="devel"

--- a/tests/integration/lxd/conftest.py
+++ b/tests/integration/lxd/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -25,10 +25,30 @@ from contextlib import contextmanager
 from typing import Any, Dict, Optional
 
 import pytest
+from craft_providers.bases import ubuntu
 from craft_providers.lxd import LXC
 from craft_providers.lxd import project as lxc_project
 from craft_providers.lxd.lxd_instance import LXDInstance
 from craft_providers.lxd.lxd_provider import LXDProvider
+
+_xfail_bases = {
+    ubuntu.BuilddBaseAlias.XENIAL: "Fails to setup snapd (#582)",
+    ubuntu.BuilddBaseAlias.ORACULAR: "24.10 fails setup (#598)",
+    ubuntu.BuilddBaseAlias.DEVEL: "24.10 fails setup (#598)",
+}
+"""List of bases that are expected to fail and a reason why."""
+
+UBUNTU_BASES_PARAM = [
+    (
+        pytest.param(
+            base, marks=pytest.mark.xfail(reason=_xfail_bases[base], strict=True)
+        )
+        if base in _xfail_bases
+        else base
+    )
+    for base in ubuntu.BuilddBaseAlias
+]
+"""List of testable Ubuntu bases."""
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -133,8 +133,7 @@ def test_copy_error(instance, instance_name, lxc, session_project):
             f"{instance_name} local:{instance_name}'\n"
             "* Command exit code: 1\n"
             "* Command standard error output: b'Error: Failed creating instance "
-            'record: Add instance info to the database: This "instances" entry '
-            "already exists\\n'"
+            f'record: Instance "{instance_name}" already exists\\n\''
         ),
     )
 

--- a/tests/integration/lxd/test_lxd_provider.py
+++ b/tests/integration/lxd/test_lxd_provider.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022-2023 Canonical Ltd.
+# Copyright 2022-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,8 +17,10 @@
 #
 
 import pytest
-from craft_providers.bases import almalinux, get_base_from_alias, ubuntu
+from craft_providers.bases import almalinux, get_base_from_alias
 from craft_providers.lxd import LXDProvider, is_installed
+
+from .conftest import UBUNTU_BASES_PARAM
 
 
 def test_ensure_provider_is_available_not_installed(uninstalled_lxd):
@@ -42,11 +44,7 @@ def test_create_environment(installed_lxd, instance_name):
 
 
 @pytest.mark.parametrize(
-    "alias",
-    [
-        *set(ubuntu.BuilddBaseAlias) - {ubuntu.BuilddBaseAlias.XENIAL},
-        almalinux.AlmaLinuxBaseAlias.NINE,
-    ],
+    "alias", [*UBUNTU_BASES_PARAM, almalinux.AlmaLinuxBaseAlias.NINE]
 )
 def test_launched_environment(
     alias, installed_lxd, instance_name, tmp_path, session_provider

--- a/tests/integration/lxd/test_remotes.py
+++ b/tests/integration/lxd/test_remotes.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,8 @@ import pytest
 from craft_providers import lxd
 from craft_providers.bases import ubuntu
 
+from .conftest import UBUNTU_BASES_PARAM
+
 # The LXD tests can be flaky, erroring out with a BaseCompatibilityError:
 # "Clean incompatible instance and retry the requested operation."
 # This is due to an upstream LXD bug that appears to still be present in LXD 5.14:
@@ -28,10 +30,7 @@ from craft_providers.bases import ubuntu
 pytestmark = pytest.mark.flaky(reruns=3, reruns_delay=2)
 
 
-# exclude XENIAL because it is not supported for LXD
-@pytest.mark.parametrize(
-    "alias", set(ubuntu.BuilddBaseAlias) - {ubuntu.BuilddBaseAlias.XENIAL}
-)
+@pytest.mark.parametrize("alias", UBUNTU_BASES_PARAM)
 def test_configure_and_launch_remote(instance_name, alias):
     """Verify remotes are configured and images can be launched."""
     base_configuration = ubuntu.BuilddBase(alias=alias)

--- a/tests/integration/multipass/test_basic.py
+++ b/tests/integration/multipass/test_basic.py
@@ -106,3 +106,29 @@ def test_smoketest(instance_name, home_tmp_path):
 
     # test delete instance
     assert instance.exists() is False
+
+
+@pytest.mark.smoketest()
+def test_multipass_noble_failure(instance_name):
+    """Test that Multipass<1.14.1 fails for Ubuntu 24.04 (Noble).
+
+    This test acts as an xfail - it will start failing once Multipass 1.14.1 is released
+    on homebrew and can be removed (#628).
+    """
+    base_configuration = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.NOBLE)
+    error = (
+        r"Multipass '\d+\.\d+\.\d+' does not support Ubuntu 24\.04 \(Noble\)\.\n"
+        r"Upgrade to Multipass 1\.14\.1 or newer\."
+    )
+
+    assert multipass.is_installed()
+
+    with pytest.raises(multipass.MultipassError, match=error):
+        multipass.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name="snapcraft:core24",
+            cpus=2,
+            disk_gb=8,
+            mem_gb=4,
+        )

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -56,9 +56,6 @@ def test_launched_environment(alias, installed_multipass, instance_name, tmp_pat
     if sys.platform == "darwin" and alias == BuilddBaseAlias.NOBLE:
         pytest.skip(reason="Noble on MacOS are not available")
 
-    if sys.platform == "darwin" and alias == BuilddBaseAlias.MANTIC:
-        pytest.skip(reason="Mantic on MacOS are not available")
-
     if sys.platform == "darwin" and alias == BuilddBaseAlias.DEVEL:
         pytest.skip(reason="snapcraft:devel is not working on MacOS (LP #2007419)")
 

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -145,8 +145,8 @@ def test_add_remote_race_condition_error(fake_remote_image, mock_lxc, logs):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
         (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
+        (ubuntu.BuilddBaseAlias.ORACULAR, "oracular"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )
@@ -164,8 +164,8 @@ def test_get_image_remote(provider_base_alias, image_name):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
         (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
+        (ubuntu.BuilddBaseAlias.ORACULAR, "oracular"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )

--- a/tests/unit/multipass/test_launch.py
+++ b/tests/unit/multipass/test_launch.py
@@ -15,6 +15,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+import re
 from unittest import mock
 
 import pytest
@@ -23,7 +24,9 @@ from craft_providers import Base, bases, multipass
 
 @pytest.fixture()
 def mock_base_configuration():
-    return mock.Mock(spec=Base)
+    _mock_base_configuration = mock.Mock(spec=Base)
+    _mock_base_configuration.alias = bases.BuilddBaseAlias.JAMMY
+    return _mock_base_configuration
 
 
 @pytest.fixture()
@@ -123,4 +126,65 @@ def test_launch_with_existing_instance_incompatible_without_auto_clean(
     ]
     assert mock_base_configuration.mock_calls == [
         mock.call.warmup(executor=mock_multipass_instance)
+    ]
+
+
+@pytest.mark.parametrize("exists", [True, False])
+@pytest.mark.parametrize("version", ["1.13.0", "1.14.0"])
+def test_noble_less_than_minimum_version(
+    fake_process, exists, version, mock_base_configuration, mock_multipass_instance
+):
+    mock_multipass_instance.exists.return_value = exists
+    mock_base_configuration.alias = bases.BuilddBaseAlias.NOBLE
+    mock_multipass_instance._multipass = mock.Mock(spec=multipass.Multipass)
+    mock_multipass_instance._multipass.version.return_value = (
+        version,
+        version,
+    )
+    fake_process.register_subprocess(
+        ["multipass", "version"],
+        stdout=f"multipass  {version}\nmultipassd {version}\n".encode(),
+    )
+    error = re.escape(
+        f"Multipass {version!r} does not support Ubuntu 24.04 (Noble).\n"
+        "Upgrade to Multipass 1.14.1 or newer."
+    )
+
+    with pytest.raises(multipass.MultipassError, match=error):
+        multipass.launch(
+            "test-instance",
+            base_configuration=mock_base_configuration,
+            image_name="24.04",
+        )
+
+
+@pytest.mark.parametrize("version", ["1.14.1", "1.15.0", "1.15.1", "1.16.0"])
+def test_noble_greater_or_equal_to_minimum_version(
+    fake_process, version, mock_base_configuration, mock_multipass_instance
+):
+    mock_multipass_instance.exists.return_value = False
+    mock_base_configuration.alias = bases.BuilddBaseAlias.NOBLE
+    mock_multipass_instance._multipass = mock.Mock(spec=multipass.Multipass)
+    mock_multipass_instance._multipass.version.return_value = (
+        version,
+        version,
+    )
+    fake_process.register_subprocess(
+        ["multipass", "version"],
+        stdout=f"multipass  {version}\nmultipassd {version}\n".encode(),
+    )
+
+    multipass.launch(
+        "test-instance",
+        base_configuration=mock_base_configuration,
+        image_name="24.04",
+    )
+
+    assert mock_multipass_instance.mock_calls == [
+        mock.call._multipass.version(),
+        mock.call.exists(),
+        mock.call.launch(cpus=2, disk_gb=64, mem_gb=2, image="24.04"),
+    ]
+    assert mock_base_configuration.mock_calls == [
+        mock.call.setup(executor=mock_multipass_instance)
     ]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Require Multipass>=`1.14.1` for launching Ubuntu 24.04 (Noble).  

Previously, Multipass had been using the `snapcraft:devel` alias for 24.04 images (#602).  This worked until last month when the `devel` alias started pointing to `24.10` images.

Once Multipass `1.14.1` is released to `latest/stable` and to homebrew, this can be reverted and the minimum Multipass version will be bumped to `1.14.1` (#638).

Fixes #628
(CRAFT-3270)