### PR TITLE
test: failing reproducer - no error for high UID (>65535)

### DIFF
--- a/tests/unit/lxd/test_launcher.py
+++ b/tests/unit/lxd/test_launcher.py
@@ -1261,7 +1261,34 @@ def test_set_id_map_all_options(fake_base_instance, mock_lxc, mocker):
     ]
 
 
+# Regression tests for:
+# https://github.com/canonical/craft-providers/issues/259
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="unsupported on windows")
+@pytest.mark.parametrize("high_uid", [65536, 100000, 200000, 1_000_000])
+def test_set_id_map_raises_for_high_uid(fake_base_instance, mock_lxc, high_uid):
+    """_set_id_map() must raise a clear error when uid > 65535.
+
+    Enterprise systems using NIS, SSSD, or Active Directory commonly assign UIDs
+    above 65535. LXD rejects these with 'Host id is in the range of subids',
+    which is cryptic. craft-providers should detect this and raise a descriptive
+    ProviderError before calling LXD.
+
+    Regression test for https://github.com/canonical/craft-providers/issues/259
+    """
+    with pytest.raises(ProviderError, match="uid"):
+        lxd.launcher._set_id_map(
+            instance=fake_base_instance,
+            lxc=mock_lxc,
+            uid=high_uid,
+            gid=high_uid,
+        )
+
+    # The error must be raised BEFORE calling LXD (not after LXD silently fails).
+    mock_lxc.config_set.assert_not_called()
+
+
 @pytest.mark.parametrize(
     (
         "map_user_uid",


### PR DESCRIPTION
## Reproducer for #259

Enterprise systems using NIS, SSSD, or Active Directory commonly assign UIDs above 65535. When `map_user_uid=True` with such a UID, LXD rejects it with:

```
Error: Failed instance creation: Failed creating instance record:
Failed initialising instance: Host id is in the range of subids
```

This message is cryptic. craft-providers should detect this condition and raise a clear `ProviderError` **before** calling LXD.

### Failing test

`test_set_id_map_raises_for_high_uid` — shows that `_set_id_map()` currently calls `lxc.config_set(raw.idmap=...)` for UIDs > 65535 rather than raising a descriptive error first.

### Fix

Add a check in `_set_id_map()` before the `lxc.config_set` call: if `uid > 65535`, raise a `ProviderError` with a link to documentation.

Closes #259