### PR TITLE
fix(lxd): wait for instance to start and stop

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -34,7 +34,7 @@ from craft_providers.errors import details_from_called_process_error
 from .errors import LXDError
 from .lxc import LXC
 from .lxd_instance import LXDInstance
-from .lxd_instance_status import ProviderInstanceStatus
+from .lxd_instance_status import LXDInstanceState, ProviderInstanceStatus
 from .project import create_with_default_profile
 
 logger = logging.getLogger(__name__)
@@ -585,7 +585,7 @@ def _wait_for_instance_ready(instance: LXDInstance) -> None:
     # check if the instance is ready
     if (
         instance_status == ProviderInstanceStatus.FINISHED.value
-        and instance_state == "STOPPED"
+        and instance_state == LXDInstanceState.STOPPED.value
     ):
         logger.debug("Instance %r is ready.", instance.instance_name)
         return

--- a/craft_providers/lxd/lxc.py
+++ b/craft_providers/lxd/lxc.py
@@ -32,7 +32,10 @@ from typing import Any, Callable, Dict, List, Optional
 import yaml
 
 from craft_providers import errors
-from craft_providers.lxd.lxd_instance_status import ProviderInstanceStatus
+from craft_providers.lxd.lxd_instance_status import (
+    LXDInstanceState,
+    ProviderInstanceStatus,
+)
 
 from .errors import LXDError
 
@@ -1164,7 +1167,7 @@ class LXC:
 
             if (
                 instance_status == ProviderInstanceStatus.FINISHED.value
-                and instance_info["Status"] == "STOPPED"
+                and instance_info["Status"] == LXDInstanceState.STOPPED.value
             ):
                 logger.debug("Instance %s is ready.", instance_name)
                 return

--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -32,6 +32,7 @@ from craft_providers.errors import details_from_called_process_error
 from craft_providers.executor import Executor, get_instance_name
 from craft_providers.lxd.errors import LXDError
 from craft_providers.lxd.lxc import LXC
+from craft_providers.lxd.lxd_instance_status import LXDInstanceState
 from craft_providers.util import env_cmd
 
 logger = logging.getLogger(__name__)
@@ -338,7 +339,8 @@ class LXDInstance(Executor):
         if state is None:
             raise LXDError(brief=f"Instance {self.instance_name!r} does not exist.")
 
-        return state.get("status") == "Running"
+        # state is title-case in yaml output
+        return state.get("status") == LXDInstanceState.RUNNING.value.title()
 
     def launch(
         self,

--- a/craft_providers/lxd/lxd_instance_status.py
+++ b/craft_providers/lxd/lxd_instance_status.py
@@ -21,8 +21,36 @@ from enum import Enum
 
 
 class ProviderInstanceStatus(Enum):
-    """Status of the instance."""
+    """Status of craft-providers setup of a LXD instance.
+
+    This value is controlled by craft-providers and configured under
+    `user.craft-providers.status` in the instance's config.
+
+    This is different from the instance state, which is controlled by LXD.
+    """
 
     PREPARING = "PREPARING"
     FINISHED = "FINISHED"
     STARTING = "STARTING"
+
+
+class LXDInstanceState(Enum):
+    """State of a LXD instance as reported by LXD.
+
+    The value is displayed either as `State` or `Status`, depending on the
+    command and output format.
+
+    The capitalization also varies. For example, `lxc list --format table`
+    prints uppercase values but `lxc list --format yaml` gives title case values.
+
+    Ref: https://github.com/lxc/lxc/blob/9e95451ecc718b88de46134527b1e46aee2586cd/src/lxc/state.c#L29
+    """
+
+    STOPPED = "STOPPED"
+    STARTING = "STARTING"
+    RUNNING = "RUNNING"
+    STOPPING = "STOPPING"
+    ABORTING = "ABORTING"
+    FREEZING = "FREEZING"
+    FROZEN = "FROZEN"
+    THAWED = "THAWED"

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
-2.2.0 (2025-MMM-DD)
+2.2.0 (2025-Feb-11)
 -------------------
 
 New features:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,17 +4,25 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
-2.1.1 (2025-Feb-11)
+2.2.0 (2025-MMM-DD)
 -------------------
-- Fix a bug where instances with underscores in their names would fail to
-  launch.
 
-2.2.0 (2025-Jan-16)
--------------------
+New features:
+
 - ``hookutil.py`` now available for dependent projects to clean up lxd
   instances.
 - Dependent projects can now disable lxd ``mknod`` interception via
   ``LXDProvider``'s ``__init__``.
+
+Bug fixes:
+
+- Fix a bug where LXD instances would fail during setup, due to a race
+  condition where the setup began before the instance had started.
+
+2.1.1 (2025-Feb-11)
+-------------------
+- Fix a bug where instances with underscores in their names would fail to
+  launch.
 
 2.1.0 (2025-Jan-10)
 -------------------

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -1033,7 +1033,10 @@ def test_name_matches_base_name(
 )
 def test_is_valid(creation_date, fake_instance):
     """Instances younger than the expiration date (inclusive) are valid."""
-    fake_instance.info.return_value = {"Created": creation_date, "Status": "STOPPED"}
+    fake_instance.info.return_value = {
+        "Created": creation_date,
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
+    }
     fake_instance.config_get.return_value = (
         lxd_instance_status.ProviderInstanceStatus.FINISHED.value
     )
@@ -1052,7 +1055,7 @@ def test_is_valid_expired(fake_instance, mock_lxc):
     # 91 days old
     fake_instance.info.return_value = {
         "Created": "2022/09/07 11:05 UTC",
-        "Status": "STOPPED",
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
     }
     fake_instance.config_get.return_value = (
         lxd_instance_status.ProviderInstanceStatus.FINISHED.value
@@ -1120,7 +1123,7 @@ def test_is_valid_wait_for_ready_error(logs, fake_instance, mocker):
     )
     fake_instance.info.return_value = {
         "Created": "2022/12/08 11:05 UTC",
-        "Status": "STOPPED",
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
     }
 
     fake_instance.config_get.return_value = (
@@ -1312,7 +1315,9 @@ def test_timer_error_ignore(fake_instance, fake_process, mock_lxc, mocker):
 
 def test_wait_for_instance_ready(fake_instance, logs):
     """Return if the instance is ready."""
-    fake_instance.info.return_value = {"Status": "STOPPED"}
+    fake_instance.info.return_value = {
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
+    }
     fake_instance.config_get.return_value = "FINISHED"
 
     lxd.launcher._wait_for_instance_ready(fake_instance)
@@ -1322,7 +1327,9 @@ def test_wait_for_instance_ready(fake_instance, logs):
 
 def test_wait_for_instance_pid_active(fake_instance, mocker):
     """If the instance is not ready and the pid is active, then check the status."""
-    fake_instance.info.return_value = {"Status": "STOPPED"}
+    fake_instance.info.return_value = {
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
+    }
     # first call returns status, second returns the pid
     fake_instance.config_get.side_effect = ["PREPARING", "123"]
     # mock for the call `Path("/proc/123").exists()
@@ -1337,7 +1344,9 @@ def test_wait_for_instance_pid_active(fake_instance, mocker):
 def test_wait_for_instance_skip_pid_check(platform, fake_instance, mocker, logs):
     """Do not check for the pid if not on linux."""
     mocker.patch("sys.platform", platform)
-    fake_instance.info.return_value = {"Status": "STOPPED"}
+    fake_instance.info.return_value = {
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
+    }
     # first call returns status, second returns the pid
     fake_instance.config_get.side_effect = ["PREPARING", "123"]
 
@@ -1350,7 +1359,9 @@ def test_wait_for_instance_skip_pid_check(platform, fake_instance, mocker, logs)
 @pytest.mark.usefixtures("mock_platform")
 def test_wait_for_instance_no_pid(fake_instance):
     """Raise an error if there is no pid in the config."""
-    fake_instance.info.return_value = {"Status": "STOPPED"}
+    fake_instance.info.return_value = {
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
+    }
     # first call returns status, second returns an empty string for the pid
     fake_instance.config_get.side_effect = ["PREPARING", ""]
 
@@ -1367,7 +1378,9 @@ def test_wait_for_instance_no_pid(fake_instance):
 @pytest.mark.usefixtures("mock_platform")
 def test_wait_for_instance_pid_inactive(fake_instance, mocker):
     """Raise an error if the instance is not ready and the pid is inactive."""
-    fake_instance.info.return_value = {"Status": "STOPPED"}
+    fake_instance.info.return_value = {
+        "Status": lxd_instance_status.LXDInstanceState.STOPPED.value,
+    }
     # first call returns status, second returns the pid
     fake_instance.config_get.side_effect = ["PREPARING", "123"]
     # mock for the call `Path("/proc/123").exists()

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -23,6 +23,7 @@ import pytest
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, lxc
 from craft_providers.lxd.lxc import StdinType
+from craft_providers.lxd.lxd_instance_status import LXDInstanceState
 from freezegun import freeze_time
 
 
@@ -1255,8 +1256,8 @@ def test_check_instance_status_retry(fake_process, mocker):
     mocker.patch("time.sleep")
     mock_instance = mocker.patch("craft_providers.lxd.lxc.LXC.info")
     mock_instance.side_effect = [
-        {"Status": "STOPPED"},
-        {"Status": "STOPPED"},
+        {"Status": LXDInstanceState.STOPPED.value},
+        {"Status": LXDInstanceState.STOPPED.value},
     ]
     mock_instance_config = mocker.patch("craft_providers.lxd.lxc.LXC.config_get")
     mock_instance_config.side_effect = [
@@ -1276,7 +1277,7 @@ def test_check_instance_status_boot_failed(fake_process, mocker):
     time_time.return_value = 0
     mocker.patch("time.sleep")
     mock_instance = mocker.patch("craft_providers.lxd.lxc.LXC.info")
-    mock_instance.return_value = {"Status": "STOPPED"}
+    mock_instance.return_value = {"Status": LXDInstanceState.STOPPED.value}
     mock_instance_config = mocker.patch("craft_providers.lxd.lxc.LXC.config_get")
     mock_instance_config.side_effect = [
         "STARTING",
@@ -1295,12 +1296,12 @@ def test_check_instance_status_wait(fake_process, mocker):
     mocker.patch("time.sleep")
     mock_instance = mocker.patch("craft_providers.lxd.lxc.LXC.info")
     mock_instance.side_effect = [
-        {"Status": "STOPPED"},  # STARTING
-        {"Status": "RUNNING"},  # STARTING
-        {"Status": "RUNNING"},  # PREPARING
-        {"Status": "RUNNING"},  # PREPARING
-        {"Status": "RUNNING"},  # FINISHED
-        {"Status": "STOPPED"},  # FINISHED
+        {"Status": LXDInstanceState.STOPPED.value},  # STARTING
+        {"Status": LXDInstanceState.RUNNING.value},  # STARTING
+        {"Status": LXDInstanceState.RUNNING.value},  # PREPARING
+        {"Status": LXDInstanceState.RUNNING.value},  # PREPARING
+        {"Status": LXDInstanceState.RUNNING.value},  # FINISHED
+        {"Status": LXDInstanceState.STOPPED.value},  # FINISHED
     ]
     mock_instance_config = mocker.patch("craft_providers.lxd.lxc.LXC.config_get")
     mock_instance_config.side_effect = [
@@ -1405,18 +1406,18 @@ def test_check_instance_status_lxd_error_retry(fake_process, mocker):
             details="* Command that failed: 'lxc --project test-project info test-remote:test-instance'\n* Command exit code: 1",
             resolution=None,
         ),
-        {"Status": "STOPPED"},
-        {"Status": "RUNNING"},
-        {"Status": "RUNNING"},
+        {"Status": LXDInstanceState.STOPPED.value},
+        {"Status": LXDInstanceState.RUNNING.value},
+        {"Status": LXDInstanceState.RUNNING.value},
         LXDError(
             brief="Failed to get instance info.",
             details="* Command that failed: 'lxc --project test-project info test-remote:test-instance'\n* Command exit code: 1",
             resolution=None,
         ),
-        {"Status": "RUNNING"},
-        {"Status": "RUNNING"},
-        {"Status": "RUNNING"},
-        {"Status": "STOPPED"},
+        {"Status": LXDInstanceState.RUNNING.value},
+        {"Status": LXDInstanceState.RUNNING.value},
+        {"Status": LXDInstanceState.RUNNING.value},
+        {"Status": LXDInstanceState.STOPPED.value},
     ]
     mock_instance_config = mocker.patch("craft_providers.lxd.lxc.LXC.config_get")
     mock_instance_config.side_effect = [

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -850,11 +850,47 @@ def test_start(mock_lxc, instance):
             instance_name=instance.instance_name,
             project=instance.project,
             remote=instance.remote,
-        )
+        ),
+        mock.call.list(
+            project=instance.project,
+            remote=instance.remote,
+        ),
     ]
 
 
+@pytest.mark.usefixtures("instant_sleep")
+@pytest.mark.parametrize("wait_count", list(range(6)))
+def test_start_with_retries(wait_count, mocker, mock_lxc, instance):
+    """Retry while waiting for an instance to start."""
+    mock_is_running = mocker.patch.object(
+        instance,
+        "_get_state",
+        side_effect=[LXDInstanceState.STARTING] * wait_count
+        + [LXDInstanceState.RUNNING],
+    )
+
+    instance.start()
+
+    mock_lxc.start.assert_called_once_with(
+        instance_name=instance.instance_name,
+        project=instance.project,
+        remote=instance.remote,
+    )
+    mock_is_running.assert_has_calls([mock.call()] * (wait_count + 1))
+
+
+@pytest.mark.usefixtures("instant_sleep")
+def test_start_timeout(mocker, mock_lxc, instance):
+    """Timeout if the instance doesn't start."""
+    mocker.patch("craft_providers.lxd.lxd_instance.TIMEOUT_SIMPLE", 0.01)
+    mocker.patch.object(instance, "_get_state", side_effect=LXDInstanceState.STARTING)
+
+    with pytest.raises(LXDError, match="Instance failed to start."):
+        instance.start()
+
+
 def test_restart(mock_lxc, instance):
+    """Restart an instance."""
     instance.restart()
 
     assert mock_lxc.mock_calls == [
@@ -862,11 +898,70 @@ def test_restart(mock_lxc, instance):
             instance_name="test-instance-fa2d407652a1c51f6019",
             project="default",
             remote="local",
-        )
+        ),
+        mock.call.list(
+            project=instance.project,
+            remote=instance.remote,
+        ),
     ]
 
 
-def test_stop(mock_lxc, instance):
+@pytest.mark.usefixtures("instant_sleep")
+@pytest.mark.parametrize("wait_count", list(range(6)))
+def test_restart_with_retries(wait_count, mocker, mock_lxc, instance):
+    """Retry while waiting for an instance to restart."""
+    mock_is_running = mocker.patch.object(
+        instance,
+        "_get_state",
+        side_effect=[LXDInstanceState.STARTING] * wait_count
+        + [LXDInstanceState.RUNNING],
+    )
+
+    instance.restart()
+
+    mock_lxc.restart.assert_called_once_with(
+        instance_name=instance.instance_name,
+        project=instance.project,
+        remote=instance.remote,
+    )
+    mock_is_running.assert_has_calls([mock.call()] * (wait_count + 1))
+
+
+@pytest.mark.usefixtures("instant_sleep")
+def test_restart_timeout(mocker, mock_lxc, instance):
+    """Timeout if the instance doesn't restart."""
+    mocker.patch("craft_providers.lxd.lxd_instance.TIMEOUT_SIMPLE", 0.01)
+    mocker.patch.object(instance, "_get_state", side_effect=LXDInstanceState.STARTING)
+
+    with pytest.raises(LXDError, match="Instance failed to restart."):
+        instance.restart()
+
+
+def test_stop(mock_lxc, mocker):
+    """Stop an instance."""
+    instance = LXDInstance(name=_STOPPED_INSTANCE["name"], lxc=mock_lxc)
+    mocker.patch.object(instance, "exists", return_value=True)
+
+    instance.stop()
+
+    assert mock_lxc.mock_calls == [
+        mock.call.stop(
+            instance_name=instance.instance_name,
+            project=instance.project,
+            remote=instance.remote,
+        ),
+        mock.call.list(
+            project=instance.project,
+            remote=instance.remote,
+        ),
+    ]
+
+
+def test_stop_ephemeral(mock_lxc, instance, mocker):
+    """Stop an ephemeral instance."""
+    # ephemeral instances don't exist after stopping
+    mocker.patch.object(instance, "exists", return_value=False)
+
     instance.stop()
 
     assert mock_lxc.mock_calls == [
@@ -876,6 +971,39 @@ def test_stop(mock_lxc, instance):
             remote=instance.remote,
         )
     ]
+
+
+@pytest.mark.usefixtures("instant_sleep")
+@pytest.mark.parametrize("wait_count", list(range(6)))
+def test_stop_with_retries(wait_count, mocker, mock_lxc, instance):
+    """Retry while waiting for an instance to stop."""
+    mocker.patch.object(instance, "exists", return_value=True)
+    mock_is_running = mocker.patch.object(
+        instance,
+        "_get_state",
+        side_effect=[[LXDInstanceState.STOPPING]] * wait_count
+        + [LXDInstanceState.STOPPED],
+    )
+
+    instance.stop()
+
+    mock_lxc.stop.assert_called_once_with(
+        instance_name=instance.instance_name,
+        project=instance.project,
+        remote=instance.remote,
+    )
+    mock_is_running.assert_has_calls([mock.call()] * (wait_count + 1))
+
+
+@pytest.mark.usefixtures("instant_sleep")
+def test_stop_timeout(mocker, mock_lxc, instance):
+    """Timeout if the instance doesn't stop."""
+    mocker.patch.object(instance, "exists", return_value=True)
+    mocker.patch("craft_providers.lxd.lxd_instance.TIMEOUT_SIMPLE", 0.01)
+    mocker.patch.object(instance, "_get_state", side_effect=[LXDInstanceState.STOPPING])
+
+    with pytest.raises(LXDError, match="Instance failed to stop."):
+        instance.stop()
 
 
 def test_supports_mount(instance):

--- a/tests/unit/lxd/test_lxd_instance.py
+++ b/tests/unit/lxd/test_lxd_instance.py
@@ -29,6 +29,7 @@ from unittest.mock import call
 import pytest
 from craft_providers import errors
 from craft_providers.lxd import LXC, LXDError, LXDInstance
+from craft_providers.lxd.lxd_instance_status import LXDInstanceState
 
 # These names include invalid characters so a lxd-compatible instance_name
 # is generated. This ensures an Instance's `name` and `instance_name` are
@@ -60,8 +61,14 @@ def project_path(tmp_path):
 def mock_lxc(project_path):
     with mock.patch("craft_providers.lxd.lxd_instance.LXC", spec=LXC) as lxc:
         lxc.list.return_value = [
-            {"name": _TEST_INSTANCE["instance-name"], "status": "Running"},
-            {"name": _STOPPED_INSTANCE["instance-name"], "status": "Stopped"},
+            {
+                "name": _TEST_INSTANCE["instance-name"],
+                "status": LXDInstanceState.RUNNING.value.title(),
+            },
+            {
+                "name": _STOPPED_INSTANCE["instance-name"],
+                "status": LXDInstanceState.STOPPED.value.title(),
+            },
         ]
         lxc.config_device_show.return_value = {
             "test_mount": {


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Waits for LXD instances to start, restart, or stop before returning.  This is necessary because `lxc [start|restart|stop]` is asynchronous - the call may return before the operation completes. 

This can cause a race condition between Craft Providers calling `lxc start` then `lxc file pull` and the instance completing startup.  

I did some internal refactoring to make this cleaner to implement, so I recommend reviewing per-commit.

Fixes #719
(CRAFT-4048)