### PR TITLE
ci: add weekly lxd tests

### DIFF
--- a/.github/workflows/tests-weekly.yaml
+++ b/.github/workflows/tests-weekly.yaml
@@ -30,13 +30,6 @@ jobs:
           - 5.0/candidate
           - 5.0/edge
         python-version: ["3.10", "3.12"]
-        include:
-          - os: self-hosted-linux-amd64-focal-medium
-            lxd-channel: 4.0/candidate
-            python-version: "3.10"
-          - os: self-hosted-linux-amd64-focal-medium
-            lxd-channel: 4.0/edge
-            python-version: "3.10"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Pristine Ubuntu


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This has us running our LXD instance tests on a matrix of Ubuntu/lxd/Python versions each week.

Example run: https://github.com/canonical/craft-providers/actions/runs/19977333039

This should catch errors such as https://github.com/canonical/craft-providers/issues/856 earlier.