### PR TITLE
feat: enabled pro services on managed LXD instance

### DIFF
--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -1218,3 +1218,46 @@ class LXC:
                 brief=f"Failed to run `pro` command on {instance_name!r}.",
                 details=errors.details_from_called_process_error(error),
             ) from error
+
+    def enable_pro_service(
+        self,
+        *,
+        instance_name: str,
+        service: str,
+        project: str = "default",
+        remote: str = "local",
+    ) -> None:
+        """Enable a Pro service on the instance.
+
+        :param instance_name: Name of instance.
+        :param service: Name of a single service to enable.
+        :param project: Name of LXD project.
+        :param remote: Name of LXD remote.
+
+        :raises LXDError: on unexpected error.
+        """
+        command = [
+            "pro",
+            "api",
+            f"{remote}:{instance_name}",
+            "u.pro.services.enable.v1",
+            "--data",
+            json.dumps({"service": service}),
+        ]
+        try:
+            self._run_lxc(
+                command,
+                capture_output=True,
+                project=project,
+            )
+
+            logger.debug(f"Pro service {service!r} successfully enabled on instance.")
+        except json.JSONDecodeError as error:
+            raise LXDError(
+                brief=f"Failed to parse JSON response of `pro` command on {instance_name!r}.",
+            ) from error
+        except subprocess.CalledProcessError as error:
+            raise LXDError(
+                brief=f"Failed to enable Pro service {service!r} on instance {instance_name!r}.",
+                details=errors.details_from_called_process_error(error),
+            ) from error

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -1237,9 +1237,11 @@ class LXC:
         :raises LXDError: on unexpected error.
         """
         command = [
+            "exec",
+            f"{remote}:{instance_name}",
+            "--",
             "pro",
             "api",
-            f"{remote}:{instance_name}",
             "u.pro.services.enable.v1",
             "--data",
             json.dumps({"service": service}),
@@ -1251,6 +1253,9 @@ class LXC:
                 project=project,
             )
 
+            # No need to parse the output here, as an output with
+            # "result": "failure" will also have a return code != 0
+            # hence triggering a CalledProcesssError exception
             logger.debug(f"Pro service {service!r} successfully enabled on instance.")
         except json.JSONDecodeError as error:
             raise LXDError(

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -28,7 +28,7 @@ import threading
 import time
 from collections import deque
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 import yaml
 
@@ -1276,46 +1276,49 @@ class LXC:
         self,
         *,
         instance_name: str,
-        service: str,
+        services: Iterable[str],
         project: str = "default",
         remote: str = "local",
     ) -> None:
         """Enable a Pro service on the instance.
 
         :param instance_name: Name of instance.
-        :param service: Name of a single service to enable.
+        :param services: Name of services to enable.
         :param project: Name of LXD project.
         :param remote: Name of LXD remote.
 
         :raises LXDError: on unexpected error.
         """
-        command = [
-            "exec",
-            f"{remote}:{instance_name}",
-            "--",
-            "pro",
-            "api",
-            "u.pro.services.enable.v1",
-            "--data",
-            json.dumps({"service": service}),
-        ]
-        try:
-            self._run_lxc(
-                command,
-                capture_output=True,
-                project=project,
-            )
+        for service in services:
+            command = [
+                "exec",
+                f"{remote}:{instance_name}",
+                "--",
+                "pro",
+                "api",
+                "u.pro.services.enable.v1",
+                "--data",
+                json.dumps({"service": service}),
+            ]
+            try:
+                self._run_lxc(
+                    command,
+                    capture_output=True,
+                    project=project,
+                )
 
-            # No need to parse the output here, as an output with
-            # "result": "failure" will also have a return code != 0
-            # hence triggering a CalledProcesssError exception
-            logger.debug(f"Pro service {service!r} successfully enabled on instance.")
-        except json.JSONDecodeError as error:
-            raise LXDError(
-                brief=f"Failed to parse JSON response of `pro` command on {instance_name!r}.",
-            ) from error
-        except subprocess.CalledProcessError as error:
-            raise LXDError(
-                brief=f"Failed to enable Pro service {service!r} on instance {instance_name!r}.",
-                details=errors.details_from_called_process_error(error),
-            ) from error
+                # No need to parse the output here, as an output with
+                # "result": "failure" will also have a return code != 0
+                # hence triggering a CalledProcesssError exception
+                logger.debug(
+                    f"Pro service {service!r} successfully enabled on instance."
+                )
+            except json.JSONDecodeError as error:
+                raise LXDError(
+                    brief=f"Failed to parse JSON response of `pro` command on {instance_name!r}.",
+                ) from error
+            except subprocess.CalledProcessError as error:
+                raise LXDError(
+                    brief=f"Failed to enable Pro service {service!r} on instance {instance_name!r}.",
+                    details=errors.details_from_called_process_error(error),
+                ) from error

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -660,3 +660,17 @@ class LXDInstance(Executor):
             project=self.project,
             remote=self.remote,
         )
+
+    def enable_pro_service(self, service: str) -> None:
+        """Enable a Pro service on the instance.
+
+        :param service: Pro service to enable.
+
+        :raises: LXDError: On unexpected error.
+        """
+        self.lxc.enable_pro_service(
+            instance_name=self.instance_name,
+            service=service,
+            project=self.project,
+            remote=self.remote,
+        )

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -26,7 +26,7 @@ import re
 import shutil
 import subprocess
 import tempfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from craft_providers import pro
 from craft_providers.const import TIMEOUT_SIMPLE
@@ -671,16 +671,16 @@ class LXDInstance(Executor):
             remote=self.remote,
         )
 
-    def enable_pro_service(self, service: str) -> None:
+    def enable_pro_service(self, services: Iterable[str]) -> None:
         """Enable a Pro service on the instance.
 
-        :param service: Pro service to enable.
+        :param services: Pro services to enable.
 
         :raises: LXDError: On unexpected error.
         """
         self.lxc.enable_pro_service(
             instance_name=self.instance_name,
-            service=service,
+            services=services,
             project=self.project,
             remote=self.remote,
         )

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -304,3 +304,17 @@ def test_is_pro_enabled_alma(instance_alma, lxc, session_project):
         )
 
     assert raised.value.brief == (f"Failed to run `pro` command on {instance_alma!r}.")
+
+
+def test_enable_pro_service(instance, lxc, session_project):
+    """Test the scenario where Pro client is not installed."""
+    with pytest.raises(LXDError) as raised:
+        lxc.enable_pro_service(
+            instance_name=instance,
+            service="esm-infra",
+            project=session_project,
+        )
+
+    assert raised.value.brief == (
+        f"Failed to enable Pro service 'esm-infra' on instance {instance!r}."
+    )

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -325,7 +325,7 @@ def test_enable_pro_service(instance, lxc, session_project):
     with pytest.raises(LXDError) as raised:
         lxc.enable_pro_service(
             instance_name=instance,
-            service="esm-infra",
+            services=["esm-infra"],
             project=session_project,
         )
 

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -2818,18 +2818,34 @@ def test_enable_pro_service_success(fake_process):
         ],
         stdout=b"""{"_schema_version": "v1", "data": {"attributes": {"disabled": [], "enabled": ["esm-infra"], "messages": [], "reboot_required": false}, "meta": {"environment_vars": []}, "type": "EnableService"}, "errors": [], "result": "success", "version": "32.3.1~24.04", "warnings": []}""",
     )
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "exec",
+            "test-remote:test-instance",
+            "--",
+            "pro",
+            "api",
+            "u.pro.services.enable.v1",
+            "--data",
+            '{"service": "esm-apps"}',
+        ],
+        stdout=b"""{"_schema_version": "v1", "data": {"attributes": {"disabled": [], "enabled": ["esm-apps"], "messages": [], "reboot_required": false}, "meta": {"environment_vars": []}, "type": "EnableService"}, "errors": [], "result": "success", "version": "32.3.1~24.04", "warnings": []}""",
+    )
 
     assert (
         LXC().enable_pro_service(
             instance_name="test-instance",
-            service="esm-infra",
+            services=["esm-infra", "esm-apps"],
             project="test-project",
             remote="test-remote",
         )
         is None
     )
 
-    assert len(fake_process.calls) == 1
+    assert len(fake_process.calls) == 2
 
 
 def test_enable_pro_service_failed(fake_process):
@@ -2854,7 +2870,7 @@ def test_enable_pro_service_failed(fake_process):
     with pytest.raises(LXDError) as exc_info:
         LXC().enable_pro_service(
             instance_name="test-instance",
-            service="invalid",
+            services=["invalid"],
             project="test-project",
             remote="test-remote",
         )
@@ -2888,7 +2904,7 @@ def test_enable_pro_service_process_error(fake_process):
     with pytest.raises(LXDError) as exc_info:
         LXC().enable_pro_service(
             instance_name="test-instance",
-            service="esm-infra",
+            services=["esm-infra"],
             project="test-project",
             remote="test-remote",
         )

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -1065,12 +1065,12 @@ def test_is_pro_enabled(mock_lxc, instance):
 
 
 def test_enable_pro_service(mock_lxc, instance):
-    instance.enable_pro_service("esm-apps")
+    instance.enable_pro_service(["esm-apps"])
 
     assert mock_lxc.mock_calls == [
         mock.call.enable_pro_service(
             instance_name=instance.instance_name,
-            service="esm-apps",
+            services=["esm-apps"],
             project=instance.project,
             remote=instance.remote,
         )

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -1062,3 +1062,16 @@ def test_is_pro_enabled(mock_lxc, instance):
             remote=instance.remote,
         )
     ]
+
+
+def test_enable_pro_service(mock_lxc, instance):
+    instance.enable_pro_service("esm-apps")
+
+    assert mock_lxc.mock_calls == [
+        mock.call.enable_pro_service(
+            instance_name=instance.instance_name,
+            service="esm-apps",
+            project=instance.project,
+            remote=instance.remote,
+        )
+    ]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This is a part of a series of adding Pro features to craft libraries.
This PR adds the functionality of enabling a single Pro service on a managed LXD instance.