### PR TITLE
chore: require multipass>=1.14.1

### DIFF
--- a/craft_providers/multipass/_launch.py
+++ b/craft_providers/multipass/_launch.py
@@ -19,10 +19,7 @@
 
 import logging
 
-import packaging.version
-
 from craft_providers import Base, bases
-from craft_providers.multipass.errors import MultipassError
 from craft_providers.multipass.multipass_instance import MultipassInstance
 
 logger = logging.getLogger(__name__)
@@ -57,15 +54,6 @@ def launch(
     :raises MultipassError: on unexpected Multipass error.
     """
     instance = MultipassInstance(name=name)
-
-    # TODO: drop this after 1.14.1 is released to latest/stable (#638)
-    if base_configuration.alias == bases.ubuntu.BuilddBaseAlias.NOBLE:
-        version, _ = instance._multipass.version()
-        if packaging.version.parse(version) < packaging.version.Version("1.14.1"):
-            raise MultipassError(
-                brief=f"Multipass {version!r} does not support Ubuntu 24.04 (Noble).",
-                resolution="Upgrade to Multipass 1.14.1 or newer.",
-            )
 
     if instance.exists():
         # TODO: Warn if existing instance doesn't match cpu/disk/mem specs.

--- a/craft_providers/multipass/multipass.py
+++ b/craft_providers/multipass/multipass.py
@@ -48,8 +48,7 @@ class Multipass:
     :cvar minimum_required_version: Minimum required version for compatibility.
     """
 
-    # TODO: bump to 1.14.1 once it is released (#638)
-    minimum_required_version = "1.7"
+    minimum_required_version = "1.14.1"
 
     def __init__(
         self, *, multipass_path: pathlib.Path = pathlib.Path("multipass")

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -22,6 +22,7 @@ Kubeflow
 Kubernetes
 Launchpad
 LTS
+MMM
 Makefile
 Matrix
 Mattermost

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+X.Y.Z (2024-MMM-DD)
+-------------------
+- Require Multipass>=1.14.1
+
 2.0.4 (2024-Oct-03)
 -------------------
 - ``requests-unixsocket`` dependency is replaced with ``requests-unixsocket2``

--- a/tests/unit/multipass/test_multipass.py
+++ b/tests/unit/multipass/test_multipass.py
@@ -204,7 +204,7 @@ def test_info_error(fake_process, mock_details_from_process_error):
 @pytest.mark.parametrize(
     "version_output",
     [
-        b"multipass  1.7.0\nmultipassd 1.7.0\n",
+        b"multipass  1.14.1\nmultipassd 1.14.1\n",
         b"multipass   1.15.0-dev.354+g533e02ffc\nmultipassd  1.15.0-dev.354+g533e02ffc\n",  # Snap multipass, edge channel
         b"multipass   1.15.0-dev.2929.pr661+gc67ef6641.mac\nmultipassd  1.15.0-dev.2929.pr661+gc67ef6641.mac",  # Dev build on a mac
     ],
@@ -221,6 +221,8 @@ def test_is_supported_version(fake_process, version_output):
     "version_output",
     [
         b"multipass  1.4.0\nmultipassd 1.4.0\n",
+        b"multipass  1.7.0\nmultipassd 1.7.0\n",
+        b"multipass  1.14.0\nmultipassd 1.14.0\n",
         b"multipass  1.invalid.15.999\nmultipassd 999\n",
     ],
 )


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Multipass 1.14.1 has been released so we can bump the minimum version.

Fixes #638 
(CRAFT-3308)