### PR TITLE
ci: add tics workflow

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -1,0 +1,15 @@
+name: TICS
+on:
+  push:
+    branches:
+      - "main"
+      # For troubleshooting
+      - "work/tiobe*"
+
+jobs:
+  TICS:
+    uses: canonical/starflow/.github/workflows/tics.yaml@main
+    # Uncomment this and add your project's name on Tiobe TICS
+    with:
+      project: "craft-providers"
+    secrets: inherit

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   TICS:
     uses: canonical/starflow/.github/workflows/tics.yaml@main
-    # Uncomment this and add your project's name on Tiobe TICS
     with:
       project: "craft-providers"
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# This Makefile exists for compatibility with the Starflow TICS workflow.
+# https://github.com/canonical/starflow/blob/main/.github/workflows/tics.yaml
+
+.PHONY: setup-tics
+setup-tics:
+	@ # Intentional no-op
+
+.PHONY: test-coverage
+test-coverage:
+	tox -f tics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ docs = [
     "sphinx-tabs==3.4.7",
     "canonical-sphinx~=0.2.0"
 ]
+tics = ["flake8", "pylint"]
 
 [build-system]
 requires = [

--- a/tox.ini
+++ b/tox.ini
@@ -164,3 +164,20 @@ description = Lint the documentation with sphinx-lint
 base = docs
 commands = sphinx-lint --ignore docs/_build --ignore .tox --ignore .venv --ignore venv --max-line-length 80 -e all {posargs}
 labels = lint
+
+[tics]
+extras = tics
+package = editable
+no_package = true
+env_dir = {work_dir}/results
+runner = ignore_env_name_mismatch
+source_dir = {tox_root}/{project_name}
+
+[testenv:tics]
+description = Run TICS analysis
+base = test, lint, tics
+commands =
+    coverage run --source craft_cli,tests -m pytest
+    coverage xml -o results/coverage.xml
+    coverage report -m
+    coverage html


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Needs to be merged to see if it works.

The `setup-tics` and `test-coverage` targets are used by starflow's upstream TICS workflow. To more easily adopt full "uv-ification" later, this PR adds a dummy makefile for those two targets and puts the "actual" commands into the tox configuration file.

`tox -f tics` appears to have an identical output to `make test-coverage` in other repositories, so this "should" work.

CRAFT-4536