### PR TITLE
fix(base): warn, don't fail, on failures to mount a shared cache

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -45,6 +45,7 @@ from craft_providers.errors import (
     BaseCompatibilityError,
     BaseConfigurationError,
     NetworkError,
+    ProviderError,
     details_from_called_process_error,
 )
 from craft_providers.executor import Executor
@@ -834,7 +835,13 @@ class Base(ABC):
             ["mkdir", "-p", guest_pip_cache_path.as_posix()],
         )
 
-        executor.mount(host_source=host_pip_cache_path, target=guest_pip_cache_path)
+        try:
+            executor.mount(host_source=host_pip_cache_path, target=guest_pip_cache_path)
+        except ProviderError as exc:
+            logger.warning(
+                "Failed to mount cache in instance. Proceeding without cache."
+            )
+            logger.debug(exc)
 
     def _pre_setup_packages(self, executor: Executor) -> None:
         """Do anything before setting up the packages.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+2.3.1 (2025-Jun-05)
+-------------------
+
+Bug fixes:
+
+- Warn, but don't fail, on failures to mount a shared cache.
+
 2.3.0 (2025-May-09)
 -------------------
 


### PR DESCRIPTION
This is a fix for https://github.com/canonical/charmcraft/issues/2107

CHARMCRAFT-409

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
