### PR TITLE
ci: fix and upgrade macOS runners

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -54,7 +54,7 @@ jobs:
     with:
       # All fast tests run in the basic job
       fast-test-platforms: "[]"
-      slow-test-platforms: '["macos-14-large"]'
+      slow-test-platforms: '["macos-15-intel"]'
       slow-test-python-versions: '["3.12"]'
       lowest-python-platform: ""
       use-lxd: false

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -14,31 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    uses: canonical/starflow/.github/workflows/lint-python.yaml@main
-  test-basic:
-    uses: canonical/starflow/.github/workflows/test-python.yaml@main
-    with:
-      # Fast tests run on several Ubuntu platforms and macos on ARM
-      fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15-intel"]'
-      fast-test-python-versions: '["3.10", "3.12", "3.13"]'
-      # Slow tests (which include everything that needs multipass) run on several Ubuntu platforms
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
-      slow-test-python-versions: '["3.12"]'
-      lowest-python-platform: "ubuntu-22.04"
-      lowest-python-version: "3.10"
-      use-lxd: true
-      pytest-markers: not lxd_instance and not multipass_instance
-  test-lxd:
-    uses: canonical/starflow/.github/workflows/test-python.yaml@main
-    with:
-      # All fast tests run in the basic job
-      fast-test-platforms: "[]"
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
-      slow-test-python-versions: '["3.12"]'
-      lowest-python-platform: ""
-      use-lxd: true
-      pytest-markers: lxd_instance
+  #   lint:
+  #     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
+  #   test-basic:
+  #     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+  #     with:
+  #       # Fast tests run on several Ubuntu platforms and macos on ARM
+  #       fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15-intel"]'
+  #       fast-test-python-versions: '["3.10", "3.12", "3.13"]'
+  #       # Slow tests (which include everything that needs multipass) run on several Ubuntu platforms
+  #       slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+  #       slow-test-python-versions: '["3.12"]'
+  #       lowest-python-platform: "ubuntu-22.04"
+  #       lowest-python-version: "3.10"
+  #       use-lxd: true
+  #       pytest-markers: not lxd_instance and not multipass_instance
+  #   test-lxd:
+  #     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+  #     with:
+  #       # All fast tests run in the basic job
+  #       fast-test-platforms: "[]"
+  #       slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+  #       slow-test-python-versions: '["3.12"]'
+  #       lowest-python-platform: ""
+  #       use-lxd: true
+  #       pytest-markers: lxd_instance
   # test-multipass:
   #   uses: canonical/starflow/.github/workflows/test-python.yaml@main
   #   with:

--- a/.github/workflows/tests-weekly.yaml
+++ b/.github/workflows/tests-weekly.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.13"]
-        os: [macos-14-large]
+        os: [macos-15-intel]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     steps:
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.13"]
-        os: [macos-14-large]
+        os: [macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Multipass

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ else ifeq ($(CI)_$(OS),true_Darwin)  # Only do this in CI on macOS
 	# Disable spotlight because it tries to index the multipass images, crashing
 	# macOS 14+ runners. Thapple.
 	sudo mdutil -a -i off
+	# Disable Application Firewall and Packet Filter on macOS 15 to allow VM networking
+	sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off || true
+	sudo pfctl -d || true
 endif
 
 


### PR DESCRIPTION
This draft PR isolates the macOS CI job and upgrades the macOS runners to `macos-15-intel` (Sequoia, Intel architecture) to support nested virtualization for integration tests.