### PR TITLE
chore(lint): enable passing Ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,11 +300,8 @@ ignore = [
     "D107",   # Missing docstring in __init__ (reason: documented in class docstring)
     "D203",   # 1 blank line required before class docstring (reason: pep257 default)
     "D213",   # Multi-line docstring summary should start at the second line (reason: pep257 default)
-    "D215",   # Section underline is over-indented (reason: pep257 default)
-    "A003",   # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
     "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
     # (reason: this creates long lines that get wrapped and reduces readability)
-    "PLW1641", # eq-without-hash (most of our classes should be unhashable)
 
     # Ignored due to conflicts with ruff's formatter:
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules


### PR DESCRIPTION
## Summary

Enable Ruff rules that already pass on the current codebase by removing them from the global ignore list:

- `D215`
- `A003`
- `PLW1641`

This keeps the change small and reduces the number of disabled lint rules tracked by #325.

Refs #325.

## Tests

- `env -u VIRTUAL_ENV uv run --group lint --group types ruff check .`
- `env -u VIRTUAL_ENV uv run --group lint --group types ruff check --select D215,A003,PLW1641 .`
- `env -u VIRTUAL_ENV uv run --group lint --group types ruff format --check pyproject.toml`