### PR TITLE
docs(changelog): add 2.0.4 release notes

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -8,23 +8,23 @@ X.Y.Z (2024-MM-DD)
 ------------------
 - ``requests-unixsocket`` dependency is replaced with ``requests-unixsocket2``
 
-2.0.3 (2024-10-02)
-------------------
+2.0.3 (2024-Oct-02)
+-------------------
 - Fix a bug where signed aliased snaps couldn't be injected into the build
   environment.
 
-1.20.4 (2024-09-27)
--------------------
+1.20.4 (2024-Sep-27)
+--------------------
 - ``requests-unixsocket`` dependency is replaced with ``requests-unixsocket2``
 - Fix a bug where signed aliased snaps couldn't be injected into the build
   environment.
 
-2.0.2 (2024-09-26)
-------------------
+2.0.2 (2024-Sep-26)
+-------------------
 - Improve multipass version parsing
 
-2.0.1 (2024-08-28)
-------------------
+2.0.1 (2024-Aug-28)
+-------------------
 - Require Multipass>=1.14.1 when launching Ubuntu 24.04 (Noble) VMs, which
   adds support for the 24.04 buildd image
 
@@ -32,8 +32,8 @@ X.Y.Z (2024-MM-DD)
 
    2.0.1 includes changes from the 1.24.2 release.
 
-1.24.2 (2024-08-27)
--------------------
+1.24.2 (2024-Aug-27)
+--------------------
 - Remove Ubuntu 23.10 (Mantic) support
 - Require Multipass>=1.14.1 when launching Ubuntu 24.04 (Noble) VMs, which
   adds support for the 24.04 buildd image

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,8 +4,8 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
-X.Y.Z (2024-MM-DD)
-------------------
+2.0.4 (2024-Oct-03)
+-------------------
 - ``requests-unixsocket`` dependency is replaced with ``requests-unixsocket2``
 
 2.0.3 (2024-Oct-02)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Release notes for 2.0.4.

Waiting on https://github.com/canonical/craft-providers/pull/674 to land first.