### PR TITLE
test: failing reproducer - instance not stopped on setup error

### DIFF
--- a/craft_providers/lxd/launcher.py
+++ b/craft_providers/lxd/launcher.py
@@ -164,20 +164,22 @@ def _create_instance(  # noqa: PLR0913, too many arguments
 
             # The base configuration shouldn't mount cache directories because if
             # they get deleted, copying the base instance will fail.
-            base_configuration.setup(executor=base_instance, mount_cache=False)
-            _set_timezone(
-                base_instance,
-                base_instance.project,
-                base_instance.remote,
-                base_instance.lxc,
-            )
-            # set the full instance name as image description
-            base_instance.config_set("image.description", base_instance.name)
-            base_instance.config_set(
-                "user.craft_providers.status", ProviderInstanceStatus.FINISHED.value
-            )
-            config_timer.stop()
-            base_instance.stop()
+            try:
+                base_configuration.setup(executor=base_instance, mount_cache=False)
+                _set_timezone(
+                    base_instance,
+                    base_instance.project,
+                    base_instance.remote,
+                    base_instance.lxc,
+                )
+                # set the full instance name as image description
+                base_instance.config_set("image.description", base_instance.name)
+                base_instance.config_set(
+                    "user.craft_providers.status", ProviderInstanceStatus.FINISHED.value
+                )
+                config_timer.stop()
+            finally:
+                base_instance.stop()
 
         # Copy the base instance to the instance.
         logger.info("Creating new instance from base instance")
@@ -223,12 +225,16 @@ def _create_instance(  # noqa: PLR0913, too many arguments
             if prepare_instance:
                 prepare_instance(instance)
 
-            base_configuration.setup(executor=instance)
-            _set_timezone(instance, project, remote, instance.lxc)
-            instance.config_set(
-                "user.craft_providers.status", ProviderInstanceStatus.FINISHED.value
-            )
-            config_timer.stop()
+            try:
+                base_configuration.setup(executor=instance)
+                _set_timezone(instance, project, remote, instance.lxc)
+                instance.config_set(
+                    "user.craft_providers.status", ProviderInstanceStatus.FINISHED.value
+                )
+                config_timer.stop()
+            except Exception:
+                instance.stop()
+                raise
             if not ephemeral:
                 # stop ephemeral instances will delete them immediately
                 instance.stop()

--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, Mock, call
 
 import pytest
 from craft_providers import Base, Executor, ProviderError, bases, lxd
+from craft_providers.errors import BaseConfigurationError
 from craft_providers.lxd import LXDError, lxd_instance_status
 from freezegun import freeze_time
 from logassert import Exact  # type: ignore[import-untyped]
@@ -1472,3 +1473,74 @@ def test_wait_for_instance_pid_inactive(fake_instance, mocker):
         "Instance 'test-instance-fa2d407652a1c51f6019' is not ready and "
         "the process (pid 123) that created the instance is inactive."
     )
+
+
+# Regression tests for:
+# https://github.com/canonical/craft-providers/issues/447
+# https://github.com/canonical/craft-providers/issues/757
+
+
+def test_instance_stopped_when_setup_fails(
+    fake_instance,
+    mock_base_configuration,
+    mock_lxc,
+    mock_lxd_instance,
+    mock_platform,
+    mock_timezone,
+):
+    """Instance must be stopped when base_configuration.setup() raises an error.
+
+    Regression test for https://github.com/canonical/craft-providers/issues/757
+    """
+    fake_instance.config_get.return_value = "PREPARING"
+    mock_base_configuration.setup.side_effect = BaseConfigurationError(
+        brief="setup failed"
+    )
+
+    with pytest.raises(BaseConfigurationError):
+        lxd.launch(
+            name=fake_instance.name,
+            base_configuration=mock_base_configuration,
+            image_name="image-name",
+            image_remote="image-remote",
+            use_base_instance=False,
+            lxc=mock_lxc,
+        )
+
+    # Bug: stop() is not called when setup() raises, leaving the instance running.
+    fake_instance.stop.assert_called_once()
+
+
+def test_base_instance_stopped_when_setup_fails(
+    fake_instance,
+    fake_base_instance,
+    mock_base_configuration,
+    mock_is_valid,
+    mock_lxc,
+    mock_lxd_instance,
+    mock_platform,
+    mock_timezone,
+):
+    """Base instance must be stopped when base_configuration.setup() raises an error.
+
+    Regression test for https://github.com/canonical/craft-providers/issues/447
+    """
+    mock_base_configuration.setup.side_effect = BaseConfigurationError(
+        brief="setup failed"
+    )
+
+    with pytest.raises(BaseConfigurationError):
+        lxd.launch(
+            name=fake_instance.name,
+            base_configuration=mock_base_configuration,
+            image_name="image-name",
+            image_remote="image-remote",
+            use_base_instance=True,
+            project="test-project",
+            remote="test-remote",
+            lxc=mock_lxc,
+        )
+
+    # Bug: base_instance.stop() is not called when setup() raises,
+    # leaving the base instance running.
+    fake_base_instance.stop.assert_called_once()


### PR DESCRIPTION
## Reproducer for #447 and #757

Adds two failing tests that demonstrate instances are left running when `base_configuration.setup()` raises an error.

### Root cause

In `_create_instance()` in `launcher.py`, `instance.stop()` / `base_instance.stop()` are only called when `setup()` succeeds. If `setup()` raises, the instance is left running.

### Failing tests

- `test_instance_stopped_when_setup_fails`: regular instance path (issue #757)
- `test_base_instance_stopped_when_setup_fails`: base instance path (issue #447)

### Fix

Wrap the `setup()` + `stop()` calls in `_create_instance()` in a `try/finally` block.

Closes #447
Closes #757