### PR TITLE
feat(experimental): don't update packages

### DIFF
--- a/craft_providers/bases/centos.py
+++ b/craft_providers/bases/centos.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import os
 import subprocess
 from typing import TYPE_CHECKING
 
@@ -192,19 +193,22 @@ class CentOSBase(Base[CentOSBaseAlias]):
 
     def _setup_packages(self, executor: Executor) -> None:
         """Configure yum, update cache and install needed packages."""
-        # update system
-        try:
-            self._execute_run(
-                ["yum", "update", "-y"],
-                executor=executor,
-                verify_network=True,
-                timeout=self._timeout_unpredictable,
-            )
-        except subprocess.CalledProcessError as error:
-            raise BaseConfigurationError(
-                brief="Failed to update system using yum.",
-                details=details_from_called_process_error(error),
-            ) from error
+        suppress_upgrade = os.environ.get(
+            "CRAFT_PROVIDERS_EXPERIMENTAL_SUPPRESS_UPGRADE_UNSUPPORTED"
+        )
+        if not suppress_upgrade:
+            try:
+                self._execute_run(
+                    ["yum", "update", "-y"],
+                    executor=executor,
+                    verify_network=True,
+                    timeout=self._timeout_unpredictable,
+                )
+            except subprocess.CalledProcessError as error:
+                raise BaseConfigurationError(
+                    brief="Failed to update system using yum.",
+                    details=details_from_called_process_error(error),
+                ) from error
 
         # install required packages and user-defined packages
         if not self._packages:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
 import types
 
 import pytest
@@ -34,3 +35,12 @@ def project_main_module() -> types.ModuleType:
             "Failed to import the project's main module: check if it needs updating",
         )
     return main_module
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _suppress_upgrade() -> None:
+    """Suppress dist-upgrade when starting containers during tests.
+
+    This speeds up our tests since dist-upgrade can take a while.
+    """
+    os.environ["CRAFT_PROVIDERS_EXPERIMENTAL_SUPPRESS_UPGRADE_UNSUPPORTED"] = "1"

--- a/tests/unit/bases/test_almalinux.py
+++ b/tests/unit/bases/test_almalinux.py
@@ -632,8 +632,11 @@ def test_setup_dnf_install_override_system(fake_executor, fake_process):
     base._setup_packages(executor=fake_executor)
 
 
-def test_setup_dnf_install_packages_install_error(mocker, fake_executor, fake_process):
+def test_setup_dnf_install_packages_install_error(
+    monkeypatch, mocker, fake_executor, fake_process
+):
     """Verify error is caught from `dnf install` call."""
+    monkeypatch.delenv("CRAFT_PROVIDERS_EXPERIMENTAL_SUPPRESS_UPGRADE_UNSUPPORTED")
     error = subprocess.CalledProcessError(100, ["error"])
     base = almalinux.AlmaLinuxBase(alias=almalinux.AlmaLinuxBaseAlias.NINE)
 

--- a/tests/unit/bases/test_centos_7.py
+++ b/tests/unit/bases/test_centos_7.py
@@ -571,8 +571,11 @@ def test_setup_yum_install_override_system(fake_executor, fake_process):
     base._setup_packages(executor=fake_executor)
 
 
-def test_setup_yum_install_packages_install_error(mocker, fake_executor, fake_process):
+def test_setup_yum_install_packages_install_error(
+    monkeypatch, mocker, fake_executor, fake_process
+):
     """Verify error is caught from `yum install` call."""
+    monkeypatch.delenv("CRAFT_PROVIDERS_EXPERIMENTAL_SUPPRESS_UPGRADE_UNSUPPORTED")
     error = subprocess.CalledProcessError(100, ["error"])
     base = centos.CentOSBase(alias=centos.CentOSBaseAlias.SEVEN)
 


### PR DESCRIPTION
This allows the suppression of the dist-upgrade setup step if the `CRAFT_PROVIDERS_EXPERIMENTAL_SUPPRESS_UPGRADE_UNSUPPORTED` environment variable is set to a truthy value.

This is mostly used to speed up tests that don't need to run the upgrade.

Because this is an experimental, unsupported feature, it is not getting included in the changelog.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
