### PR TITLE
style: improve typing for temporarily_pull_file

### DIFF
--- a/craft_providers/executor.py
+++ b/craft_providers/executor.py
@@ -26,6 +26,7 @@ import re
 import subprocess
 from abc import ABC, abstractmethod
 from collections.abc import Generator
+from typing import Literal, overload
 
 import craft_providers.util.temp_paths
 from craft_providers.errors import ProviderError
@@ -103,6 +104,16 @@ class Executor(ABC):
         :raises ProviderError: On error copying file.
         """
 
+    @overload
+    @contextlib.contextmanager
+    def temporarily_pull_file(
+        self, *, source: pathlib.PurePath, missing_ok: Literal[False] = False
+    ) -> Generator[pathlib.Path, None, None]: ...
+    @overload
+    @contextlib.contextmanager
+    def temporarily_pull_file(
+        self, *, source: pathlib.PurePath, missing_ok: Literal[True]
+    ) -> Generator[pathlib.Path | None, None, None]: ...
     @contextlib.contextmanager
     def temporarily_pull_file(
         self, *, source: pathlib.PurePath, missing_ok: bool = False


### PR DESCRIPTION
By adding these overloads, type checkers will recognise that if you don't declare `missing_ok=True`, you will always get a path.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
