### PR TITLE
ci: enable integration tests on arm64

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -23,7 +23,7 @@ jobs:
       fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15-intel"]'
       fast-test-python-versions: '["3.10", "3.12", "3.13"]'
       # Slow tests (which include everything that needs multipass) run on several Ubuntu platforms
-      slow-test-platforms: '["ubuntu-24.04"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
       slow-test-python-versions: '["3.12"]'
       lowest-python-platform: "ubuntu-22.04"
       lowest-python-version: "3.10"


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This runs the basic and LXD integration tests on Ubuntu ARM runners. It's a CI precursor to the work for CRAFT-4990