### PR TITLE
chore(types): enable explicit re-export checking

### DIFF
--- a/craft_providers/lxd/installer.py
+++ b/craft_providers/lxd/installer.py
@@ -29,7 +29,7 @@ import sys
 import requests
 import requests_unixsocket
 
-from craft_providers.errors import details_from_called_process_error
+from craft_providers.errors import ProviderError, details_from_called_process_error
 
 from . import errors
 from .lxc import LXC
@@ -123,9 +123,7 @@ def is_installed() -> bool:
     try:
         snap_info = requests_unixsocket.get(url=url, params={"select": "enabled"})  # type: ignore[reportUnknownMemberType] # requests_unixsocket does not have good types
     except requests.ConnectionError as error:
-        raise errors.ProviderError(
-            brief="Unable to connect to snapd service."
-        ) from error
+        raise ProviderError(brief="Unable to connect to snapd service.") from error
 
     try:
         snap_info.raise_for_status()
@@ -138,7 +136,7 @@ def is_installed() -> bool:
     try:
         status = snap_info.json()["result"]["status"]
     except (TypeError, KeyError):
-        raise errors.ProviderError(brief="Unexpected response from snapd service.")
+        raise ProviderError(brief="Unexpected response from snapd service.")
 
     logger.debug(f"LXD snap status: {status}")
     # snap status can be "installed" or "active" - "installed" revisions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ strict_equality = true
 extra_checks = true
 warn_return_any = true
 disallow_subclassing_any = true
+no_implicit_reexport = true
 disallow_untyped_decorators = true
 disallow_any_generics = true
 


### PR DESCRIPTION
## Summary

Enable mypy's `no_implicit_reexport` check for the package.

This caught an implicit use of `ProviderError` through `craft_providers.lxd.errors`; the code now imports `ProviderError` directly from `craft_providers.errors`.

This is a small incremental typing cleanup related to #326.

Refs #326.

## Tests

- `env -u VIRTUAL_ENV uv run --group lint --group types mypy craft_providers`
- `env -u VIRTUAL_ENV uv run --group lint --group types ruff check pyproject.toml craft_providers/lxd/installer.py`
- `env -u VIRTUAL_ENV uv run --group lint --group types ruff format --check pyproject.toml craft_providers/lxd/installer.py`