### PR TITLE
fix: get assertions for aliased snaps

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -259,7 +259,7 @@ def _get_assertions_file(
             "public-key-sha3-384=BWDEoaqyr25nF5SNCvEv2v"
             "7QnM9QsfCc0PBMYD_i2NGSQ32EF2d4D0hqUel3m8ul",
         ],
-        ["snap-declaration", f"snap-name={snap_name}"],
+        ["snap-declaration", f"snap-name={snap_name.partition('_')[0]}"],
         ["snap-revision", f"snap-revision={snap_revision}", f"snap-id={snap_id}"],
         ["account", f"account-id={snap_publisher_id}"],
     ]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ included in each version.
 1.20.4 (2024-09-27)
 -------------------
 - ``requests-unixsocket`` dependency is replaced with ``requests-unixsocket2``
+- Fix a bug where signed aliased snaps couldn't be injected into the build
+  environment.
 
 1.20.3 (2024-04-11)
 -------------------


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Use the snap name when getting a [declaration assertion](https://ubuntu.com/core/docs/reference/assertions/snap-declaration) from snapd.

Same as #670, but for 1.20.

Unblocks https://github.com/canonical/snapcraft/issues/4683
Unblocks https://github.com/canonical/snapcraft/issues/4927
Unblocks https://github.com/canonical/charmcraft/issues/1770
Fixes #622 
(CRAFT-3259)
(CRAFT-3351)