### PR TITLE
fix: adjust file permissions on root for _apt

### DIFF
--- a/craft_providers/base.py
+++ b/craft_providers/base.py
@@ -982,6 +982,15 @@ class Base(ABC):
         """
         self._update_setup_status(executor=executor, status=True)
 
+    def configure_root(self, executor: Executor) -> None:
+        """Configure permissions on the root directory.
+
+        This step fixes an issue with service users, such as "_apt", end up unable to
+        make use of project cache directories because they live under a directory they
+        cannot enter on the instance.
+        """
+        executor.execute_run(["chmod", "go+x", "/root"])
+
     @final
     def setup(
         self,
@@ -1034,6 +1043,8 @@ class Base(ABC):
         self._post_setup_os(executor=executor)
 
         self._setup_wait_for_system_ready(executor=executor)
+
+        self.configure_root(executor=executor)
 
         self._pre_setup_network(executor=executor)
         self._setup_network(executor=executor)


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

Allows the _apt user to traverse its way ultimately to the project cache for stage package downloads. Requires https://github.com/canonical/craft-parts/pull/1194.