### PR TITLE
fix: use Multipass-compatible instance names

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -215,8 +215,8 @@ def get_instance_name(name: str, error_class: type[ProviderError]) -> str:
     :raises error_class: if name contains no alphanumeric characters
     :returns: the instance name
     """
-    # remove anything that is not an alphanumeric characters or hyphen
-    name_with_valid_chars = re.sub(r"[^\w-]", "", name)
+    # remove anything that is not an alphanumeric character or hyphen
+    name_with_valid_chars = re.sub(r"[^\w-]", "", name, flags=re.ASCII)
     if not name_with_valid_chars:
         raise error_class(
             brief=f"failed to create an instance with name {name!r}.",

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
-2.1.0 (2025-Jan-09)
+2.1.0 (2025-Jan-10)
 -------------------
 - Require Multipass>=1.14.1
 - Use Multipass-compatible instance names

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,9 +4,10 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
-X.Y.Z (2024-MMM-DD)
+2.1.0 (2025-Jan-09)
 -------------------
 - Require Multipass>=1.14.1
+- Use Multipass-compatible instance names
 
 2.0.4 (2024-Oct-03)
 -------------------

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -145,6 +145,7 @@ def test_set_instance_name_unchanged(logs, name):
         ("test-!@#$%^&*()test", "test-test"),
         ("$1test", "test"),
         ("test-$", "test"),
+        ("test-𝔣𝔯𝔞𝔨𝔱𝔲𝔯'𝔡 𝔭𝔩𝔞𝔱𝔣𝔬𝔯𝔪", "test"),  # noqa: RUF001 (ambiguous-unicode)
         # this name contains invalid characters so it gets converted, even
         # though it is 63 characters
         (
@@ -194,6 +195,7 @@ def test_set_instance_name_hash_value():
         "-",
         "$$$",
         "-$-$-",
+        "𝔣𝔯𝔞𝔨𝔱𝔲𝔯'𝔡 𝔭𝔩𝔞𝔱𝔣𝔬𝔯𝔪",  # noqa: RUF001 (ambiguous-unicode)
     ],
 )
 def test_set_instance_name_invalid(name):


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Normalizes names when creating a Multipass instance.

Uses the same normalization function as LXD.

Unblocks https://github.com/canonical/charmcraft/issues/2058
Fixes #226 
(CRAFT-3883)