### PR TITLE
ci: disable Linux ARM64 CI

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -23,7 +23,7 @@ jobs:
       fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15-intel"]'
       fast-test-python-versions: '["3.10", "3.12", "3.13"]'
       # Slow tests (which include everything that needs multipass) run on several Ubuntu platforms
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-24.04"]'
       slow-test-python-versions: '["3.12"]'
       lowest-python-platform: "ubuntu-22.04"
       lowest-python-version: "3.10"
@@ -34,7 +34,7 @@ jobs:
     with:
       # All fast tests run in the basic job
       fast-test-platforms: "[]"
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-24.04"]'
       slow-test-python-versions: '["3.12"]'
       lowest-python-platform: ""
       use-lxd: true


### PR DESCRIPTION
This CI is currently failing in very unhelpful ways.

I have created #882 as a task for re-enabling this.

Admin side: https://github.com/canonical/canonical-repo-automation/pull/556

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
