### PR TITLE
fix(ci): install tox in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: setup-tics
 setup-tics:
-	@ # Intentional no-op
+	python -m pip install --user tox
 
 .PHONY: test-coverage
 test-coverage:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Tox needed to be installed in CI for the TICS job.