### PR TITLE
fix(feature/pro-sources): Inherit Host's `contract_url`

### DIFF
--- a/craft_providers/lxd/lxd_instance.py
+++ b/craft_providers/lxd/lxd_instance.py
@@ -634,9 +634,12 @@ class LXDInstance(Executor):
 
     def attach_pro_subscription(self):
         """Attach the instance to a Pro subscription."""
+        guest_token, contract_url = pro.request_pro_guest_token()
+
         self.lxc.attach_pro_subscription(
             instance_name=self.instance_name,
-            pro_token=pro.request_pro_guest_token(),
+            pro_token=guest_token,
+            contract_url=contract_url,
             project=self.project,
             remote=self.remote,
         )

--- a/craft_providers/pro.py
+++ b/craft_providers/pro.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import requests
+import yaml
 
 from craft_providers.errors import GuestTokenError, MachineTokenError
 
@@ -35,43 +36,56 @@ class ProHostInfo:
     machine_token: str
     machine_id: str
     contract_id: str
+    contract_url: str
 
 
 def retrieve_pro_host_info() -> ProHostInfo:
     """Get the machine info from the pro host."""
+    token_file = Path("/var/lib/ubuntu-advantage/private/machine-token.json")
+    config_file = Path("/etc/ubuntu-advantage/uaclient.conf")
+
     try:
-        token_file = Path("/var/lib/ubuntu-advantage/private/machine-token.json")
-        content = json.loads(token_file.read_text())
-        machine_token = content.get("machineToken", "")
-        machine_id = content.get("machineTokenInfo", {}).get("machineId")
-        contract_id = (
-            content.get("machineTokenInfo", {}).get("contractInfo", {}).get("id")
-        )
-        if not machine_token:
-            raise MachineTokenError("No machineToken in machine token file.")
-        if not machine_id:
-            raise MachineTokenError("No machineId in machine token file.")
-        if not contract_id:
-            raise MachineTokenError("No contractID in machine token file.")
-        return ProHostInfo(machine_token, machine_id, contract_id)
-    except FileNotFoundError:
-        raise MachineTokenError("Machine token file does not exist.")
-    except PermissionError:
+        # Note: tests currently depend on reading machine-token.json first
+        # then uaclient.conf for mocking purposes.
+        token_file_content = json.loads(token_file.read_text())
+        config_file_content = yaml.safe_load(config_file.read_text())
+
+    except FileNotFoundError as exc:
+        raise MachineTokenError(f"Missing file on host: {exc.filename}")
+    except PermissionError as exc:
         raise MachineTokenError(
-            brief="Machine token file is not accessible.",
+            brief=f"Invalid permissions to access file: {exc.filename}",
             resolution="Make sure you are running with root access.",
         )
 
+    machine_token = token_file_content.get("machineToken", "")
+    machine_id = token_file_content.get("machineTokenInfo", {}).get("machineId")
+    contract_id = (
+        token_file_content.get("machineTokenInfo", {}).get("contractInfo", {}).get("id")
+    )
 
-def request_pro_guest_token() -> str:
-    """Request a guest token from contracts API."""
+    contract_url = config_file_content.get("contract_url", "")
+
+    if not machine_token:
+        raise MachineTokenError("No machineToken in machine token file.")
+    if not machine_id:
+        raise MachineTokenError("No machineId in machine token file.")
+    if not contract_id:
+        raise MachineTokenError("No contractID in machine token file.")
+    if not contract_url:
+        raise MachineTokenError("No contractURL in Pro client config.")
+
+    return ProHostInfo(machine_token, machine_id, contract_id, contract_url)
+
+
+def request_pro_guest_token() -> (str, str):
+    """Request a guest token and from contracts API."""
     info = retrieve_pro_host_info()
 
     try:
-        base_url = "https://contracts.canonical.com"
         endpoint = f"/v1/contracts/{info.contract_id}/context/machines/{info.machine_id}/guest-token"
         response = requests.get(
-            base_url + endpoint,
+            info.contract_url + endpoint,
             headers={"Authorization": f"Bearer {info.machine_token}"},
             timeout=20,
         )
@@ -81,9 +95,9 @@ def request_pro_guest_token() -> str:
         if not guest_token:
             raise GuestTokenError(brief="API response does not contain a guest token.")
         logger.info("Guest token received successfully.")
-        return guest_token  # noqa: TRY300
+        return guest_token, info.contract_url  # noqa: TRY300
     except requests.exceptions.JSONDecodeError:
-        # recrived data was not in json format
+        # received data was not in json format
         raise GuestTokenError(
             brief="Error decoding JSON data when retrieving guest token."
         )

--- a/tests/integration/lxd/test_lxc.py
+++ b/tests/integration/lxd/test_lxc.py
@@ -314,6 +314,7 @@ def test_attach_pro_subscription_success(instance, lxc, session_project):
         lxc.attach_pro_subscription(
             instance_name=instance,
             pro_token="random",  # noqa: S106
+            contract_url="random",
             project=session_project,
         )
 
@@ -328,6 +329,7 @@ def test_attach_pro_subscription_failure(instance_alma, lxc, session_project):
         lxc.attach_pro_subscription(
             instance_name=instance_alma,
             pro_token="random",  # noqa: S106
+            contract_url="random",
             project=session_project,
         )
 

--- a/tests/unit/lxd/test_lxc.py
+++ b/tests/unit/lxd/test_lxc.py
@@ -2724,7 +2724,7 @@ def test_is_pro_enabled_process_error(fake_process):
     assert len(fake_process.calls) == 1
 
 
-def test_attach_pro_subscription_success(fake_process):
+def test_attach_pro_subscription_success(mocker, fake_process):
     fake_process.register_subprocess(
         [
             "lxc",
@@ -2742,20 +2742,37 @@ def test_attach_pro_subscription_success(fake_process):
         stdout=b"""{"_schema_version": "v1", "data": {"attributes": {"enabled": [], "reboot_required": false}, "meta": {"environment_vars": []}, "type": "FullTokenAttach"}, "errors": [], "result": "success", "version": "32.3.1~24.04", "warnings": []}""",
     )
 
+    # patch loading Pro client configuration file
+    mocker.patch("yaml.safe_load", return_value={})
+
+    # fake push/pulling pulling pro configuration file
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "file",
+            fake_process.any(),
+        ],
+        stdout="",
+        occurrences=2,
+    )
+
     assert (
         LXC().attach_pro_subscription(
             instance_name="test-instance",
             pro_token="random",  # noqa: S106
+            contract_url="random",
             project="test-project",
             remote="test-remote",
         )
         is None
     )
 
-    assert len(fake_process.calls) == 1
+    assert len(fake_process.calls) == 3
 
 
-def test_attach_pro_subscription_failed(fake_process):
+def test_attach_pro_subscription_failed(mocker, fake_process):
     fake_process.register_subprocess(
         [
             "lxc",
@@ -2774,10 +2791,27 @@ def test_attach_pro_subscription_failed(fake_process):
         returncode=1,
     )
 
+    # patch loading Pro client configuration file
+    mocker.patch("yaml.safe_load", return_value={})
+
+    # fake push/pulling pulling pro configuration file
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "file",
+            fake_process.any(),
+        ],
+        stdout="",
+        occurrences=2,
+    )
+
     with pytest.raises(LXDError) as exc_info:
         LXC().attach_pro_subscription(
             instance_name="test-instance",
             pro_token="random",  # noqa: S106
+            contract_url="random",
             project="test-project",
             remote="test-remote",
         )
@@ -2787,10 +2821,10 @@ def test_attach_pro_subscription_failed(fake_process):
         == "Invalid token used to attach 'test-instance' to a Pro subscription."
     )
 
-    assert len(fake_process.calls) == 1
+    assert len(fake_process.calls) == 3
 
 
-def test_attach_pro_subscription_already_attached(fake_process):
+def test_attach_pro_subscription_already_attached(mocker, fake_process):
     fake_process.register_subprocess(
         [
             "lxc",
@@ -2809,19 +2843,36 @@ def test_attach_pro_subscription_already_attached(fake_process):
         returncode=2,
     )
 
+    # patch loading Pro client configuration file
+    mocker.patch("yaml.safe_load", return_value={})
+
+    # fake push/pulling pulling pro configuration file
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "file",
+            fake_process.any(),
+        ],
+        stdout="",
+        occurrences=2,
+    )
+
     assert (
         LXC().attach_pro_subscription(
             instance_name="test-instance",
             pro_token="random",  # noqa: S106
+            contract_url="random",
             project="test-project",
             remote="test-remote",
         )
     ) is None
 
-    assert len(fake_process.calls) == 1
+    assert len(fake_process.calls) == 3
 
 
-def test_attach_pro_subscription_process_error(fake_process):
+def test_attach_pro_subscription_process_error(mocker, fake_process):
     fake_process.register_subprocess(
         [
             "lxc",
@@ -2839,10 +2890,27 @@ def test_attach_pro_subscription_process_error(fake_process):
         returncode=127,
     )
 
+    # patch loading Pro client configuration file
+    mocker.patch("yaml.safe_load", return_value={})
+
+    # fake push/pulling pulling pro configuration file
+    fake_process.register_subprocess(
+        [
+            "lxc",
+            "--project",
+            "test-project",
+            "file",
+            fake_process.any(),
+        ],
+        stdout="",
+        occurrences=2,
+    )
+
     with pytest.raises(LXDError) as exc_info:
         LXC().attach_pro_subscription(
             instance_name="test-instance",
             pro_token="random",  # noqa: S106
+            contract_url="random",
             project="test-project",
             remote="test-remote",
         )
@@ -2851,7 +2919,7 @@ def test_attach_pro_subscription_process_error(fake_process):
         exc_info.value.brief == "Ubuntu Pro Client is not installed on 'test-instance'."
     )
 
-    assert len(fake_process.calls) == 1
+    assert len(fake_process.calls) == 3
 
 
 def test_enable_pro_service_success(fake_process):


### PR DESCRIPTION
# Included in this PR:
- Inherit host's `contract_url` in order to support Pro builds on systems that use custom contract servers.
- Associated tests for fix.