### PR TITLE
fix(ubuntu): don't check if devel is EOL

### DIFF
--- a/craft_providers/bases/ubuntu.py
+++ b/craft_providers/bases/ubuntu.py
@@ -356,6 +356,9 @@ class BuilddBase(Base[BuilddBaseAlias]):
 
         :raises BaseConfigurationError: If the EOL data can't be determined.
         """
+        if self.alias is BuilddBaseAlias.DEVEL:
+            logger.debug("Skipping EOL check for base 'devel'.")
+            return False
         logger.debug(f"Getting EOL data for {self.alias.value} ({codename}).")
         with importlib.resources.path(
             "craft_providers.data", "ubuntu.csv"

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 See the `Releases page`_ on GitHub for a complete list of commits that are
 included in each version.
 
+3.1.1 (2025-11-12)
+------------------
+
+Bug fixes:
+
+- Do not check whether the "devel" base is end-of-life.
+
 3.1.0 (2025-09-08)
 ------------------
 

--- a/tests/unit/bases/test_ubuntu_buildd.py
+++ b/tests/unit/bases/test_ubuntu_buildd.py
@@ -1733,6 +1733,19 @@ def test_disable_and_wait_for_snap_refresh_wait_error(fake_process, fake_executo
         base_config._disable_and_wait_for_snap_refresh(executor=fake_executor)
 
 
+def test_devel_never_eol(fake_process, fake_executor, mock_requests_head, logs):
+    """Update the sources if the base is past its EOL date."""
+    base_config = ubuntu.BuilddBase(alias=ubuntu.BuilddBaseAlias.DEVEL)
+    fake_process.register_subprocess(
+        [*DEFAULT_FAKE_CMD, "cat", "/etc/os-release"],
+        stdout="UBUNTU_CODENAME=grumpy",
+    )
+
+    base_config._update_eol_sources(fake_executor)
+
+    assert re.escape("Skipping EOL check for base 'devel'.") in logs.debug
+
+
 @freeze_time("2027-01-01")
 @pytest.mark.parametrize("mock_requests_head", [200], indirect=True)
 def test_base_past_eol(fake_process, fake_executor, mock_requests_head, logs):


### PR DESCRIPTION
This fixes the latest snapcraft's inability to build for core26 because the devel base doesn't exist in the distro info data file.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
