### PR TITLE
build(deps): replace requests-unixsocket with requests-unixsocket2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -135,7 +135,7 @@ jobs:
           echo "::group::Configure LXD"
           sudo groupadd --force --system lxd
           sudo usermod --append --groups lxd $USER
-          sudo snap refresh lxd --channel=latest/stable
+          sudo snap refresh lxd --channel=5.21/stable
           sudo snap start lxd
           sudo lxd waitready --timeout=30
           sudo lxd init --auto
@@ -163,7 +163,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.11"]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Install Multipass
         run: |

--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -59,7 +59,6 @@ BASE_NAME_TO_BASE_ALIAS: Dict[BaseName, BaseAlias] = {
     BaseName("ubuntu", "18.04"): ubuntu.BuilddBaseAlias.BIONIC,
     BaseName("ubuntu", "20.04"): ubuntu.BuilddBaseAlias.FOCAL,
     BaseName("ubuntu", "22.04"): ubuntu.BuilddBaseAlias.JAMMY,
-    BaseName("ubuntu", "23.10"): ubuntu.BuilddBaseAlias.MANTIC,
     BaseName("ubuntu", "devel"): ubuntu.BuilddBaseAlias.DEVEL,
     BaseName("centos", "7"): centos.CentOSBaseAlias.SEVEN,
     BaseName("almalinux", "9"): almalinux.AlmaLinuxBaseAlias.NINE,

--- a/craft_providers/bases/__init__.py
+++ b/craft_providers/bases/__init__.py
@@ -59,7 +59,6 @@ BASE_NAME_TO_BASE_ALIAS: Dict[BaseName, BaseAlias] = {
     BaseName("ubuntu", "18.04"): ubuntu.BuilddBaseAlias.BIONIC,
     BaseName("ubuntu", "20.04"): ubuntu.BuilddBaseAlias.FOCAL,
     BaseName("ubuntu", "22.04"): ubuntu.BuilddBaseAlias.JAMMY,
-    BaseName("ubuntu", "23.04"): ubuntu.BuilddBaseAlias.LUNAR,
     BaseName("ubuntu", "23.10"): ubuntu.BuilddBaseAlias.MANTIC,
     BaseName("ubuntu", "devel"): ubuntu.BuilddBaseAlias.DEVEL,
     BaseName("centos", "7"): centos.CentOSBaseAlias.SEVEN,

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -43,7 +43,6 @@ class BuilddBaseAlias(enum.Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
-    LUNAR = "23.04"
     MANTIC = "23.10"
     DEVEL = "devel"
 

--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -43,7 +43,6 @@ class BuilddBaseAlias(enum.Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
-    MANTIC = "23.10"
     DEVEL = "devel"
 
 

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -35,11 +35,9 @@ logger = logging.getLogger(__name__)
 BUILDD_RELEASES_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd"
 BUILDD_RELEASES_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/releases"
 
-# XXX: lunar buildd daily images are not working (LP #2007419)
 BUILDD_DAILY_REMOTE_NAME = "craft-com.ubuntu.cloud-buildd-daily"
 BUILDD_DAILY_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/buildd/daily"
 
-# temporarily use the cloud release images until daily buildd images are fixed
 DAILY_REMOTE_NAME = "ubuntu-daily"
 DAILY_REMOTE_ADDRESS = "https://cloud-images.ubuntu.com/daily"
 
@@ -123,7 +121,6 @@ class RemoteImage:
                 logger.debug("Remote %r was successfully added.", self.remote_name)
 
 
-# XXX: support xenial?
 # mapping from supported bases to actual lxd remote images
 _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.BIONIC: RemoteImage(
@@ -144,18 +141,14 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
         remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
-    ubuntu.BuilddBaseAlias.LUNAR: RemoteImage(
-        image_name="lunar",
-        remote_name=DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
-        remote_protocol=ProtocolType.SIMPLESTREAMS,
-    ),
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
         image_name="mantic",
         remote_name=DAILY_REMOTE_NAME,
         remote_address=DAILY_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
+    # devel buildd daily image blocked by
+    # https://github.com/canonical/craft-providers/pull/489
     ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(
         image_name="devel",
         remote_name=DAILY_REMOTE_NAME,

--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -141,14 +141,6 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
         remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
-    ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
-        image_name="mantic",
-        remote_name=DAILY_REMOTE_NAME,
-        remote_address=DAILY_REMOTE_ADDRESS,
-        remote_protocol=ProtocolType.SIMPLESTREAMS,
-    ),
-    # devel buildd daily image blocked by
-    # https://github.com/canonical/craft-providers/pull/489
     ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(
         image_name="devel",
         remote_name=DAILY_REMOTE_NAME,

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -96,9 +96,6 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.JAMMY: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="22.04"
     ),
-    ubuntu.BuilddBaseAlias.LUNAR: RemoteImage(
-        remote=Remote.RELEASE, image_name="lunar"
-    ),
     ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
         remote=Remote.RELEASE, image_name="mantic"
     ),

--- a/craft_providers/multipass/multipass_provider.py
+++ b/craft_providers/multipass/multipass_provider.py
@@ -96,12 +96,10 @@ _BUILD_BASE_TO_MULTIPASS_REMOTE_IMAGE: Dict[Enum, RemoteImage] = {
     ubuntu.BuilddBaseAlias.JAMMY: RemoteImage(
         remote=Remote.SNAPCRAFT, image_name="22.04"
     ),
-    ubuntu.BuilddBaseAlias.MANTIC: RemoteImage(
-        remote=Remote.RELEASE, image_name="mantic"
+    # devel images are not available on macos
+    ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(
+        remote=Remote.SNAPCRAFT, image_name="devel"
     ),
-    # XXX: snapcraft:devel image is not working (LP #2007419)
-    # daily:devel image is not available on macos
-    ubuntu.BuilddBaseAlias.DEVEL: RemoteImage(remote=Remote.DAILY, image_name="devel"),
 }
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,8 +5,12 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
-1.20.3 (2024-04-11)
+1.20.4 (2024-09-27)
+-------------------
+- ``requests-unixsocket`` dependency is replaced with ``requests-unixsocket2``
 
+1.20.3 (2024-04-11)
+-------------------
 - Do not mount cache directories in LXD base instances.
 - Update base compatibility tag from ``base-v4`` to ``base-v8``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,8 @@ dependencies = [
     "packaging>=14.1",
     "pydantic<2.0",
     "pyyaml",
-    "requests_unixsocket",
-    # Needed until requests-unixsocket supports urllib3 v2
-    # https://github.com/msabramo/requests-unixsocket/pull/69
-    "urllib3<2",
+    "requests>=2.31",
+    "requests_unixsocket2>=0.4.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -133,8 +133,7 @@ def test_copy_error(instance, instance_name, lxc, session_project):
             f"{instance_name} local:{instance_name}'\n"
             "* Command exit code: 1\n"
             "* Command standard error output: b'Error: Failed creating instance "
-            'record: Add instance info to the database: This "instances" entry '
-            "already exists\\n'"
+            f'record: Instance "{instance_name}" already exists\\n\''
         ),
     )
 

--- a/tests/integration/multipass/test_multipass_provider.py
+++ b/tests/integration/multipass/test_multipass_provider.py
@@ -53,9 +53,6 @@ ALIASES.remove(BuilddBaseAlias.XENIAL)
 def test_launched_environment(alias, installed_multipass, instance_name, tmp_path):
     """Verify `launched_environment()` creates and starts an instance then stops
     the instance when the method loses context."""
-    if sys.platform == "darwin" and alias == BuilddBaseAlias.MANTIC:
-        pytest.skip(reason="Mantic on MacOS are not available")
-
     if sys.platform == "darwin" and alias == BuilddBaseAlias.DEVEL:
         pytest.skip(reason="snapcraft:devel is not working on MacOS (LP #2007419)")
 

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -145,7 +145,8 @@ def test_add_remote_race_condition_error(fake_remote_image, mock_lxc, logs):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.LUNAR, "lunar"),
+        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
+        (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )
@@ -163,7 +164,8 @@ def test_get_image_remote(provider_base_alias, image_name):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.LUNAR, "lunar"),
+        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
+        (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )

--- a/tests/unit/lxd/test_remotes.py
+++ b/tests/unit/lxd/test_remotes.py
@@ -145,8 +145,6 @@ def test_add_remote_race_condition_error(fake_remote_image, mock_lxc, logs):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
-        (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )
@@ -164,8 +162,6 @@ def test_get_image_remote(provider_base_alias, image_name):
         (ubuntu.BuilddBaseAlias.BIONIC, "core18"),
         (ubuntu.BuilddBaseAlias.FOCAL, "core20"),
         (ubuntu.BuilddBaseAlias.JAMMY, "core22"),
-        (ubuntu.BuilddBaseAlias.MANTIC, "mantic"),
-        (ubuntu.BuilddBaseAlias.NOBLE, "core24"),
         (ubuntu.BuilddBaseAlias.DEVEL, "devel"),
     ],
 )


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

This backports the `requests-unixsocket2` change to 1.20, which is used by both Snapcraft 7 and Charmcraft 2