### PR TITLE
fix(base): warn, don't fail, on failures to mount a shared cache

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -45,6 +45,7 @@ from craft_providers.errors import (
     BaseCompatibilityError,
     BaseConfigurationError,
     NetworkError,
+    ProviderError,
     details_from_called_process_error,
 )
 from craft_providers.executor import Executor
@@ -837,7 +838,13 @@ class Base(ABC):
             ["mkdir", "-p", guest_pip_cache_path.as_posix()],
         )
 
-        executor.mount(host_source=host_pip_cache_path, target=guest_pip_cache_path)
+        try:
+            executor.mount(host_source=host_pip_cache_path, target=guest_pip_cache_path)
+        except ProviderError as exc:
+            logger.warning(
+                "Failed to mount cache in instance. Proceeding without cache."
+            )
+            logger.debug(exc)
 
     def _pre_setup_packages(self, executor: Executor) -> None:
         """Do anything before setting up the packages.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.3.1 (2025-Jun-05)
+-------------------
+
+Bug fixes:
+
+- Warn, but don't fail, on failures to mount a shared cache.
+
 2.3.0 (2025-May-09)
 -------------------
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -17,6 +17,7 @@
 """Tests for abstract Base's implementations."""
 
 import enum
+import logging
 import pathlib
 import subprocess
 import sys
@@ -25,7 +26,7 @@ from unittest import mock
 import pytest
 import pytest_subprocess.fake_popen
 from craft_providers import Executor, base
-from craft_providers.errors import BaseConfigurationError
+from craft_providers.errors import BaseConfigurationError, ProviderError
 
 from tests.unit.conftest import DEFAULT_FAKE_CMD
 
@@ -199,6 +200,36 @@ def test_mount_shared_cache_dirs_mkdir_failed(
 
     with pytest.raises(BaseConfigurationError):
         fake_base._mount_shared_cache_dirs(fake_executor)
+
+
+def test_mount_shared_cache_dirs_mount_failed(
+    caplog: pytest.LogCaptureFixture, fake_process, fake_base, fake_executor, mocker
+):
+    """Test mounting of cache directories with a cache directory set, but mkdir failed."""
+    caplog.set_level(logging.DEBUG)
+    error_msg = "Lol couldn't mount the cache dir"
+    cache_dir = pathlib.Path("/this/directory/should/not/exist")
+    fake_base._cache_path = cache_dir
+    user_cache_dir = pathlib.Path("/root/.cache")
+
+    fake_process.register(
+        [*DEFAULT_FAKE_CMD, "bash", "-c", "echo -n ${XDG_CACHE_HOME:-${HOME}/.cache}"],
+        stdout=str(user_cache_dir),
+    )
+    fake_process.register(
+        [*DEFAULT_FAKE_CMD, "mkdir", "-p", "/root/.cache/pip"],
+    )
+    mocker.patch("pathlib.Path.mkdir")  # don't try to create the directory
+    mocker.patch.object(fake_executor, "mount", side_effect=ProviderError(error_msg))
+
+    fake_base._mount_shared_cache_dirs(fake_executor)
+
+    log_entries = caplog.get_records("call")
+    assert (
+        log_entries[0].message
+        == "Failed to mount cache in instance. Proceeding without cache."
+    )
+    assert log_entries[1].message == error_msg
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a fix for https://github.com/canonical/charmcraft/issues/2107

CHARMCRAFT-409

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
