### PR TITLE
fix(ci): install tox in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else ifeq ($(OS),Windows_NT)
 else
 	curl -LsSf https://astral.sh/uv/install.sh | sh
 endif
-uv tool install tox
+	uv tool install tox
 
 
 .PHONY: test-coverage

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: setup-tics
 setup-tics:
-	@ # Intentional no-op
+	python -m pip install --user tox
 
 .PHONY: test-coverage
 test-coverage:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,18 @@
 
 .PHONY: setup-tics
 setup-tics:
-	python -m pip install tox
+ifneq ($(shell which uv),)
+else ifneq ($(shell which snap),)
+	sudo snap install --classic astral-uv
+else ifneq ($(shell which brew),)
+	brew install uv
+else ifeq ($(OS),Windows_NT)
+	pwsh -c "irm https://astral.sh/uv/install.ps1 | iex"
+else
+	curl -LsSf https://astral.sh/uv/install.sh | sh
+endif
+uv tool install tox
+
 
 .PHONY: test-coverage
 test-coverage:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: setup-tics
 setup-tics:
-	python -m pip install --user tox
+	python -m pip install tox
 
 .PHONY: test-coverage
 test-coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,6 @@ markers = [
 
 [tool.coverage.run]
 branch = true
-parallel = true
 omit = ["tests/**"]
 
 [tool.coverage.report]

--- a/tox.ini
+++ b/tox.ini
@@ -177,7 +177,7 @@ source_dir = {tox_root}/{project_name}
 description = Run TICS analysis
 base = test, lint, tics
 commands =
-    coverage run --source craft_cli,tests -m pytest
+    coverage run --source craft_providers,tests -m pytest
     coverage xml -o results/coverage.xml
     coverage report -m
     coverage html


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Includes three fixes for the TICS CI: install tox in CI, use the correct project name, don't parallelize coverage (this breaks reporting)