### PR TITLE
ci: install lxd from candidate channel, install lxd on ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -135,7 +135,7 @@ jobs:
           echo "::group::Configure LXD"
           sudo groupadd --force --system lxd
           sudo usermod --append --groups lxd $USER
-          sudo snap refresh lxd --channel=latest/stable
+          sudo snap install lxd --channel=latest/stable
           sudo snap start lxd
           sudo lxd waitready --timeout=30
           sudo lxd init --auto
@@ -157,8 +157,9 @@ jobs:
           CRAFT_PROVIDERS_TESTS_ENABLE_LXD_UNINSTALL: 1
           PYTEST_ADDOPTS: "--no-header -vv -rN"
         run: |
-          sg lxd -c "lxc version"
-          sg lxd -c ".tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies --colored yes -e integration-${{ matrix.python.tox-version }}"
+          # https://github.com/actions/runner-images/issues/9932
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc version
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- .tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies --colored yes -e integration-${{ matrix.python.tox-version }}
   integration-smoketests-macos:
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -135,7 +135,7 @@ jobs:
           echo "::group::Configure LXD"
           sudo groupadd --force --system lxd
           sudo usermod --append --groups lxd $USER
-          sudo snap install lxd --channel=latest/stable
+          sudo snap install lxd --channel=latest/candidate
           sudo snap start lxd
           sudo lxd waitready --timeout=30
           sudo lxd init --auto


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

`ubuntu-latest` is being migrated to 24.04 this month.  Seems like LXD is no longer installed by default.

I took the liberty to test lxd on `candidate` while touching this.

source: https://github.com/canonical/craft-providers/pull/701