### PR TITLE
fix: get assertions for aliased snaps

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -259,7 +259,7 @@ def _get_assertions_file(
             "public-key-sha3-384=BWDEoaqyr25nF5SNCvEv2v"
             "7QnM9QsfCc0PBMYD_i2NGSQ32EF2d4D0hqUel3m8ul",
         ],
-        ["snap-declaration", f"snap-name={snap_name}"],
+        ["snap-declaration", f"snap-name={snap_name.partition('_')[0]}"],
         ["snap-revision", f"snap-revision={snap_revision}", f"snap-id={snap_id}"],
         ["account", f"account-id={snap_publisher_id}"],
     ]

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.0.3 (2024-10-02)
+------------------
+- Fix a bug where signed aliased snaps couldn't be injected into the build
+  environment.
+
 2.0.2 (2024-09-26)
 ------------------
 - Improve multipass version parsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ docs = [
     "sphinx-autobuild==2024.9.19",
     "sphinx-lint==1.0.0",
     "sphinx-tabs==3.4.5",
-    "canonical-sphinx~=0.1"
+    "canonical-sphinx==0.1.0"
 ]
 
 [build-system]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Use the snap name when getting a [declaration assertion](https://ubuntu.com/core/docs/reference/assertions/snap-declaration) from snapd.

Unblocks https://github.com/canonical/snapcraft/issues/4683
Unblocks https://github.com/canonical/snapcraft/issues/4927
Unblocks https://github.com/canonical/charmcraft/issues/1770
Fixes #622 
(CRAFT-3259)
(CRAFT-3351)