### PR TITLE
fix(lxd/remotes): use release images for plucky

### DIFF
--- a/craft_providers/lxd/remotes.py
+++ b/craft_providers/lxd/remotes.py
@@ -152,8 +152,8 @@ _PROVIDER_BASE_TO_LXD_REMOTE_IMAGE: dict[Enum, RemoteImage] = {
     ),
     ubuntu.BuilddBaseAlias.PLUCKY: RemoteImage(
         image_name="plucky",
-        remote_name=BUILDD_DAILY_REMOTE_NAME,
-        remote_address=BUILDD_DAILY_REMOTE_ADDRESS,
+        remote_name=BUILDD_RELEASES_REMOTE_NAME,
+        remote_address=BUILDD_RELEASES_REMOTE_ADDRESS,
         remote_protocol=ProtocolType.SIMPLESTREAMS,
     ),
     ubuntu.BuilddBaseAlias.QUESTING: RemoteImage(


### PR DESCRIPTION
Plucky is no longer getting daily buildd images, so we need to switch it to the release images (which it should have been on anyway).

OSV issue is fixed in #963 

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
