### PR TITLE
feat: fix command formating

### DIFF
--- a/craft_providers/actions/snap_installer.py
+++ b/craft_providers/actions/snap_installer.py
@@ -237,7 +237,7 @@ def _get_assertion(query: list[str]) -> bytes:
     :raises SnapInstallationError: if 'snap known' call fails
     """
     command = snap_cmd.formulate_known_command(query=query)
-    logger.debug("Executing command on host: %s", command)
+    logger.debug("Executing command on host: %s", shlex.join(command))
     try:
         return subprocess.run(command, capture_output=True, check=True).stdout
     except subprocess.CalledProcessError as error:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

```
...
2025-10-15 14:08:29.458 Executing command on host: ['snap', 'known', 'account', 'account-id=canonical']
2025-10-15 14:08:29.507 Executing in container: lxc --project rockcraft exec local:rockcraft-prime-arm64-4100954 -- env CRAFT_MANAGED_MODE=1 ROCKCRAFT_DEBUG=False ROCKCRAFT_LXD_REMOTE=local ROCKCRAFT_LAUNCHPAD_INSTANCE=production DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true DEBIAN_PRIORITY=critical test -d /tmp
...
```

note the discrepancy between `Executing command on host` and  `Executing in container`. this PR fixes that