### PR TITLE
fix: check lxd availability for non-snap socket path

### DIFF
--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -149,6 +149,9 @@ def is_user_permitted() -> bool:
 
     :returns: True if user has correct permissions.
     """
+    # try non-snap lxd socket first
+    if os.access("/var/lib/lxd/unix.socket", os.O_RDWR):
+        return True
     return os.access("/var/snap/lxd/common/lxd/unix.socket", os.O_RDWR)
 
 


### PR DESCRIPTION
Currently, the lxd crafting provider assumes lxd is installed as snap, by only checking the socket path in `/var/snap`.
With this patch, the non-snap default socket path is tried first.

Maybe, as a follow-up, one should just check if `lxc` or `lxd` work properly, instead of hardcoding path names.

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

