### PR TITLE
feat: mknod intercepts now configurable from LXDProvider

### DIFF
--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 import tempfile
 from typing import Any, Dict, List, Optional
+import warnings
 
 from craft_providers.const import TIMEOUT_SIMPLE
 from craft_providers.errors import details_from_called_process_error
@@ -54,6 +55,7 @@ class LXDInstance(Executor):
         project: str = "default",
         remote: str = "local",
         lxc: Optional[LXC] = None,
+        intercept_mknod: bool = True,
     ) -> None:
         """Create an LXD executor.
 
@@ -65,6 +67,7 @@ class LXDInstance(Executor):
         :param project: The name of the LXD project.
         :param remote: The name of the LXD remote.
         :param lxc: The LXC wrapper to use.
+        :param intercept_mknod: If the host can, tell LXD instance to intercept mknod
 
         :raises LXDError: If the name is invalid.
         """
@@ -79,6 +82,7 @@ class LXDInstance(Executor):
         self.instance_name = get_instance_name(name, LXDError)
         self.project = project
         self.remote = remote
+        self._intercept_mknod = intercept_mknod
 
         if lxc is None:
             self.lxc = LXC()
@@ -363,8 +367,14 @@ class LXDInstance(Executor):
                 uid = os.getuid()
             config_keys["raw.idmap"] = f"both {uid!s} 0"
 
-        if self._host_supports_mknod():
-            config_keys["security.syscalls.intercept.mknod"] = "true"
+        if self._intercept_mknod:
+            if not self._host_supports_mknod():
+                warnings.warn(
+                    "Application configured to intercept guest mknod calls, "
+                    "but the host OS does not support intercepting mknod."
+                )
+            else:
+                config_keys["security.syscalls.intercept.mknod"] = "true"
 
         self.lxc.launch(
             config_keys=config_keys,

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -24,8 +24,8 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
-from typing import Any, Dict, List, Optional
 import warnings
+from typing import Any, Dict, List, Optional
 
 from craft_providers.const import TIMEOUT_SIMPLE
 from craft_providers.errors import details_from_called_process_error

--- a/craft_providers/lxd/lxd_provider.py
+++ b/craft_providers/lxd/lxd_provider.py
@@ -45,6 +45,7 @@ class LXDProvider(Provider):
     :param lxc: Optional lxc client to use.
     :param lxd_project: LXD project to use (default is default).
     :param lxd_remote: LXD remote to use (default is local).
+    :param intercept_mknod: If the host can, tell LXD instance to intercept mknod
     """
 
     def __init__(
@@ -53,10 +54,12 @@ class LXDProvider(Provider):
         lxc: LXC = LXC(),
         lxd_project: str = "default",
         lxd_remote: str = "local",
+        intercept_mknod: bool = True,
     ) -> None:
         self.lxc = lxc
         self.lxd_project = lxd_project
         self.lxd_remote = lxd_remote
+        self._intercept_mknod = intercept_mknod
 
     @property
     def name(self) -> str:
@@ -98,6 +101,7 @@ class LXDProvider(Provider):
             name=instance_name,
             project=self.lxd_project,
             remote=self.lxd_remote,
+            intercept_mknod=self._intercept_mknod,
         )
 
     @contextlib.contextmanager

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.2.0 (2025-Jan-16)
+-------------------
+- ``hookutil.py`` now available for dependent projects to clean up lxd
+  instances.
+- Dependent projects can now disable lxd ``mknod`` interception via
+  ``LXDProvider``'s ``__init__``.
+
 2.1.0 (2025-Jan-10)
 -------------------
 - Require Multipass>=1.14.1

--- a/tests/unit/lxd/test_lxd_provider.py
+++ b/tests/unit/lxd/test_lxd_provider.py
@@ -121,7 +121,7 @@ def test_create_environment(mocker):
     provider.create_environment(instance_name="test-name")
 
     mock_lxd_instance.assert_called_once_with(
-        name="test-name", project="default", remote="local"
+        name="test-name", project="default", remote="local", intercept_mknod=True
     )
 
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Allow `craft-application`'s `ProviderService` to dis/allow intercepting `mknod` calls in LXD.

https://github.com/canonical/craft-application/pull/607