### PR TITLE
fix: invalid ty configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -369,4 +369,4 @@ classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
 [tool.ty.rules]
 # Temporarily disabled while mypy and pyright are still in use.
 # See: https://github.com/canonical/craft-providers/issues/901
-unused-type-ignore-comment = "ignore"
+unused-ignore-comment = "ignore"


### PR DESCRIPTION
Fix an invalid `ty` configuration rule so unused `# type: ignore` comments are handled correctly.

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
